### PR TITLE
Fix the magic numbers and replace with offset_of!

### DIFF
--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -719,22 +719,32 @@ pub fn read_latest_slot_bytes(
     // SAFETY: mmap is validated to be at least TOPIC_HEADER_SIZE (640) bytes above.
     // All offsets (12, 20, 64, 72, 76, 80) are within the header and read_unaligned
     // handles any alignment. base is a valid pointer from the mmap.
-    let type_size = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, type_size)) as *const u32) } as usize;
+    let type_size = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, type_size)) as *const u32)
+    } as usize;
     // SAFETY: base is a valid mmap pointer; offset 20 is within the validated header region;
     // read_unaligned handles any alignment for the u8 is_pod field.
     let is_pod_raw = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, is_pod))) };
     // SAFETY: base is a valid mmap pointer; offset 64 is within the validated header region;
     // read_unaligned handles any alignment for the u64 seq/head field.
-    let write_idx = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64) };
+    let write_idx = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64)
+    };
     // SAFETY: base is a valid mmap pointer; offset 72 is within the validated header region;
     // read_unaligned handles any alignment for the u32 capacity field.
-    let capacity = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, capacity)) as *const u32) } as usize;
+    let capacity = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, capacity)) as *const u32)
+    } as usize;
     // SAFETY: base is a valid mmap pointer; offset 76 is within the validated header region;
     // read_unaligned handles any alignment for the u32 cap_mask field.
-    let cap_mask = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, capacity_mask)) as *const u32) } as usize;
+    let cap_mask = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, capacity_mask)) as *const u32)
+    } as usize;
     // SAFETY: base is a valid mmap pointer; offset 80 is within the validated header region;
     // read_unaligned handles any alignment for the u32 slot_size field.
-    let slot_size = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, slot_size)) as *const u32) } as usize;
+    let slot_size = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, slot_size)) as *const u32)
+    } as usize;
 
     let is_pod = is_pod_raw == POD_YES;
 
@@ -806,8 +816,11 @@ pub fn read_latest_slot_bytes(
 
     // Read topic_kind (byte 48 in cache line 1) and messages_total (offset 56).
     // SAFETY: mmap is validated to be at least TOPIC_HEADER_SIZE (640) bytes.
-    let topic_kind = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, topic_kind))) };
-    let messages_total = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64) };
+    let topic_kind =
+        unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, topic_kind))) };
+    let messages_total = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64)
+    };
 
     Some(TopicSlotRead {
         payload,
@@ -843,7 +856,9 @@ pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
         return None;
     }
     // SAFETY: offset 64 is within the validated header (sequence_or_head field).
-    let seq = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64) };
+    let seq = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64)
+    };
     Some(seq)
 }
 
@@ -870,7 +885,9 @@ pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
         return None;
     }
     // SAFETY: offset 56 is within the validated header (messages_total field).
-    let total = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64) };
+    let total = unsafe {
+        std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64)
+    };
     Some(total)
 }
 
@@ -918,15 +935,23 @@ pub fn read_topic_header_info(path: &std::path::Path) -> Option<TopicHeaderInfo>
 
     // SAFETY: all offsets are within the validated 640-byte header.
     unsafe {
-        let type_size = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, type_size)) as *const u32);
+        let type_size =
+            std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, type_size)) as *const u32);
         let is_pod_raw = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, is_pod)));
         let topic_kind = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, topic_kind)));
-        let messages_total = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64);
-        let publisher_count = (*(base.add(offset_of!(TopicHeader, publisher_count)) as *const AtomicU32)).load(Ordering::Relaxed);
-        let subscriber_count = (*(base.add(offset_of!(TopicHeader, subscriber_count)) as *const AtomicU32)).load(Ordering::Relaxed);
+        let messages_total = std::ptr::read_unaligned(
+            base.add(offset_of!(TopicHeader, messages_total)) as *const u64,
+        );
+        let publisher_count = (*(base.add(offset_of!(TopicHeader, publisher_count))
+            as *const AtomicU32))
+            .load(Ordering::Relaxed);
+        let subscriber_count = (*(base.add(offset_of!(TopicHeader, subscriber_count))
+            as *const AtomicU32))
+            .load(Ordering::Relaxed);
 
         // type_name at offset 216, 32 bytes
-        let name_bytes = std::slice::from_raw_parts(base.add(offset_of!(TopicHeader, type_name)), 32);
+        let name_bytes =
+            std::slice::from_raw_parts(base.add(offset_of!(TopicHeader, type_name)), 32);
         let end = name_bytes.iter().position(|&b| b == 0).unwrap_or(32);
         let type_name = std::str::from_utf8(&name_bytes[..end])
             .unwrap_or("")

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -6,6 +6,7 @@
 //! migration coordination.
 
 use std::mem;
+use std::mem::offset_of;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 
 use crate::error::{HorusError, HorusResult};
@@ -718,22 +719,22 @@ pub fn read_latest_slot_bytes(
     // SAFETY: mmap is validated to be at least TOPIC_HEADER_SIZE (640) bytes above.
     // All offsets (12, 20, 64, 72, 76, 80) are within the header and read_unaligned
     // handles any alignment. base is a valid pointer from the mmap.
-    let type_size = unsafe { std::ptr::read_unaligned(base.add(12) as *const u32) } as usize;
+    let type_size = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, type_size)) as *const u32) } as usize;
     // SAFETY: base is a valid mmap pointer; offset 20 is within the validated header region;
     // read_unaligned handles any alignment for the u8 is_pod field.
-    let is_pod_raw = unsafe { std::ptr::read_unaligned(base.add(20)) };
+    let is_pod_raw = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, is_pod))) };
     // SAFETY: base is a valid mmap pointer; offset 64 is within the validated header region;
     // read_unaligned handles any alignment for the u64 seq/head field.
