### PR TITLE
Potential fix for code scanning alert no. 54: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -906,6 +906,7 @@ jobs:
   # Summary job
   integration-success:
     name: Integration Tests Success
+    permissions: {}
     needs: [ipc-integration, cli-integration, runtime-integration]
     runs-on: ubuntu-latest
     if: always()


### PR DESCRIPTION
Potential fix for [https://github.com/softmata/horus/security/code-scanning/54](https://github.com/softmata/horus/security/code-scanning/54)

Add an explicit `permissions` block to the `integration-success` job, since that is the job called out and it can be safely constrained without impacting other unseen jobs.

Best targeted fix (no functionality change): in `.github/workflows/integration-tests.yml`, under `integration-success` job definition, add:

```yml
permissions: {}
```

This explicitly grants no token permissions to that job, which is valid because the job only runs shell commands printing `needs.*.result` values and does not call GitHub APIs or perform write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
