### PR TITLE
Fix: Remove non-existent horus-algorithms dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ dependencies = [
  "pin-project",
  "quick-xml",
  "rand 0.8.5",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "rustc_version 0.4.1",
  "serde",
  "serde_json",
@@ -1677,7 +1677,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3426,7 +3426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.3",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3666,7 +3666,7 @@ dependencies = [
  "google-cloud-token",
  "home",
  "jsonwebtoken",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3682,7 +3682,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d901aeb453fd80e51d64df4ee005014f6cf39f2d736dd64f7239c132d9d39a6a"
 dependencies = [
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -3707,7 +3707,7 @@ dependencies = [
  "percent-encoding",
  "pkcs8 0.10.2",
  "regex",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "ring",
  "serde",
@@ -3945,13 +3945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "horus-algorithms"
-version = "0.1.0"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "horus_ai"
 version = "0.1.7"
 dependencies = [
@@ -4064,7 +4057,6 @@ dependencies = [
  "colored",
  "crossterm 0.27.0",
  "gilrs",
- "horus-algorithms",
  "horus_core",
  "i2cdev 0.6.2",
  "icm20948",
@@ -4170,7 +4162,7 @@ dependencies = [
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
  "uuid",
  "walkdir",
  "webbrowser",
@@ -4234,7 +4226,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4884,6 +4876,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,7 +5119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6200,9 +6202,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -6352,7 +6354,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec 1.15.1",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6771,9 +6773,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -6960,9 +6962,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -7321,9 +7323,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7336,16 +7338,14 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-tls 0.6.0",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -7354,13 +7354,13 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util",
  "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -7372,7 +7372,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -7644,7 +7644,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.0",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -9221,6 +9221,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10318,7 +10336,7 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
 ]
@@ -10391,26 +10409,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
-]
 
 [[package]]
 name = "windows-result"
@@ -10423,20 +10424,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10451,20 +10443,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10518,7 +10501,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10573,7 +10556,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/horus/src/lib.rs
+++ b/horus/src/lib.rs
@@ -205,14 +205,6 @@ pub mod prelude {
     pub use horus_library::messages::*;
 
     // ============================================
-    // Algorithms
-    // ============================================
-    pub use horus_library::algorithms::{
-        astar::AStar, differential_drive::DifferentialDrive, ekf::EKF, kalman_filter::KalmanFilter,
-        occupancy_grid::OccupancyGrid, pid::PID, pure_pursuit::PurePursuit, rrt::RRT,
-    };
-
-    // ============================================
     // Error Types (clean aliases - no Horus prefix)
     // ============================================
     pub use horus_core::error::{Error, Result};

--- a/horus_library/Cargo.toml
+++ b/horus_library/Cargo.toml
@@ -15,7 +15,6 @@ path = "lib.rs"
 
 [dependencies]
 horus_core = { path = "../horus_core" }
-horus_algorithms = { path = "../../registry_packages/horus-algorithms", package = "horus-algorithms" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 bytemuck = { workspace = true }

--- a/horus_library/lib.rs
+++ b/horus_library/lib.rs
@@ -7,7 +7,6 @@
 //! ```text
 //! horus_library/
 //! ├── messages/       # Shared memory-safe message types
-//! ├── algorithms/     # Common robotics algorithms
 //! ├── hframe/         # HFrame - High-performance transform system
 //! ├── nodes/          # Node infrastructure (traits, re-exports)
 //! └── drivers/        # Driver infrastructure (traits, re-exports)
@@ -23,12 +22,6 @@
 //! - **Vision**: `Image`, `CameraInfo`, `CompressedImage`
 //! - **Control**: `MotorCommand`, `JointState`, `ServoCommand`
 //! - **I/O**: `DigitalIO`, `AnalogIO`, `CanFrame`, `ModbusData`, `I2CData`
-//!
-//! ### Algorithms
-//! Common robotics algorithms (via horus-algorithms crate):
-//! - `PID`, `KalmanFilter`, `EKF`
-//! - `AStar`, `RRT`, `PurePursuit`
-//! - `DifferentialDrive`, `OccupancyGrid`
 //!
 //! ### HFrame Transform System
 //! High-performance coordinate transform system:
@@ -82,8 +75,6 @@
 //! use sim3d::rl::{RLTask, Action, Observation};
 //! ```
 
-// Re-export algorithms from horus-algorithms crate
-pub use horus_algorithms as algorithms;
 pub mod drivers;
 pub mod hframe;
 pub mod messages;


### PR DESCRIPTION
## Description
Removed the non-existent `horus-algorithms` dependency that was causing installation failures during `./install.sh`.

**Note:** This PR targets the `dev` branch as per CONTRIBUTING.md.

## Problem
The installation script failed with:
```
error: failed to read /home/Rpi/registry_packages/horus-algorithms/Cargo.toml
Caused by: No such file or directory (os error 2)
```

## Root Cause
- `horus_library/Cargo.toml` referenced a path that doesn't exist: `../../registry_packages/horus-algorithms`
- This dependency was also re-exported in `horus_library/lib.rs` and `horus/src/lib.rs`

## Solution
- Removed `horus_algorithms` dependency from `horus_library/Cargo.toml`
- Removed re-exports from `horus_library/lib.rs` and `horus/src/lib.rs`
- Updated documentation to remove algorithms section references

As confirmed by maintainer, `horus-algorithms` will be developed separately and open-sourced in the future.

## Changes
- ✅ Removed horus_algorithms dependency from horus_library/Cargo.toml
- ✅ Removed algorithms re-export from horus_library/lib.rs
- ✅ Removed algorithms re-export from horus/src/lib.rs
- ✅ Updated documentation in lib.rs files

## Testing
- [x] Installation completes successfully (`./install.sh`)
- [x] `horus --help` works correctly
- [x] Code compiles without errors
- [x] Cargo.lock updated

## Related Issues
Fixes #40

## Verification
Installation now completes successfully on Raspberry Pi with Embedded profile.
