### PR TITLE
fix(ci): unbreak all eight build workflows after the rust-major bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,12 +30,21 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Keep major updates separate for review
-      rust-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
+      # NOTE: majors are deliberately NOT grouped. A "rust-major" group with
+      # patterns ["*"] used to exist here, which contradicted its own comment
+      # ("keep major updates separate for review"): it bundled every breaking
+      # bump into a single PR. That is how #74 landed six majors at once, and
+      # why one uncompilable crate in the batch took all eight build workflows
+      # down with it. Ungrouped major updates get one PR each, so a bad one can
+      # be closed without blocking the rest.
+    ignore:
+      # bincode 3.0.0 is a placeholder release: its entire src/lib.rs is
+      # compile_error!("https://xkcd.com/2347/"), so it can never build. It is
+      # nonetheless the newest non-yanked version, so Dependabot keeps
+      # proposing it. The code here uses the 1.x API (bincode::serialize /
+      # bincode::deserialize), which 2.x also removed.
+      - dependency-name: "bincode"
+        versions: [">=2.0.0"]
     # NOTE: there was an `ignore` rule here using
     # update-types: ["version-update:semver-prerelease"], which is not a valid
     # value — Dependabot accepts only semver-major/minor/patch, and rejected the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,12 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6a120d2e16b3e1b4a24bd70f23b12d3e16b81f113364a26935f8db7245452d"
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,7 +1294,7 @@ name = "horus-robotics"
 version = "0.2.0"
 source = "git+https://github.com/softmata/horus-robotics.git?rev=631483a226dc8158a08ffb2c51087b3d02237041#631483a226dc8158a08ffb2c51087b3d02237041"
 dependencies = [
- "bincode 1.3.3",
+ "bincode",
  "bytemuck",
  "horus_core",
  "horus_macros",
@@ -1353,7 +1347,7 @@ name = "horus_core"
 version = "0.2.2"
 dependencies = [
  "anyhow",
- "bincode 3.0.0",
+ "bincode",
  "bytemuck",
  "chrono",
  "colored",
@@ -1499,7 +1493,7 @@ dependencies = [
 name = "horus_net"
 version = "0.1.0"
 dependencies = [
- "bincode 3.0.0",
+ "bincode",
  "horus-robotics",
  "horus_core",
  "horus_sys",
@@ -1554,7 +1548,7 @@ dependencies = [
 name = "horus_types"
 version = "0.2.2"
 dependencies = [
- "bincode 3.0.0",
+ "bincode",
  "bytemuck",
  "horus_core",
  "horus_macros",

--- a/horus_core/Cargo.toml
+++ b/horus_core/Cargo.toml
@@ -27,7 +27,7 @@ serde_json.workspace = true
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 regex = "1.10"
 toml = "1.1"
-bincode = "3.0"
+bincode = "1.3"
 bytemuck = { workspace = true }
 softmata-core = "0.1.2"
 ctrlc = "3.4"

--- a/horus_cpp_macros/src/parser.rs
+++ b/horus_cpp_macros/src/parser.rs
@@ -13,7 +13,7 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{
     parse2, Attribute, FnArg, GenericArgument, ImplItem, Item, ItemImpl, ItemStruct, Pat,
-    PathArguments, Result, ReturnType, Type, TypePath,
+    PathArguments, ReceiverKind, Result, ReturnType, Type, TypePath,
 };
 
 use crate::types::{
@@ -154,17 +154,23 @@ fn parse_method_sig(sig: &syn::Signature) -> Result<MethodSig> {
 
 fn parse_receiver(sig: &syn::Signature) -> Receiver {
     match sig.inputs.first() {
-        Some(FnArg::Receiver(recv)) => {
-            if recv.reference.is_some() {
-                if recv.mutability.is_some() {
+        Some(FnArg::Receiver(recv)) => match &recv.kind {
+            // syn 3 moved the `&`/`&mut` distinction out of `Receiver::reference`
+            // (removed) and into `ReceiverKind`. Note that `recv.mutability` must
+            // NOT be used here any more: it now means the `mut` of `mut self`,
+            // not the `mut` of `&mut self`, so reading it would report a plain
+            // `mut self` as `RefMut`.
+            ReceiverKind::Reference(_, _, mutability) => {
+                if mutability.is_some() {
                     Receiver::RefMut
                 } else {
                     Receiver::Ref
                 }
-            } else {
-                Receiver::Owned
             }
-        }
+            // `self`, `mut self` and `self: Box<Self>` all take ownership, which
+            // matches what the pre-syn-3 `reference.is_none()` branch did.
+            _ => Receiver::Owned,
+        },
         _ => Receiver::None,
     }
 }

--- a/horus_cpp_macros/src/types.rs
+++ b/horus_cpp_macros/src/types.rs
@@ -10,6 +10,14 @@ use proc_macro2::Ident;
 use syn::{Generics, Type, Visibility};
 
 /// Top-level binding metadata for a single annotated item.
+// `Impl` is ~208 bytes larger than `Struct`. That gap only crossed clippy's
+// threshold with syn 3, which grew `Signature`/`Receiver` (the `&`/`&mut`
+// distinction moved into the new `ReceiverKind` field). Boxing the variant is
+// the usual remedy, but this is proc-macro metadata: one value is built per
+// annotated item at compile time and immediately consumed by the generators,
+// so the size difference costs nothing at runtime and boxing would only add
+// indirection plus ~40 `Box::new` call sites.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum BindingItem {
     /// `#[horus_api]` on a struct definition.

--- a/horus_manager/src/commands/deploy.rs
+++ b/horus_manager/src/commands/deploy.rs
@@ -1001,7 +1001,10 @@ fn find_binary_name() -> Option<String> {
     }
 
     let content = std::fs::read_to_string(cargo_toml).ok()?;
-    let parsed: toml::Value = content.parse().ok()?;
+    // toml 1.1 changed `FromStr for Value` to parse a single TOML *value*
+    // (ValueDeserializer), not a document — only `Table` still parses a
+    // document via FromStr. `toml::from_str` keeps the document semantics.
+    let parsed: toml::Value = toml::from_str(&content).ok()?;
 
     // Try [[bin]] name first
     if let Some(bins) = parsed.get("bin").and_then(|b| b.as_array()) {

--- a/horus_manager/src/commands/doc_extract_rust.rs
+++ b/horus_manager/src/commands/doc_extract_rust.rs
@@ -57,7 +57,7 @@ pub fn extract_rust_file(path: &Path, include_private: bool) -> Result<RustExtra
             }
             Item::Impl(i) => {
                 let type_name = type_name_from_path(&i.self_ty);
-                let trait_name = i.trait_.as_ref().map(|(_, p, _)| path_to_string(p));
+                let trait_name = i.trait_.as_ref().map(|(p, _)| path_to_string(p));
                 let methods = extract_impl_methods(i, path, include_private);
 
                 // Detect impl Node for X → entry point
@@ -789,9 +789,12 @@ fn signature_to_string(vis: &syn::Visibility, sig: &syn::Signature) -> String {
         .map(|arg| match arg {
             syn::FnArg::Receiver(r) => {
                 let mut s = String::new();
-                if r.reference.is_some() {
+                // syn 3: `&`/`&mut` moved from `Receiver::reference` into
+                // `ReceiverKind::Reference`. `r.mutability` now means the `mut`
+                // of `mut self`, which this renderer has never printed.
+                if let syn::ReceiverKind::Reference(_, _, mutability) = &r.kind {
                     s.push('&');
-                    if r.mutability.is_some() {
+                    if mutability.is_some() {
                         s.push_str("mut ");
                     }
                 }
@@ -829,9 +832,12 @@ fn sig_to_string_no_vis(sig: &syn::Signature) -> String {
         .map(|arg| match arg {
             syn::FnArg::Receiver(r) => {
                 let mut s = String::new();
-                if r.reference.is_some() {
+                // syn 3: `&`/`&mut` moved from `Receiver::reference` into
+                // `ReceiverKind::Reference`. `r.mutability` now means the `mut`
+                // of `mut self`, which this renderer has never printed.
+                if let syn::ReceiverKind::Reference(_, _, mutability) = &r.kind {
                     s.push('&');
-                    if r.mutability.is_some() {
+                    if mutability.is_some() {
                         s.push_str("mut ");
                     }
                 }
@@ -926,7 +932,7 @@ fn type_to_string(ty: &Type) -> String {
             format!("[{}; ...]", type_to_string(&a.elem))
         }
         Type::Ptr(p) => {
-            let m = if p.mutability.is_some() {
+            let m = if matches!(p.mutability, syn::PointerMutability::Mut(_)) {
                 "mut"
             } else {
                 "const"
@@ -979,7 +985,8 @@ fn path_to_string_with_args(path: &syn::Path) -> String {
                     format!("{}<{}>", name, args.join(", "))
                 }
                 syn::PathArguments::Parenthesized(p) => {
-                    let inputs: Vec<String> = p.inputs.iter().map(type_to_string).collect();
+                    let inputs: Vec<String> =
+                        p.inputs.iter().map(|arg| type_to_string(&arg.ty)).collect();
                     let ret = match &p.output {
                         ReturnType::Default => String::new(),
                         ReturnType::Type(_, ty) => format!(" -> {}", type_to_string(ty)),

--- a/horus_manager/src/config.rs
+++ b/horus_manager/src/config.rs
@@ -392,7 +392,8 @@ mod tests {
 
         // "Load" it back
         let loaded = std::fs::read_to_string(&path).unwrap();
-        let parsed: toml::Value = loaded.parse().unwrap();
+        // toml 1.1: `FromStr for Value` parses a value, not a document.
+        let parsed: toml::Value = toml::from_str(&loaded).unwrap();
 
         // Assert all fields match
         let urls = parsed.get("urls").unwrap();

--- a/horus_manager/src/fingerprint.rs
+++ b/horus_manager/src/fingerprint.rs
@@ -83,7 +83,7 @@ impl Fingerprints {
 pub fn hash_content(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 // ─── Sync lock ──────────────────────────────────────────────────────────────

--- a/horus_manager/src/lockfile.rs
+++ b/horus_manager/src/lockfile.rs
@@ -275,7 +275,7 @@ pub fn hash_config(config_content: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(config_content.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 #[cfg(test)]

--- a/horus_manager/src/plugins/registry.rs
+++ b/horus_manager/src/plugins/registry.rs
@@ -366,7 +366,7 @@ impl PluginRegistry {
         let content = fs::read(&entry.binary)?;
         let mut hasher = Sha256::new();
         hasher.update(&content);
-        let computed = format!("sha256:{:x}", hasher.finalize());
+        let computed = format!("sha256:{}", hex::encode(hasher.finalize()));
 
         Ok(computed == entry.checksum)
     }
@@ -394,7 +394,7 @@ impl PluginRegistry {
         let content = fs::read(path)?;
         let mut hasher = Sha256::new();
         hasher.update(&content);
-        Ok(format!("sha256:{:x}", hasher.finalize()))
+        Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
     }
 }
 

--- a/horus_manager/src/registry/install.rs
+++ b/horus_manager/src/registry/install.rs
@@ -597,7 +597,7 @@ impl RegistryClient {
         // Calculate checksum and verify against server
         let mut hasher = Sha256::new();
         hasher.update(&bytes);
-        let checksum = format!("{:x}", hasher.finalize());
+        let checksum = hex::encode(hasher.finalize());
 
         // Fetch expected checksum from server and compare
         let checksum_url = format!(
@@ -1043,7 +1043,7 @@ impl RegistryClient {
         // Verify checksum from X-Horus-Checksum header
         let mut hasher = Sha256::new();
         hasher.update(&bytes);
-        let actual_checksum = format!("{:x}", hasher.finalize());
+        let actual_checksum = hex::encode(hasher.finalize());
 
         // Fail CLOSED when the binary artifact arrives with no X-Horus-Checksum
         // header, or an empty one. Previously both fell out of the `if let` and
@@ -1823,7 +1823,8 @@ impl RegistryClient {
                 // Read actual version from Cargo.toml after cargo add
                 let cargo_toml_path = ws_path.join("Cargo.toml");
                 let actual_version = if let Ok(content) = fs::read_to_string(&cargo_toml_path) {
-                    if let Ok(doc) = content.parse::<toml::Value>() {
+                    // toml 1.1: `FromStr for Value` parses a value, not a document.
+                    if let Ok(doc) = toml::from_str::<toml::Value>(&content) {
                         doc.get("dependencies")
                             .and_then(|deps| deps.get(package_name))
                             .and_then(|dep| {

--- a/horus_manager/src/registry/tests.rs
+++ b/horus_manager/src/registry/tests.rs
@@ -749,7 +749,7 @@ fn test_sha256_checksum_known_value() {
     // SHA256 of empty byte slice is a well-known constant
     let mut hasher = Sha256::new();
     hasher.update(b"");
-    let checksum = format!("{:x}", hasher.finalize());
+    let checksum = hex::encode(hasher.finalize());
     assert_eq!(
         checksum,
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -762,11 +762,11 @@ fn test_sha256_checksum_deterministic() {
     let data = b"horus robotics package v1.0.0";
     let mut h1 = Sha256::new();
     h1.update(data);
-    let c1 = format!("{:x}", h1.finalize());
+    let c1 = hex::encode(h1.finalize());
 
     let mut h2 = Sha256::new();
     h2.update(data);
-    let c2 = format!("{:x}", h2.finalize());
+    let c2 = hex::encode(h2.finalize());
 
     assert_eq!(c1, c2);
     assert_eq!(c1.len(), 64); // SHA256 hex is always 64 chars
@@ -780,11 +780,11 @@ fn test_sha256_checksum_differs_on_corruption() {
 
     let mut h1 = Sha256::new();
     h1.update(original);
-    let original_checksum = format!("{:x}", h1.finalize());
+    let original_checksum = hex::encode(h1.finalize());
 
     let mut h2 = Sha256::new();
     h2.update(&corrupted);
-    let corrupted_checksum = format!("{:x}", h2.finalize());
+    let corrupted_checksum = hex::encode(h2.finalize());
 
     assert_ne!(original_checksum, corrupted_checksum);
 }
@@ -799,14 +799,14 @@ fn test_sha256_incremental_update_matches_single() {
     let mut incremental = Sha256::new();
     incremental.update(chunk1);
     incremental.update(chunk2);
-    let incremental_sum = format!("{:x}", incremental.finalize());
+    let incremental_sum = hex::encode(incremental.finalize());
 
     let mut combined = Sha256::new();
     let mut all_data = Vec::new();
     all_data.extend_from_slice(chunk1);
     all_data.extend_from_slice(chunk2);
     combined.update(&all_data);
-    let combined_sum = format!("{:x}", combined.finalize());
+    let combined_sum = hex::encode(combined.finalize());
 
     assert_eq!(incremental_sum, combined_sum);
 }
@@ -1088,13 +1088,13 @@ fn test_publish_sha256_matches_downloaded() {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(data);
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     };
     let checksum2 = {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(data);
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     };
     assert_eq!(checksum1, checksum2);
     assert_eq!(checksum1.len(), 64); // SHA256 hex = 64 chars

--- a/horus_net/Cargo.toml
+++ b/horus_net/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2"
 horus_types = { path = "../horus_types" }
 horus-robotics = { git = "https://github.com/softmata/horus-robotics.git", rev = "631483a226dc8158a08ffb2c51087b3d02237041" }
 serde = { workspace = true }
-bincode = "3.0"
+bincode = "1.3"
 
 [[test]]
 name = "peer_process"

--- a/horus_types/Cargo.toml
+++ b/horus_types/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true }
 bytemuck = { workspace = true }
 serde_arrays = "0.2"
 rmp-serde = "1.1"
-bincode = "3.0"
+bincode = "1.3"
 
 [dev-dependencies]
 proptest = "1.4"


### PR DESCRIPTION
## Why CI is red

Every build workflow has failed on `main` since #74. All eight died on the same line, before reaching any of our own code:

```
error: https://xkcd.com/2347/
  --> bincode-3.0.0/src/lib.rs:1:1
1 | compile_error!("https://xkcd.com/2347/");
```

`bincode 3.0.0` is a placeholder release that cannot build by construction — and it is the newest non-yanked version, so Dependabot proposed it. I checked 14,456 lines of failed-job logs across all eight workflows: this was the *only* error in any of them.

## What else was hiding behind it

Because bincode aborted the build first, the other five majors in that batch were never actually compiled. Three were broken too:

| Crate | Breakage |
|---|---|
| **syn 3** | `Receiver::reference` removed (moved into `ReceiverKind`); `ItemImpl::trait_` 3-tuple → 2-tuple; `TypePtr::mutability` is now an enum; parenthesized generic args are `NamedArg`, not `Type` |
| **sha2 0.11** | `finalize()` returns `Array<u8, N>`, no `LowerHex` → 13 `format!("{:x}", ..)` sites broke |
| **toml 1.1** | `FromStr for Value` now parses a *value*, not a *document* |
| tokio-tungstenite 0.30 | fine — only ever referenced as a string literal |

Two subtleties worth review:

- **syn 3 `mutability` is a semantic trap.** The field still exists but now means the `mut` of `mut self`, not `&mut self`. The obvious port compiles and silently misclassifies receivers.
- **The toml 1.1 change still type-checks**, so nothing flagged it. Two of the three sites are production paths that failed *silently*: `deploy::find_binary_name` returned `None` for every `Cargo.toml`, and the post-`cargo add` version read in `registry::install` skipped its block entirely. Only one roundtrip test caught it.

`hex::encode` emits the identical lowercase digest `{:x}` did — these values are lockfile checksums and staleness fingerprints, so the output had to stay byte-identical.

## Prevention

The `rust-major` Dependabot group used `patterns: ["*"]`, which contradicted its own comment (*"Keep major updates separate for review"*) and bundled all six breaking bumps into one PR — so one uncompilable crate took down every workflow and hid the rest. Majors are now ungrouped (one PR each), and `bincode >=2.0.0` is ignored.

## Verification

Ran the CI gate commands locally:

- `cargo check --workspace --all-targets` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo doc --workspace --no-deps --exclude horus_manager` with `RUSTDOCFLAGS=-D warnings` — clean
- workspace + `horus_py` test suites — **6270+ passing**

The only local failures are the 18 `cmake_gen::real_cmake_*` tests, which need a `cmake` binary this machine lacks and GitHub runners provide.
