### PR TITLE
Fix: Remove non-existent horus-algorithms dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,13 +3945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "horus-algorithms"
-version = "0.1.0"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "horus_ai"
 version = "0.1.7"
 dependencies = [
@@ -4064,7 +4057,6 @@ dependencies = [
  "colored",
  "crossterm 0.27.0",
  "gilrs",
- "horus-algorithms",
  "horus_core",
  "i2cdev 0.6.2",
  "icm20948",

--- a/horus/src/lib.rs
+++ b/horus/src/lib.rs
@@ -205,14 +205,7 @@ pub mod prelude {
     pub use horus_library::messages::*;
 
     // ============================================
-    // Algorithms
-    // ============================================
-    pub use horus_library::algorithms::{
-        astar::AStar, differential_drive::DifferentialDrive, ekf::EKF, kalman_filter::KalmanFilter,
-        occupancy_grid::OccupancyGrid, pid::PID, pure_pursuit::PurePursuit, rrt::RRT,
-    };
 
-    // ============================================
     // Error Types (clean aliases - no Horus prefix)
     // ============================================
     pub use horus_core::error::{Error, Result};

--- a/horus_library/Cargo.toml
+++ b/horus_library/Cargo.toml
@@ -15,7 +15,6 @@ path = "lib.rs"
 
 [dependencies]
 horus_core = { path = "../horus_core" }
-horus_algorithms = { path = "../../registry_packages/horus-algorithms", package = "horus-algorithms" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 bytemuck = { workspace = true }

--- a/horus_library/lib.rs
+++ b/horus_library/lib.rs
@@ -7,7 +7,6 @@
 //! ```text
 //! horus_library/
 //! ├── messages/       # Shared memory-safe message types
-//! ├── algorithms/     # Common robotics algorithms
 //! ├── hframe/         # HFrame - High-performance transform system
 //! ├── nodes/          # Node infrastructure (traits, re-exports)
 //! └── drivers/        # Driver infrastructure (traits, re-exports)
@@ -23,12 +22,6 @@
 //! - **Vision**: `Image`, `CameraInfo`, `CompressedImage`
 //! - **Control**: `MotorCommand`, `JointState`, `ServoCommand`
 //! - **I/O**: `DigitalIO`, `AnalogIO`, `CanFrame`, `ModbusData`, `I2CData`
-//!
-//! ### Algorithms
-//! Common robotics algorithms (via horus-algorithms crate):
-//! - `PID`, `KalmanFilter`, `EKF`
-//! - `AStar`, `RRT`, `PurePursuit`
-//! - `DifferentialDrive`, `OccupancyGrid`
 //!
 //! ### HFrame Transform System
 //! High-performance coordinate transform system:
@@ -82,8 +75,6 @@
 //! use sim3d::rl::{RLTask, Action, Observation};
 //! ```
 
-// Re-export algorithms from horus-algorithms crate
-pub use horus_algorithms as algorithms;
 pub mod drivers;
 pub mod hframe;
 pub mod messages;


### PR DESCRIPTION
## Description
Removed the non-existent `horus-algorithms` dependency that was causing installation failures during `./install.sh`.

## Problem
The installation script failed with:
```
error: failed to read /home/Rpi/registry_packages/horus-algorithms/Cargo.toml
Caused by: No such file or directory (os error 2)
```

## Root Cause
- `horus_library/Cargo.toml` referenced a path that doesn't exist: `../../registry_packages/horus-algorithms`
- This dependency was also re-exported in `horus_library/lib.rs` and `horus/src/lib.rs`

## Solution
- Removed `horus_algorithms` dependency from `horus_library/Cargo.toml`
- Removed re-exports from `horus_library/lib.rs` and `horus/src/lib.rs`
- Updated documentation to remove algorithms section references

As confirmed by maintainer, `horus-algorithms` will be developed separately and open-sourced in the future.

## Changes
- ✅ Removed horus_algorithms dependency from horus_library/Cargo.toml
- ✅ Removed algorithms re-export from horus_library/lib.rs
- ✅ Removed algorithms re-export from horus/src/lib.rs
- ✅ Updated documentation in lib.rs files

## Testing
- [x] Installation completes successfully (`./install.sh`)
- [x] `horus --help` works correctly
- [x] Code compiles without errors
- [x] Cargo.lock updated

## Related Issues
Fixes #40