### PR TITLE
fix(runtime): honor Cargo target directory in CLI smoke test

### DIFF
--- a/tests/cli_runtime_test.sh
+++ b/tests/cli_runtime_test.sh
@@ -8,7 +8,27 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-HORUS="./target/debug/horus"
+CARGO_BIN="${CARGO:-cargo}"
+TARGET_DIR="$(
+    "$CARGO_BIN" metadata --no-deps --format-version=1 |
+        sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'
+)"
+if [ -z "$TARGET_DIR" ]; then
+    echo "ERROR: Could not resolve Cargo target directory"
+    exit 1
+fi
+
+HORUS="$TARGET_DIR/debug/horus"
+QA_PUBSUB="$TARGET_DIR/debug/examples/qa_pubsub"
+QA_ACTION_SERVER="$TARGET_DIR/debug/examples/qa_action_server"
+for BINARY in "$HORUS" "$QA_PUBSUB" "$QA_ACTION_SERVER"; do
+    if [ ! -x "$BINARY" ]; then
+        echo "ERROR: Required binary not found: $BINARY"
+        echo "Run: cargo build --no-default-features -p horus --examples -p horus_manager"
+        exit 1
+    fi
+done
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -30,7 +50,7 @@ cleanup
 
 # ─── Start background scheduler ────────────────────────────────────
 echo "Starting background scheduler (qa_pubsub)..."
-HORUS_NAMESPACE="cli_rt_main" ./target/debug/examples/qa_pubsub >/dev/null 2>&1 &
+HORUS_NAMESPACE="cli_rt_main" "$QA_PUBSUB" >/dev/null 2>&1 &
 SCHED_PID=$!
 sleep 3
 
@@ -43,7 +63,7 @@ echo ""
 
 # ─── Test 1: topic list ────────────────────────────────────────────
 echo "[1/15] topic list"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS topic list 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" topic list 2>&1) || true
 if echo "$OUT" | grep -q "sensor.cmd_vel\|cmd_vel"; then
     pass "topic list shows topics"
 else
@@ -52,7 +72,7 @@ fi
 
 # ─── Test 2: topic echo ────────────────────────────────────────────
 echo "[2/15] topic echo"
-OUT=$(timeout 5 env HORUS_NAMESPACE="cli_rt_main" $HORUS topic echo sensor.cmd_vel --count 2 2>&1) || true
+OUT=$(timeout 5 env HORUS_NAMESPACE="cli_rt_main" "$HORUS" topic echo sensor.cmd_vel --count 2 2>&1) || true
 if [ -n "$OUT" ]; then
     pass "topic echo receives messages"
 else
@@ -61,7 +81,7 @@ fi
 
 # ─── Test 3: node list ─────────────────────────────────────────────
 echo "[3/15] node list"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS node list 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" node list 2>&1) || true
 if echo "$OUT" | grep -q "sensor_node" && echo "$OUT" | grep -q "controller_node" && echo "$OUT" | grep -q "motor_node"; then
     pass "node list shows all 3 nodes"
 else
@@ -70,7 +90,7 @@ fi
 
 # ─── Test 4: node info ─────────────────────────────────────────────
 echo "[4/15] node info"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS node info sensor_node 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" node info sensor_node 2>&1) || true
 if echo "$OUT" | grep -q "sensor_node"; then
     pass "node info shows node details"
 else
@@ -79,8 +99,8 @@ fi
 
 # ─── Test 5: param set/get ─────────────────────────────────────────
 echo "[5/15] param set/get"
-HORUS_NAMESPACE="cli_rt_main" $HORUS param set test.speed 2.5 >/dev/null 2>&1 || true
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS param get test.speed 2>&1) || true
+HORUS_NAMESPACE="cli_rt_main" "$HORUS" param set test.speed 2.5 >/dev/null 2>&1 || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" param get test.speed 2>&1) || true
 if echo "$OUT" | grep -q "2.5"; then
     pass "param set/get roundtrip"
 else
@@ -89,7 +109,7 @@ fi
 
 # ─── Test 6: param list ────────────────────────────────────────────
 echo "[6/15] param list"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS param list 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" param list 2>&1) || true
 if [ -n "$OUT" ]; then
     pass "param list returns output"
 else
@@ -98,32 +118,32 @@ fi
 
 # ─── Test 7: frame list ────────────────────────────────────────────
 echo "[7/15] frame list"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS frame list 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" frame list 2>&1) || true
 # May show frames or "no frames" — both valid for qa_pubsub
 pass "frame list runs without error"
 
 # ─── Test 8: log ────────────────────────────────────────────────────
 echo "[8/15] log"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS log 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" log 2>&1) || true
 pass "log command runs without error"
 
 # ─── Test 9: blackbox ──────────────────────────────────────────────
 echo "[9/15] blackbox"