-    let write_idx = unsafe { std::ptr::read_unaligned(base.add(64) as *const u64) };
+    let write_idx = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64) };
     // SAFETY: base is a valid mmap pointer; offset 72 is within the validated header region;
     // read_unaligned handles any alignment for the u32 capacity field.
-    let capacity = unsafe { std::ptr::read_unaligned(base.add(72) as *const u32) } as usize;
+    let capacity = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, capacity)) as *const u32) } as usize;
     // SAFETY: base is a valid mmap pointer; offset 76 is within the validated header region;
     // read_unaligned handles any alignment for the u32 cap_mask field.
-    let cap_mask = unsafe { std::ptr::read_unaligned(base.add(76) as *const u32) } as usize;
+    let cap_mask = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, capacity_mask)) as *const u32) } as usize;
     // SAFETY: base is a valid mmap pointer; offset 80 is within the validated header region;
     // read_unaligned handles any alignment for the u32 slot_size field.
-    let slot_size = unsafe { std::ptr::read_unaligned(base.add(80) as *const u32) } as usize;
+    let slot_size = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, slot_size)) as *const u32) } as usize;
 
     let is_pod = is_pod_raw == POD_YES;
 
@@ -788,7 +789,7 @@ pub fn read_latest_slot_bytes(
     // Read type_name from header (bytes 216-247, 32 bytes in cache line 4).
     // Offset: cache_line_4(192) + publisher_count(4) + subscriber_count(4) +
     //         total_participants(4) + lease_timeout_ms(4) + last_topology_change_ms(8) = 216
-    const TYPE_NAME_OFFSET: usize = 216;
+    const TYPE_NAME_OFFSET: usize = offset_of!(TopicHeader, type_name);
     const TYPE_NAME_LEN: usize = 32;
     let type_name = if mmap.len() >= TYPE_NAME_OFFSET + TYPE_NAME_LEN {
         let name_bytes = &mmap[TYPE_NAME_OFFSET..TYPE_NAME_OFFSET + TYPE_NAME_LEN];
@@ -805,8 +806,8 @@ pub fn read_latest_slot_bytes(
 
     // Read topic_kind (byte 48 in cache line 1) and messages_total (offset 56).
     // SAFETY: mmap is validated to be at least TOPIC_HEADER_SIZE (640) bytes.
-    let topic_kind = unsafe { std::ptr::read_unaligned(base.add(48)) };
-    let messages_total = unsafe { std::ptr::read_unaligned(base.add(56) as *const u64) };
+    let topic_kind = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, topic_kind))) };
+    let messages_total = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64) };
 
     Some(TopicSlotRead {
         payload,
@@ -842,7 +843,7 @@ pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
         return None;
     }
     // SAFETY: offset 64 is within the validated header (sequence_or_head field).
-    let seq = unsafe { std::ptr::read_unaligned(base.add(64) as *const u64) };
+    let seq = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64) };
     Some(seq)
 }
 
@@ -869,7 +870,7 @@ pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
         return None;
     }
     // SAFETY: offset 56 is within the validated header (messages_total field).
-    let total = unsafe { std::ptr::read_unaligned(base.add(56) as *const u64) };
+    let total = unsafe { std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64) };
     Some(total)
 }
 
@@ -917,15 +918,15 @@ pub fn read_topic_header_info(path: &std::path::Path) -> Option<TopicHeaderInfo>
 
     // SAFETY: all offsets are within the validated 640-byte header.
     unsafe {
-        let type_size = std::ptr::read_unaligned(base.add(12) as *const u32);
-        let is_pod_raw = std::ptr::read_unaligned(base.add(20));
-        let topic_kind = std::ptr::read_unaligned(base.add(48));
-        let messages_total = std::ptr::read_unaligned(base.add(56) as *const u64);
-        let publisher_count = (*(base.add(192) as *const AtomicU32)).load(Ordering::Relaxed);
-        let subscriber_count = (*(base.add(196) as *const AtomicU32)).load(Ordering::Relaxed);
+        let type_size = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, type_size)) as *const u32);
+        let is_pod_raw = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, is_pod)));
+        let topic_kind = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, topic_kind)));
+        let messages_total = std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64);
+        let publisher_count = (*(base.add(offset_of!(TopicHeader, publisher_count)) as *const AtomicU32)).load(Ordering::Relaxed);
+        let subscriber_count = (*(base.add(offset_of!(TopicHeader, subscriber_count)) as *const AtomicU32)).load(Ordering::Relaxed);
 
         // type_name at offset 216, 32 bytes
-        let name_bytes = std::slice::from_raw_parts(base.add(216), 32);
+        let name_bytes = std::slice::from_raw_parts(base.add(offset_of!(TopicHeader, type_name)), 32);
         let end = name_bytes.iter().position(|&b| b == 0).unwrap_or(32);
         let type_name = std::str::from_utf8(&name_bytes[..end])
             .unwrap_or("")


### PR DESCRIPTION
Replace all the offset hardcoding with calculating the offset from offset_of! from the structure. This adds more flexibility to the code, and avoids remembering the magic numbers by the developer.

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on my local machine

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Safety (for unsafe code changes)

- [x] N/A - No unsafe code changes
- [ ] I have verified the unsafe code with MIRI locally
- [ ] I have documented why unsafe is necessary
- [ ] I have added appropriate safety comments

## Performance (for performance-sensitive changes)

- [x] N/A - Not performance-sensitive
- [ ] I have run benchmarks and there is no regression
- [ ] I have added benchmarks for new performance-critical code

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
