### PR TITLE
Suppress rust warings for avx specific, when moving to other target a…

### DIFF
--- a/horus_core/src/memory/simd.rs
+++ b/horus_core/src/memory/simd.rs
@@ -36,12 +36,15 @@ use std::sync::OnceLock;
 pub const SIMD_COPY_THRESHOLD: usize = 4096; // 4KB
 
 /// Alignment requirement for SIMD operations (AVX2 = 32 bytes)
+#[allow(unused)]
 const SIMD_ALIGNMENT: usize = 32;
 
 // Runtime feature detection — initialized exactly once, race-free
+#[allow(unused)]
 static AVX2_AVAILABLE: OnceLock<bool> = OnceLock::new();
 
 /// Check if AVX2 is available on the current CPU
+#[allow(unused)]
 #[inline]
 fn is_avx2_available() -> bool {
     *AVX2_AVAILABLE.get_or_init(|| {


### PR DESCRIPTION
Suppress rust warings for avx specific, when moving to other target archs

## Summary

Suppress rust unused warnings when compiling for other targets.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this on my local machine

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Safety (for unsafe code changes)

- [x] N/A - No unsafe code changes
- [ ] I have verified the unsafe code with MIRI locally
- [ ] I have documented why unsafe is necessary
- [ ] I have added appropriate safety comments

## Performance (for performance-sensitive changes)

- [x] N/A - Not performance-sensitive
- [ ] I have run benchmarks and there is no regression
- [ ] I have added benchmarks for new performance-critical code

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