-OUT=$(HORUS_NAMESPACE="cli_rt_main" $HORUS blackbox 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_main" "$HORUS" blackbox 2>&1) || true
 pass "blackbox runs without error"
 
 # ─── Test 10: msg list ─────────────────────────────────────────────
 echo "[10/15] msg list"
-OUT=$($HORUS msg list 2>&1) || true
-if echo "$OUT" | grep -q "CmdVel"; then
-    pass "msg list shows CmdVel"
+OUT=$("$HORUS" msg list 2>&1) || true
+if echo "$OUT" | grep -q "Twist"; then
+    pass "msg list shows core Twist type"
 else
-    fail "msg list" "missing CmdVel: $OUT"
+    fail "msg list" "missing core Twist type: $OUT"
 fi
 
 # ─── Test 11: doctor ───────────────────────────────────────────────
 echo "[11/15] doctor"
-OUT=$($HORUS doctor 2>&1) || true
+OUT=$("$HORUS" doctor 2>&1) || true
 if echo "$OUT" | grep -qi "horus\|toolchain\|summary"; then
     pass "doctor runs and shows diagnostics"
 else
@@ -132,7 +152,7 @@ fi
 
 # ─── Test 12: clean --shm ──────────────────────────────────────────
 echo "[12/15] clean --shm (dry — don't clean our running test)"
-OUT=$($HORUS clean --shm --force 2>&1) || true
+OUT=$("$HORUS" clean --shm --force 2>&1) || true
 pass "clean --shm runs without crash"
 
 # Stop main scheduler for remaining tests
@@ -158,7 +178,7 @@ nodes:
       kp: 2.5
 namespace: robot1
 YAML
-OUT=$($HORUS launch --dry-run "$TMPFILE" 2>&1) || true
+OUT=$("$HORUS" launch --dry-run "$TMPFILE" 2>&1) || true
 rm -f "$TMPFILE"
 if echo "$OUT" | grep -q "imu_driver" && echo "$OUT" | grep -q "controller" && echo "$OUT" | grep -q "robot1"; then
     pass "launch dry-run shows 2 nodes + namespace"
@@ -168,8 +188,8 @@ fi
 
 # ─── Test 14: recording pipeline ───────────────────────────────────
 echo "[14/15] recording pipeline"
-$HORUS record delete rt_pipeline_test --force >/dev/null 2>&1 || true
-HORUS_NAMESPACE="cli_rt_rec" HORUS_RECORD_SESSION="rt_pipeline_test" ./target/debug/examples/qa_pubsub >/dev/null 2>&1 &
+"$HORUS" record delete rt_pipeline_test --force >/dev/null 2>&1 || true
+HORUS_NAMESPACE="cli_rt_rec" HORUS_RECORD_SESSION="rt_pipeline_test" "$QA_PUBSUB" >/dev/null 2>&1 &
 REC_PID=$!
 sleep 3
 kill -9 $REC_PID 2>/dev/null; wait $REC_PID 2>/dev/null || true
@@ -177,16 +197,16 @@ sleep 1
 
 # Note: SIGKILL won't trigger graceful recording save (needs SIGTERM).
 # But we tested recording save in earlier sessions. Just check list/info:
-OUT=$($HORUS record list 2>&1) || true
+OUT=$("$HORUS" record list 2>&1) || true
 pass "record list runs (pipeline tested separately with SIGTERM)"
 rm -rf /dev/shm/horus_cli_rt_rec 2>/dev/null || true
 
 # ─── Test 15: action list ──────────────────────────────────────────
 echo "[15/15] action list"
-HORUS_NAMESPACE="cli_rt_action" ./target/debug/examples/qa_action_server >/dev/null 2>&1 &
+HORUS_NAMESPACE="cli_rt_action" "$QA_ACTION_SERVER" >/dev/null 2>&1 &
 ACT_PID=$!
 sleep 3
-OUT=$(HORUS_NAMESPACE="cli_rt_action" $HORUS action list 2>&1) || true
+OUT=$(HORUS_NAMESPACE="cli_rt_action" "$HORUS" action list 2>&1) || true
 kill -9 $ACT_PID 2>/dev/null; wait $ACT_PID 2>/dev/null || true
 rm -rf /dev/shm/horus_cli_rt_action 2>/dev/null || true
 if echo "$OUT" | grep -q "pick_object"; then


### PR DESCRIPTION
## What changed

- Resolve the configured Cargo `target_directory` before launching runtime test binaries.
- Validate that the CLI and QA binaries exist and are executable.
- Quote dynamic executable paths throughout the harness.
- Update the stale core assertion from `CmdVel` to `Twist`, matching the package decomposition.

## Why

The live CLI smoke harness hard-coded `./target/debug`, so it reported that the scheduler failed to start whenever Cargo used a configured target directory. After fixing that launcher issue, the harness exposed a stale assertion for `CmdVel`, which now lives in the separately installed `horus-robotics` package.

## Impact

The live runtime smoke suite now works with configured Cargo artifact directories and validates the current core message registry contract.

## Validation

- `bash tests/cli_runtime_test.sh` — 15 passed, 0 failed, 0 skipped
- `cargo check --no-default-features`
- `bash -n tests/cli_runtime_test.sh`
- `git diff --check`
