### PR TITLE
fix(security): require authentication for remote estop

### DIFF
--- a/horus_net/src/config.rs
+++ b/horus_net/src/config.rs
@@ -23,8 +23,8 @@ pub struct NetConfig {
     pub deny_export: Vec<String>,
     /// Safety heartbeat settings.
     pub safety: SafetyConfig,
-    /// Posture for acting on UNAUTHENTICATED remote e-stop packets.
-    /// Env: HORUS_ESTOP_REMOTE = warn (default) | off.
+    /// Posture for acting on authenticated remote e-stop packets.
+    /// `HORUS_ESTOP_KEY` is mandatory. Env: HORUS_ESTOP_REMOTE = warn | off.
     pub estop_remote: EstopRemotePolicy,
     /// Enabled optimizers (e.g., ["fusion", "delta"]).
     pub optimizers: Vec<String>,
@@ -34,16 +34,13 @@ pub struct NetConfig {
 
 /// Policy for acting on e-stop packets received from the network.
 ///
-/// Networked e-stop is currently UNAUTHENTICATED (see `estop::handle_remote_estop`):
-/// the wire `secret_hash` is a non-cryptographic FNV-1a value broadcast in cleartext
-/// for peer *filtering*, NOT security. Any host on the LAN can therefore forge an
-/// e-stop and halt the fleet. This policy lets an operator choose the posture.
+/// Networked e-stop requires HMAC authentication with `HORUS_ESTOP_KEY`.
+/// This policy controls whether a valid, authenticated packet is acted upon.
 /// Env: `HORUS_ESTOP_REMOTE` = `warn` (default) | `off`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EstopRemotePolicy {
-    /// Act on remote e-stop (halt), but emit a LOUD one-time warning that the
-    /// networked e-stop channel is unauthenticated. This is the default: honoring a
-    /// possibly-forged HALT is safer than ignoring a genuine one.
+    /// Act on a valid authenticated remote e-stop. Without a key, all remote
+    /// e-stop packets are rejected regardless of this setting.
     #[default]
     Warn,
     /// Ignore remote e-stop entirely. Local (watchdog/deadline) e-stop is unaffected.

--- a/horus_net/src/estop.rs
+++ b/horus_net/src/estop.rs
@@ -26,9 +26,6 @@ use crate::transport::Transport;
 const ESTOP_MAX_AGE_NS: u64 = 5_000_000_000; // 5s in the past
 const ESTOP_MAX_FUTURE_SKEW_NS: u64 = 5_000_000_000; // 5s in the future
 
-/// Emitted at most once: acting on the UNAUTHENTICATED networked e-stop channel.
-static ESTOP_UNAUTH_WARNED: AtomicBool = AtomicBool::new(false);
-
 /// Emitted at most once: rejected an e-stop whose authentication tag failed.
 static ESTOP_FORGERY_WARNED: AtomicBool = AtomicBool::new(false);
 
@@ -155,11 +152,11 @@ pub fn decode_estop(data: &[u8]) -> Option<(u16, String, u64)> {
 /// dropped — turning a limiter meant to stop a forced halt into a way to
 /// suppress a real one.
 ///
-/// Returns `true` when no key is configured: there is nothing to verify, and the
-/// caller keeps the original ordering in that case.
+/// Fails closed when no key is configured. An unprovisioned receiver must never
+/// route an attacker-controlled packet to the emergency-stop hook.
 pub fn estop_packet_is_authentic(data: &[u8]) -> bool {
     let Some(key) = crate::mac::estop_key() else {
-        return true;
+        return false;
     };
     let Some(body_len) = estop_body_len(data) else {
         return false;
@@ -172,30 +169,12 @@ pub fn estop_packet_is_authentic(data: &[u8]) -> bool {
 /// Returns `true` if this call acted on the e-stop (triggered the external stop),
 /// `false` if it was rejected (stale/malformed) or suppressed by policy.
 ///
-/// # Security posture — UNAUTHENTICATED (read before "hardening" this)
+/// # Security posture
 ///
-/// This channel is **not authenticated**. The only wire-level "identity" is the
-/// discovery `secret_hash`, which is a non-cryptographic FNV-1a value broadcast in
-/// CLEARTEXT for peer *filtering* (`config` says "NOT security"). Building e-stop
-/// auth on it would be fake security — an attacker reads the hash off the wire and
-/// replays it. This pass therefore deliberately does **not** fake authentication.
-///
-/// What it DOES provide (defense in depth, honestly scoped):
-///   * **Freshness/replay reject** — a timestamp outside `[now-5s, now+5s]` is
-///     dropped, so a captured e-stop cannot be replayed indefinitely.
-///   * **Explicit policy gate** (`EstopRemotePolicy`, env `HORUS_ESTOP_REMOTE`):
-///     `Warn` (default) acts on the e-stop but emits a LOUD one-time warning that
-///     any LAN peer can halt the fleet; `Off` ignores remote e-stop entirely.
-///     The LOCAL safety path (watchdog/deadline e-stop in horus_core) is
-///     independent and unaffected by either setting.
-///
-/// Genuine authenticated networked e-stop needs a provisioned, off-wire key.
-/// That key now exists: set `HORUS_ESTOP_KEY` (see `crate::mac`). When it is
-/// set, every e-stop packet carries an HMAC-SHA256 tag and an untagged or
-/// wrongly-tagged packet is **rejected outright**, regardless of policy —
-/// this is the actual fix for GHSA-3frr-c2j9-hhr7. When it is unset, behaviour
-/// is unchanged (`Warn` is loud-by-design, `Off` available) so an upgrade never
-/// silently severs a fleet's existing e-stop path.
+/// Remote e-stop fails closed unless `HORUS_ESTOP_KEY` provisions an off-wire
+/// shared key. Every accepted packet must carry a valid HMAC-SHA256 tag and pass
+/// the freshness check. Discovery's cleartext `secret_hash` is never treated as
+/// authentication. Local watchdog/deadline e-stop remains independent.
 pub fn handle_remote_estop(data: &[u8], policy: EstopRemotePolicy) -> bool {
     handle_remote_estop_with_key(data, policy, crate::mac::estop_key())
 }
@@ -221,22 +200,25 @@ pub fn handle_remote_estop_at(
     key: Option<&[u8; 32]>,
     now_ns: u64,
 ) -> bool {
+    // Authentication is mandatory. Backward compatibility cannot take priority
+    // over allowing any network host to halt the fleet (GHSA-3frr-c2j9-hhr7).
+    let Some(key) = key else {
+        warn_unauthenticated_rejected();
+        return false;
+    };
+
     let (host_id, reason, timestamp) = match decode_estop(data) {
         Some(v) => v,
         None => return false,
     };
 
-    // Authentication gate. Only active when a key is provisioned; when active it
-    // precedes every other check so a forged packet cannot even reach the logs.
-    if let Some(key) = key {
-        crate::mac::estop_authenticated(); // one-time "hardened path active" notice
-        let Some(body_len) = estop_body_len(data) else {
-            return false;
-        };
-        if !verify_estop_tag(key, data, body_len) {
-            warn_unauthenticated_rejected();
-            return false;
-        }
+    crate::mac::estop_authenticated();
+    let Some(body_len) = estop_body_len(data) else {
+        return false;
+    };
+    if !verify_estop_tag(key, data, body_len) {
+        warn_unauthenticated_rejected();
+        return false;
     }
 
     // Freshness / replay guard (NOT authentication — see doc above).
@@ -271,10 +253,7 @@ pub fn handle_remote_estop_at(
             // packet with an arbitrary timestamp is exactly the replay this
             // guard exists for — but say so loudly, because otherwise the
             // operator has no way to discover that their e-stop is inert.
-            warn_estop_clock_unusable(host_id, key.is_some());
-            if key.is_none() {
-                return false;
-            }
+            warn_estop_clock_unusable(host_id, true);
         }
     }
 
@@ -285,7 +264,6 @@ pub fn handle_remote_estop_at(
             false
         }
         EstopRemotePolicy::Warn => {
-            warn_unauthenticated_once();
             let msg = format!("Remote e-stop from host {:04x}: {}", host_id, reason);
             eprintln!("[horus_net] {}", msg);
             horus_core::scheduling::trigger_external_emergency_stop(msg);
@@ -413,18 +391,6 @@ fn is_fresh_estop(timestamp_ns: u64) -> bool {
 /// The reach claim here is deliberately not "this LAN": the replicator binds
 /// `0.0.0.0` (`transport/udp.rs`), so the packet can come from any host able to
 /// route a datagram to this port, not merely a link-local neighbour.
-fn warn_unauthenticated_once() {
-    if !ESTOP_UNAUTH_WARNED.swap(true, Ordering::Relaxed) {
-        eprintln!(
-            "[horus_net] WARNING: acting on a NETWORKED e-stop, which is \
-             UNAUTHENTICATED — any host that can reach this UDP port (the socket \
-             binds 0.0.0.0, so not just the local subnet) can halt the fleet. \
-             Set HORUS_ESTOP_KEY on every node to authenticate e-stop, or \
-             HORUS_ESTOP_REMOTE=off to ignore remote e-stop. (Fires once.)"
-        );
-    }
-}
-
 /// Emit the "this machine's clock cannot be compared" warning at most once.
 ///
 /// Rate-limited like the others: the condition persists until NTP lands, so an
@@ -461,9 +427,9 @@ fn warn_estop_clock_unusable(host_id: u16, authenticated: bool) {
 fn warn_unauthenticated_rejected() {
     if !ESTOP_FORGERY_WARNED.swap(true, Ordering::Relaxed) {
         eprintln!(
-            "[horus_net] WARNING: REJECTED a remote e-stop with a missing or invalid \
-             authentication tag. Either a peer is misconfigured (HORUS_ESTOP_KEY must \
-             match on every node) or someone is forging e-stop packets. (Fires once.)"
+            "[horus_net] WARNING: REJECTED a remote e-stop because HORUS_ESTOP_KEY is \
+             not provisioned or its authentication tag is missing/invalid. The key must \
+             match on every node; otherwise someone may be forging packets. (Fires once.)"
         );
     }
 }
@@ -572,9 +538,9 @@ mod tests {
     }
 
     #[test]
-    fn fresh_estop_warn_triggers() {
+    fn unkeyed_fresh_estop_is_rejected() {
         let payload = encode_estop(0xABCD, "test"); // fresh timestamp
-        assert!(handle_remote_estop(&payload, EstopRemotePolicy::Warn));
+        assert!(!handle_remote_estop(&payload, EstopRemotePolicy::Warn));
     }
 
     #[test]
@@ -788,11 +754,9 @@ mod tests {
     }
 
     #[test]
-    fn unkeyed_receiver_still_accepts_untagged_packet() {
-        // Backward compatibility: upgrading one node must not sever a fleet's
-        // existing e-stop path. Without a key, behaviour is exactly as before.
+    fn unkeyed_receiver_rejects_untagged_packet() {
         let pkt = encode_estop_with_key(0x1234, "halt", None);
-        assert!(handle_remote_estop_with_key(
+        assert!(!handle_remote_estop_with_key(
             &pkt,
             EstopRemotePolicy::Warn,
             None
@@ -800,11 +764,9 @@ mod tests {
     }
 
     #[test]
-    fn unkeyed_receiver_accepts_tagged_packet() {
-        // A hardened sender talking to a not-yet-upgraded receiver: the trailing
-        // tag is simply ignored, so a rolling upgrade does not drop e-stops.
+    fn unkeyed_receiver_rejects_tagged_packet_without_verification_key() {
         let pkt = encode_estop_with_key(0x1234, "halt", Some(&KEY_A));
-        assert!(handle_remote_estop_with_key(
+        assert!(!handle_remote_estop_with_key(
             &pkt,
             EstopRemotePolicy::Warn,
             None

--- a/horus_net/src/mac.rs
+++ b/horus_net/src/mac.rs
@@ -30,10 +30,8 @@
 //! originally did, is not adequate when every packet on the wire is an offline
 //! verifier for a guess.
 //!
-//! When a key is configured, an e-stop without a valid tag is **rejected**. When
-//! no key is configured, behaviour is unchanged (the loud one-time warning in
-//! `estop` still fires) so existing deployments do not silently lose their
-//! e-stop path on upgrade.
+//! An e-stop without a valid tag is **rejected**. When no key is configured,
+//! remote e-stop fails closed; local safety mechanisms remain available.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -466,17 +466,13 @@ impl Replicator {
             // authentication let the attacker use it to SUPPRESS a halt instead,
             // which is the strictly worse direction.
             //
-            // With a key provisioned, a forged packet is now rejected without
-            // spending anything, and only packets that could actually halt the
-            // robot consume budget. Verification is an HMAC over at most a few
+            // A forged packet (or any packet when no key is provisioned) is
+            // rejected without spending anything, and only packets that could
+            // actually halt the robot consume budget. Verification is an HMAC over at most a few
             // hundred bytes and the source has already passed `peer_filter`, so
             // the CPU an unauthenticated flood can buy is bounded.
             //
-            // Unkeyed deployments keep the original ordering — there is nothing
-            // to authenticate against, so the bucket is the only defence there.
-            if crate::mac::estop_key().is_some()
-                && !crate::estop::estop_packet_is_authentic(&msg.payload)
-            {
+            if !crate::estop::estop_packet_is_authentic(&msg.payload) {
                 self.metrics.record_topic_drop(msg.topic_hash);
                 return;
             }
@@ -1103,10 +1099,9 @@ mod tests {
     }
 
     #[test]
-    fn process_packet_dispatches_estop_data_packet() {
-        // A genuine DATA packet on _horus.estop must flow through decode_packet →
-        // process_incoming_message → the estop handler (proves data packets are
-        // dispatched, not swallowed). Observed via the external e-stop hook.
+    fn process_packet_rejects_unkeyed_estop_data_packet() {
+        // Regression for GHSA-3frr-c2j9-hhr7: a fresh, well-formed network packet
+        // must not reach the hook when no authentication key is provisioned.
         let fired = Arc::new(AtomicBool::new(false));
         let fired2 = fired.clone();
         horus_core::scheduling::set_emergency_stop_hook(move |_reason| {
@@ -1132,13 +1127,13 @@ mod tests {
         rep.process_packet(&buf[..len], from);
 
         assert!(
-            fired.load(Ordering::SeqCst),
-            "estop data packet must dispatch to the estop handler"
+            !fired.load(Ordering::SeqCst),
+            "unkeyed estop data packet must not dispatch to the estop hook"
         );
     }
 
     #[test]
-    fn a_second_estop_episode_is_not_deduped_away() {
+    fn unkeyed_estop_episodes_never_reach_the_hook() {
         // Guards two properties at once: a LATER episode must halt (the original
         // sequence-0 regression), and no unauthenticated cache upstream of the
         // MAC may drop a system-topic message.
@@ -1187,28 +1182,25 @@ mod tests {
         );
 
         rep.process_packet(&ep1, from);
-        assert!(fired.load(Ordering::SeqCst), "episode 1 must halt");
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "unkeyed episode must not halt"
+        );
 
-        // A byte-identical retry now REACHES the handler again, because system
-        // topics are deliberately exempt from deduplication: dedup runs upstream
-        // of the MAC on a cache keyed by an unauthenticated 16-bit sender id, so
-        // one forged packet could otherwise poison it and permanently silence
-        // this peer's e-stops. Re-delivering a halt is harmless — the e-stop
-        // latches and the fleet re-broadcast is gated on a rising edge — whereas
-        // suppressing one is not.
+        // A byte-identical retry must remain inert without key provisioning.
         fired.store(false, Ordering::SeqCst);
         rep.process_packet(&ep1, from);
         assert!(
-            fired.load(Ordering::SeqCst),
-            "a retry must still halt; suppressing it is the dangerous direction"
+            !fired.load(Ordering::SeqCst),
+            "an unkeyed retry must remain inert"
         );
 
-        // The genuinely new episode must get through.
+        // A genuinely new but unauthenticated episode must also remain inert.
         fired.store(false, Ordering::SeqCst);
         rep.process_packet(&ep2, from);
         assert!(
-            fired.load(Ordering::SeqCst),
-            "a LATER e-stop episode must still halt — this is the regression"
+            !fired.load(Ordering::SeqCst),
+            "a later unkeyed e-stop episode must not halt"
         );
     }
 }


### PR DESCRIPTION
## Summary
- fail closed when `HORUS_ESTOP_KEY` is not provisioned
- reject unauthenticated `_horus.estop` packets before rate limiting or dispatch
- add regression coverage for the advisory attack path

Fixes GHSA-3frr-c2j9-hhr7.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p horus_net --lib -- -D warnings`
- `cargo test -p horus_net --lib -- --test-threads=1` (318 passed)