### PR TITLE
fix(ci): repair every failing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,19 @@ jobs:
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-check-
 
+      # horus_py cannot ride along in an --all-targets sweep: --all-targets
+      # builds the lib TEST target, and horus_py/src/lib.rs raises a
+      # compile_error! whenever cfg(test) and the default `extension-module`
+      # feature are both on (pyo3 leaves Python's symbols to the interpreter
+      # that dlopens the .so, so a test binary has nothing to link them
+      # against). Cargo cannot vary features per target, so the crate gets a
+      # second pass with the feature off instead — it is excluded from the
+      # sweep, never from coverage. Same split the test job uses below.
       - name: Cargo Check
-        run: cargo check --workspace --all-targets
+        run: cargo check --workspace --all-targets --exclude horus_py
+
+      - name: Cargo Check (horus_py)
+        run: cargo check -p horus_py --all-targets --no-default-features
 
   fmt:
     name: Format
@@ -114,10 +125,18 @@ jobs:
         run: |
           # See the RUSTFLAGS comment at the top: a PR event never has
           # github.ref == refs/heads/main, so also honour the PR target branch.
+          #
+          # horus_py is linted in its own pass with --no-default-features for
+          # the reason spelled out in the check job: --all-targets builds its
+          # lib test target, and the `extension-module` default feature makes
+          # that a compile_error!. Splitting it out keeps it linted rather than
+          # dropping it from coverage.
           if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.base_ref }}" == "main" ]]; then
-            cargo clippy --workspace --all-targets -- -D warnings
+            cargo clippy --workspace --all-targets --exclude horus_py -- -D warnings
+            cargo clippy -p horus_py --all-targets --no-default-features -- -D warnings
           else
-            cargo clippy --workspace --all-targets
+            cargo clippy --workspace --all-targets --exclude horus_py
+            cargo clippy -p horus_py --all-targets --no-default-features
           fi
 
   test:
@@ -270,6 +289,12 @@ jobs:
         run: |
           # Exclude horus_manager to avoid filename collision with horus library
           # (both would create target/doc/horus/ due to binary named 'horus')
+          #
+          # horus_py needs NO split here, unlike the check and clippy jobs:
+          # rustdoc never sets cfg(test) and never links a test binary, so the
+          # `extension-module` guard in horus_py/src/lib.rs does not fire. It is
+          # also the right call — docs should describe the crate as it ships,
+          # i.e. with its default features on.
           cargo doc --workspace --no-deps --exclude horus_manager
         env:
           RUSTDOCFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}

--- a/.github/workflows/docs-contract.yml
+++ b/.github/workflows/docs-contract.yml
@@ -8,10 +8,13 @@
 #
 # This workflow closes that direction. Three tiers, cheapest first:
 #
-#   1. contract-hermetic  — every PR, no network. Runs against the snapshot
-#                           committed at horus_manager/tests/fixtures/.
+#   1. contract-hermetic  — every PR, no network, no docs checkout. Everything
+#                           that can be asserted from this repository alone.
+#                           A test that has to open a documentation page is
+#                           `#[ignore]`d and belongs to tier 2, not here.
 #   2. contract-live      — every PR, clones horus-docs at a pinned commit and
-#                           re-extracts, so docs changes are seen too.
+#                           re-extracts, so docs changes are seen too. Runs the
+#                           tier-1 binaries again with --include-ignored.
 #   3. examples-compile   — nightly + manual. Compiles the documented Rust
 #                           examples against the real horus crate.
 #
@@ -53,7 +56,34 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # Pinned so a docs edit can never turn this repo's CI red on its own. Bump it
-  # deliberately (and regenerate the snapshot — see the contract-live summary).
+  # deliberately, to the newest docs commit that is *verified* to pass — a pin
+  # is a claim about a specific tree, so check it before changing it:
+  #
+  #     HORUS_DOCS_DIR=<horus-docs checkout> \
+  #       cargo test -p horus_manager --test docs_contract -- --include-ignored
+  #     HORUS_DOCS_DIR=<horus-docs checkout> \
+  #       cargo test -p horus_manager --test docs_cli_contract
+  #
+  # 2adcb0c ("fix(seo): point canonicals, sitemap and robots at
+  # docs.horusrobotics.dev") was verified that way: docs_contract 14/14 and
+  # docs_cli_contract 7/7. The previous pin, b16c640, had gone stale — ten of
+  # docs_contract's fourteen failed against it, all of them real drift that
+  # horus-docs has since fixed.
+  #
+  # This deliberately stops short of docs main. main is three commits further
+  # on, and two of them — ad67082 and 5288fbf — add eight section landing pages
+  # (advanced, cpp, development, learn, operations, performance, reference,
+  # stdlib) without adding them to `sections` in components/DocsSidebar.tsx, so
+  # nothing links to them and `every_docs_page_is_reachable_from_the_navigation`
+  # fails: 13/14 at ad67082 (its four pages), and 13/14 again at 5288fbf and at
+  # main's tip 5c83485 (all eight). That is drift in horus-docs, which no choice
+  # of pin here can paper over; once the sidebar there lists those pages, move
+  # this to that commit rather than to main's tip as it stands today.
+  #
+  # Verified locally at this ref means those two steps, not the whole job: the
+  # "Manifest and environment contract" step still fails 2 of 6 here. Those two
+  # are older than this bump — b16c640 failed 4 of the same 6 — so they are a
+  # separate problem in the manifest/schema contract, not a regression from it.
   #
   # This is also a trust boundary, which is why there is no `docs_ref` input to
   # override it. `schedule` and `workflow_dispatch` run in default-branch
@@ -63,7 +93,7 @@ env:
   # an escalation across repos that this repo's own review never sees.
   # Verifying a different docs commit means bumping this SHA in a PR, so the
   # change is reviewed here before it runs here.
-  DOCS_PINNED_REF: b16c640c9d0169f30bcd502d835777eef52d29dd
+  DOCS_PINNED_REF: 2adcb0c704875c398a7f3921cf41ed80b817f1f1
 
 jobs:
   # ── Tier 1 ────────────────────────────────────────────────────────────────
@@ -107,11 +137,17 @@ jobs:
       - name: C++ headers are self-contained
         run: cargo test -p horus_manager --test docs_examples_cpp public_headers_are_self_contained
 
-      # `docs_contract` asserts manifest tables and hook phases; `docs_cli_contract`
-      # is the one that checks the CLI reference. Both steps here used to run
-      # `docs_contract` under a "CLI contract" name, so the CLI reference was
-      # advertised as covered while nothing checked it.
-      - name: Manifest and hook contract
+      # `docs_contract`'s page-reading tests are `#[ignore]`d, because they need
+      # a horus-docs checkout and this tier by definition has none: running them
+      # here failed all eleven every day rather than checking anything. What is
+      # left runs without a checkout — the skip-or-fail policy itself, and the
+      # guard that contract-live below really does pass --include-ignored, which
+      # is what keeps the `#[ignore]` from becoming the silent skip it replaced.
+      #
+      # `docs_cli_contract` is the one that checks the CLI reference. Both steps
+      # here used to run `docs_contract` under a "CLI contract" name, so the CLI
+      # reference was advertised as covered while nothing checked it.
+      - name: Docs contract policy and wiring
         run: cargo test -p horus_manager --test docs_contract
 
       # `horus new` must produce the tree the quick-starts tell readers to open.
@@ -165,10 +201,16 @@ jobs:
           key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-docs-
 
+      # `--include-ignored`, not `--ignored`: the page-reading tests carry
+      # `#[ignore]` so the hermetic tier can leave them alone, and the two
+      # skip-policy tests that do not carry it are worth running against a real
+      # checkout as well. This is the only job that opens a page, so a step that
+      # loses the flag stops checking the docs entirely while staying green —
+      # `the_live_docs_job_runs_the_tests_this_file_ignores` fails if it does.
       - name: Manifest and hook contract against live docs
         env:
           HORUS_DOCS_DIR: ${{ github.workspace }}/horus-docs
-        run: cargo test -p horus_manager --test docs_contract
+        run: cargo test -p horus_manager --test docs_contract -- --include-ignored
 
       # Every `horus ...` invocation in the docs, resolved against the real clap
       # tree. Cheap: one `--help` per distinct command, not one per invocation.

--- a/.github/workflows/docs-contract.yml
+++ b/.github/workflows/docs-contract.yml
@@ -64,26 +64,32 @@ env:
   #     HORUS_DOCS_DIR=<horus-docs checkout> \
   #       cargo test -p horus_manager --test docs_cli_contract
   #
-  # 2adcb0c ("fix(seo): point canonicals, sitemap and robots at
-  # docs.horusrobotics.dev") was verified that way: docs_contract 14/14 and
-  # docs_cli_contract 7/7. The previous pin, b16c640, had gone stale — ten of
-  # docs_contract's fourteen failed against it, all of them real drift that
-  # horus-docs has since fixed.
+  # f1b9762 is verified that way: docs_contract 14/14, docs_cli_contract 7/7
+  # and docs_manifest 6/6 — the whole live tier, not a subset.
   #
-  # This deliberately stops short of docs main. main is three commits further
-  # on, and two of them — ad67082 and 5288fbf — add eight section landing pages
-  # (advanced, cpp, development, learn, operations, performance, reference,
-  # stdlib) without adding them to `sections` in components/DocsSidebar.tsx, so
-  # nothing links to them and `every_docs_page_is_reachable_from_the_navigation`
-  # fails: 13/14 at ad67082 (its four pages), and 13/14 again at 5288fbf and at
-  # main's tip 5c83485 (all eight). That is drift in horus-docs, which no choice
-  # of pin here can paper over; once the sidebar there lists those pages, move
-  # this to that commit rather than to main's tip as it stands today.
+  # The two pins before it were each stale in a different direction, and the
+  # difference is worth keeping because it decides what "bump the pin" can and
+  # cannot fix. b16c640 failed ten of docs_contract's fourteen: ordinary drift,
+  # already fixed in horus-docs, and a bump was the whole remedy. Moving to
+  # docs main did not work, though — ad67082 and 5288fbf had added eight
+  # section landing pages (advanced, cpp, development, learn, operations,
+  # performance, reference, stdlib) without listing them in `sections` in
+  # components/DocsSidebar.tsx, so nothing linked to them and
+  # every_docs_page_is_reachable_from_the_navigation failed 13/14 at every
+  # commit from ad67082 through main's tip 5c83485. No choice of pin fixes
+  # that, because there was no commit anywhere in horus-docs where those pages
+  # were reachable. It had to be fixed there, and f1b9762 is that fix.
   #
-  # Verified locally at this ref means those two steps, not the whole job: the
-  # "Manifest and environment contract" step still fails 2 of 6 here. Those two
-  # are older than this bump — b16c640 failed 4 of the same 6 — so they are a
-  # separate problem in the manifest/schema contract, not a regression from it.
+  # f1b9762 also republishes public/schema/horus.toml.schema.json, which had
+  # drifted from what the manifest structs generate and was failing
+  # the_published_schema_matches_the_generator in docs_manifest.
+  #
+  # f1b9762 is the head of softmata/horus-docs#6, not a commit on main. Pinning
+  # to an unmerged commit is deliberate and temporary: this repo's CI cannot go
+  # green until those docs changes exist somewhere fetchable, and a full SHA on
+  # a live branch is fetchable. When #6 merges, move this to the resulting main
+  # commit — and do not delete that branch before you do, because this pin is
+  # the only ref keeping f1b9762 reachable.
   #
   # This is also a trust boundary, which is why there is no `docs_ref` input to
   # override it. `schedule` and `workflow_dispatch` run in default-branch
@@ -93,7 +99,7 @@ env:
   # an escalation across repos that this repo's own review never sees.
   # Verifying a different docs commit means bumping this SHA in a PR, so the
   # change is reviewed here before it runs here.
-  DOCS_PINNED_REF: 2adcb0c704875c398a7f3921cf41ed80b817f1f1
+  DOCS_PINNED_REF: f1b97620af06ac737c87adcaa5e99490e772b695
 
 jobs:
   # ── Tier 1 ────────────────────────────────────────────────────────────────

--- a/.github/workflows/docs-contract.yml
+++ b/.github/workflows/docs-contract.yml
@@ -64,32 +64,24 @@ env:
   #     HORUS_DOCS_DIR=<horus-docs checkout> \
   #       cargo test -p horus_manager --test docs_cli_contract
   #
-  # f1b9762 is verified that way: docs_contract 14/14, docs_cli_contract 7/7
-  # and docs_manifest 6/6 — the whole live tier, not a subset.
+  # 9505c1d (softmata/horus-docs main, the merge of horus-docs#6) is verified
+  # that way: docs_contract 14/14, docs_cli_contract 7/7 and docs_manifest 6/6 —
+  # the whole live tier, run against this exact commit, not against the branch it
+  # came from.
   #
   # The two pins before it were each stale in a different direction, and the
-  # difference is worth keeping because it decides what "bump the pin" can and
-  # cannot fix. b16c640 failed ten of docs_contract's fourteen: ordinary drift,
-  # already fixed in horus-docs, and a bump was the whole remedy. Moving to
-  # docs main did not work, though — ad67082 and 5288fbf had added eight
-  # section landing pages (advanced, cpp, development, learn, operations,
-  # performance, reference, stdlib) without listing them in `sections` in
-  # components/DocsSidebar.tsx, so nothing linked to them and
-  # every_docs_page_is_reachable_from_the_navigation failed 13/14 at every
-  # commit from ad67082 through main's tip 5c83485. No choice of pin fixes
-  # that, because there was no commit anywhere in horus-docs where those pages
-  # were reachable. It had to be fixed there, and f1b9762 is that fix.
-  #
-  # f1b9762 also republishes public/schema/horus.toml.schema.json, which had
-  # drifted from what the manifest structs generate and was failing
-  # the_published_schema_matches_the_generator in docs_manifest.
-  #
-  # f1b9762 is the head of softmata/horus-docs#6, not a commit on main. Pinning
-  # to an unmerged commit is deliberate and temporary: this repo's CI cannot go
-  # green until those docs changes exist somewhere fetchable, and a full SHA on
-  # a live branch is fetchable. When #6 merges, move this to the resulting main
-  # commit — and do not delete that branch before you do, because this pin is
-  # the only ref keeping f1b9762 reachable.
+  # difference decides what "bump the pin" can and cannot fix. b16c640 failed ten
+  # of docs_contract's fourteen: ordinary drift, already fixed in horus-docs, and
+  # a bump was the whole remedy. Moving to docs main did NOT work at the time —
+  # ad67082 and 5288fbf had added eight section landing pages (advanced, cpp,
+  # development, learn, operations, performance, reference, stdlib) without
+  # listing them in `sections` in components/DocsSidebar.tsx, so nothing linked to
+  # them and every_docs_page_is_reachable_from_the_navigation failed 13/14 at
+  # every commit from ad67082 through 5c83485. No choice of pin could fix that,
+  # because there was no commit anywhere in horus-docs where those pages were
+  # reachable; horus-docs#6 is the commit that made them so, and also republished
+  # public/schema/horus.toml.schema.json, which had drifted from what the manifest
+  # structs generate.
   #
   # This is also a trust boundary, which is why there is no `docs_ref` input to
   # override it. `schedule` and `workflow_dispatch` run in default-branch
@@ -99,7 +91,7 @@ env:
   # an escalation across repos that this repo's own review never sees.
   # Verifying a different docs commit means bumping this SHA in a PR, so the
   # change is reviewed here before it runs here.
-  DOCS_PINNED_REF: f1b97620af06ac737c87adcaa5e99490e772b695
+  DOCS_PINNED_REF: 9505c1dbbdc165cde338a47eac5534984a23ce04
 
 jobs:
   # ── Tier 1 ────────────────────────────────────────────────────────────────

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -113,7 +113,17 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
         with:
-          components: rust-src
+          # rust-src is what -Zbuild-std needs to rebuild std instrumented.
+          # rustfmt is a *test* dependency: this job runs the whole workspace,
+          # and horus_manager's every_template_is_already_formatted shells out
+          # to `rustfmt --check` to prove the scaffolded templates ship
+          # formatted. Its tool_on_path("rustfmt") guard cannot skip the test
+          # here — rustup's shim is always on PATH on a GitHub runner, so a
+          # missing component is not "absent", it is a shim that exits with
+          # "'rustfmt' is not installed for the toolchain 'nightly-...'" and
+          # trips the assertion. The tsan job excludes horus_manager, so it
+          # does not need this component.
+          components: rust-src, rustfmt
 
       # Setup shared memory for HORUS tests
       - name: Setup Shared Memory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,9 @@ Thank you for your interest in contributing to HORUS! This document provides gui
 
 ### Prerequisites
 
-- Rust 1.92+ (`rustup update`)
+- Rust 1.90+ (`rustup update stable`) — the workspace MSRV in `[workspace.package] rust-version`
 - Python 3.9+ with `pip` (optional)
 - Build tools (GCC/Clang)
-- Node.js 18+ for documentation site
 
 ### Building
 
@@ -38,11 +37,6 @@ cargo build --release
 # First install maturin: cargo install maturin
 cd horus_py
 maturin develop --release
-
-# Build documentation site (optional)
-cd docs-site
-npm install
-npm run dev
 ```
 
 ## Testing
@@ -67,20 +61,28 @@ cargo bench
 
 ### Acceptance Tests
 
-User acceptance tests are in `tests/acceptance/` and document expected behavior.
+Acceptance tests live in two places:
+
+- **Rust acceptance tests** — `horus_core/tests/acceptance_topic.rs` and
+  `horus_core/tests/acceptance_scheduler.rs`, run by `cargo test`.
+- **Cross-platform CLI acceptance tests** — `tests/docker/acceptance_linux_macos.sh`
+  and `tests/docker/acceptance_windows.ps1`, which verify the complete user workflow.
+
+End-to-end QA scenarios (launch files and sample pub/sub projects) live in `tests/qa/`.
 
 **Before submitting a PR:**
-1. Review relevant acceptance test files
+1. Review the relevant acceptance tests
 2. Ensure changes align with documented behavior
 3. Update tests if changing functionality
 4. Add new scenarios for new features
 
 ```bash
-# Review test documentation
-cat tests/acceptance/README.md
+# Run the Rust acceptance tests
+cargo test -p horus_core --test acceptance_topic
+cargo test -p horus_core --test acceptance_scheduler
 
-# Check specific tests
-cat tests/acceptance/horus_manager/01_new_command.md
+# Run the cross-platform CLI acceptance suite
+bash tests/docker/acceptance_linux_macos.sh
 
 # Manually verify scenarios
 horus new test_project
@@ -157,7 +159,7 @@ When reporting bugs, include:
    Optionally run `cargo fmt` (may fail in some cases) and `cargo clippy` (warnings are acceptable).
 
 2. **Check acceptance tests**:
-   - Review relevant test files in `tests/acceptance/`
+   - Review the acceptance tests in `horus_core/tests/acceptance_*.rs` and `tests/docker/`
    - Manually verify key scenarios
    - Update test scenarios if behavior changed
    - Add new scenarios for new features
@@ -174,7 +176,7 @@ When reporting bugs, include:
 
    Detailed explanation of what changed and why.
 
-   - Updated acceptance tests in tests/acceptance/...
+   - Updated acceptance tests in horus_core/tests/acceptance_*.rs
    - Added new scenarios for ...
 
    Fixes #123
@@ -227,14 +229,21 @@ Fixes #123
 ```
 horus/
 ├── horus/              # Unified entry crate (use horus::prelude::*)
-├── horus_core/         # Core framework (Node, Topic, Scheduler, types, memory)
-├── horus_macros/       # Procedural macros (node!, message!)
-├── horus_library/      # Standard message types and TransformFrame transforms
+├── horus_core/         # Core framework (Node, Topic, Scheduler, types, memory, scheduling)
+├── horus_types/        # Universal IPC types (math, diagnostics, time, generic)
+├── horus_macros/       # Procedural macros (node!, LogSummary derive)
+├── horus_sys/          # Platform abstraction layer
+├── horus_net/          # Transparent LAN replication
+├── horus_cpp/          # C++ FFI bridge (CXX, staticlib+cdylib)
+├── horus_cpp_macros/   # C++ binding codegen (#[horus_api] proc macro)
 ├── horus_manager/      # CLI tool (horus command)
 ├── horus_py/           # Python bindings
 ├── benchmarks/         # Performance benchmarks
-└── tests/              # Integration tests
+├── examples/           # Example projects (Rust, C++, Python)
+└── tests/              # Integration and QA tests
 ```
+
+Standard message types come from `horus_types/` and the external `horus-robotics` git dependency; `TransformFrame` comes from the external `horus-tf` git dependency, re-exported through `horus::prelude`.
 
 ## What Not to Do
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git clone https://github.com/softmata/horus.git && cd horus && ./install.sh
 ```
 
 **Requires Rust 1.90 or newer** (`rustup update stable`). Python 3.9+ for the
-Python API; CMake 3.16+ and a C++17 compiler for the C++ API.
+Python API; CMake 3.20+ and a C++17 compiler for the C++ API.
 
 Python: `pip install horus-robotics` · C++: link against `libhorus_cpp` and `#include <horus/horus.hpp>`
 
@@ -348,7 +348,15 @@ Measured with RDTSC cycle counting, Tukey IQR outlier filtering, bootstrap 95% C
 | Cross-process        | **171 ns** | end-to-end, one-way    |
 | 1 pub → 3 subs       | **80 ns**  | producer-side `send()` |
 
-Reproduce with `cargo run --release --bin all_paths_latency`, which prints the
+The link above is to the methodology — RDTSC timing with calibrated overhead
+subtraction, Tukey IQR fences, bootstrap 95% CIs — which is shared. The numbers
+are not: this table is an i9-14900K run whose raw percentiles are not published
+here, while the tables in [`benchmarks/README.md`](benchmarks/README.md) were
+taken on an Intel Core i7-10750H @ 2.60 GHz under the `powersave` governor. The
+two sets are not comparable row to row, and the i7 figures are the ones this
+repository can show its work for.
+
+Reproduce with `cargo run --release -p horus_benchmarks --bin all_paths_latency`, which prints the
 full percentile distribution, the backend selected for each topology, and the
 measured hardware floor it subtracts.
 
@@ -369,7 +377,7 @@ your own hardware and message sizes.
 | Throughput    | 95 M msg/s | 22 M msg/s | **4.3x** |
 
 Unlike the ROS 2 row above, this one is measured on both sides: reproduce with
-`cargo run --release --bin iceoryx2_comparison --features iceoryx2`, which links
+`cargo run --release -p horus_benchmarks --bin iceoryx2_comparison --features iceoryx2`, which links
 iceoryx2 and times it in the same harness.
 
 Scales near-linearly to 100 nodes (14% degradation) and O(1) to 1,000 topics.
@@ -382,14 +390,16 @@ cargo run --release -p horus_benchmarks --bin all_paths_latency    # run it your
 
 ## Examples
 
-10 working projects in [`examples/`](examples/) — from differential drive to quadruped gait generation:
+12 working projects in [`examples/`](examples/) — from differential drive to quadruped gait generation. Every directory there is a `horus.toml` project: `horus build` and `horus run` drive all of them, in Rust, Python or C++.
+
+The single-file API demos are examples of the `horus` crate. The workspace root is a virtual manifest, so select the package with `-p`:
 
 ```bash
-cargo run --example 01_hello_node     # your first node
-cargo run --example 02_pub_sub        # topics and messages
-cargo run --example 03_multi_rate     # multi-rate scheduling
-cargo run --example 04_services       # request/response
-cargo run --example 05_realtime       # RT with deadline enforcement
+cargo run -p horus --example 01_hello_node     # your first node
+cargo run -p horus --example 02_pub_sub        # topics and messages
+cargo run -p horus --example 03_multi_rate     # multi-rate scheduling
+cargo run -p horus --example 04_services       # request/response
+cargo run -p horus --example 05_realtime       # RT with deadline enforcement
 ```
 
 [Full examples →](examples/) · [Tutorials →](https://docs.horusrobotics.dev/tutorials/01-sensor-node-rust) · [ROS 2 bridge recipe →](https://docs.horusrobotics.dev/recipes/ros2-bridge)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@
 
 Security updates will be provided for the following versions:
 
-| Version | Supported |
-| ------- | --------- |
-| 0.2.x   | Yes       |
-| 0.1.x   | No        |
-| < 0.1   | No        |
+| Version | Supported                    |
+| ------- | ---------------------------- |
+| 0.4.x   | Yes                          |
+| 0.3.x   | No (tagged, never published) |
+| 0.2.x   | No                           |
+| < 0.2   | No                           |
 
 ## Reporting a Vulnerability
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,7 +12,7 @@ cargo run --release -p horus_benchmarks --bin all_paths_latency
 
 | Benchmark                     | What It Measures                                                        |
 |-------------------------------|-------------------------------------------------------------------------|
-| `all_paths_latency`           | All 10 communication backends end-to-end with full statistical analysis |
+| `all_paths_latency`           | Every intra- and cross-process topic path, with full statistical analysis |
 | `cross_process_benchmark`     | True IPC between separate processes                                     |
 | `robotics_messages_benchmark` | Real message types (CmdVel, Imu, LaserScan, JointCommand)               |
 | `determinism_benchmark`       | Jitter and real-time suitability                                        |
@@ -33,48 +33,61 @@ cargo bench -p horus_benchmarks
 
 ## Measured Results
 
-Benchmarked on Intel Core i7-10750H @ 2.60 GHz (6C/12T), `powersave` governor, 100K iterations per scenario.
+> **The previously published tables have been withdrawn, not updated.** They were
+> wrong in two independent ways and no run on this machine can restore them:
+>
+> 1. **They named backends that do not exist.** The intra-process table listed
+>    `DirectChannel`, `SpscIntra`, `SpmcIntra`, `MpscIntra` and `MpmcIntra` under
+>    the heading "heap ring buffers". Those backends were removed. Every topic is
+>    SHM-backed today — `Topic::backend_name()` can only return `PodShm`,
+>    `SpscShm`, `SpmcShm`, `MpscShm`, `FanoutShm` or `Unknown` — so a real
+>    `all_paths_latency` run prints SHM backends for those same scenarios and
+>    nothing named `*Intra` exists to reproduce.
+> 2. **Their tails were truncated by construction.** `Statistics::from_samples`
+>    used to apply a Tukey IQR filter *before* computing `max`, `p99`, `p99.9` and
+>    `p99.99`, so the reported worst case could not exceed `Q3 + 1.5*IQR` however
+>    badly the machine stalled. The "Worst-Case Measured 885 ns" figure behind the
+>    1 kHz / 10 kHz / 100 kHz **PASS** verdicts was a number the code guaranteed
+>    could not be large. The filter now applies only to the mean and the
+>    confidence interval; every order statistic comes from the full sample set.
+>
+> Regenerate with `cargo run --release -p horus_benchmarks --bin all_paths_latency`
+> on a machine configured as described under *For Accurate Results* below, and
+> publish what that run prints — including the scenario, backend and measurement
+> columns it already emits.
 
-### Intra-Process (same process, heap ring buffers)
+### What `all_paths_latency` reports
 
-| Scenario                 | Backend       | p50        | p99    | p99.9  | Max    |
-|--------------------------|---------------|------------|--------|--------|--------|
-| Same thread              | DirectChannel | **23 ns**  | 31 ns  | 32 ns  | 32 ns  |
-| 1 pub, 1 sub             | SpscIntra     | **10 ns**  | 19 ns  | 19 ns  | 19 ns  |
-| 1 pub, N sub             | SpmcIntra     | **3 ns**   | 10 ns  | 11 ns  | 11 ns  |
-| N pub, 1 sub (contended) | MpscIntra     | **110 ns** | 426 ns | 528 ns | 578 ns |
-| N pub, N sub (contended) | MpmcIntra     | **100 ns** | 643 ns | 757 ns | 885 ns |
+The binary prints one row per scenario. The **measurement** column is the part
+the withdrawn tables dropped, and it is not comparable across kinds:
 
-### Cross-Process (shared memory, RDTSC-in-payload one-way)
+| Scenario           | Backend   | Measurement | What the number is                                    |
+|--------------------|-----------|-------------|-------------------------------------------------------|
+| `SameThread`       | `SpscShm` | `send`      | Producer-side `Topic::send()` cost, RDTSC overhead subtracted |
+| `CrossThread-1P1C` | `SpscShm` | `send`      | Producer-side `send()` cost                           |
+| `CrossThread-MP1C` | `MpscShm` | `send`      | Producer-side `send()` cost under producer contention |
+| `CrossThread-1PMC` | `PodShm`  | `send`      | Producer-side `send()` cost                           |
+| `CrossThread-MPMC` | `PodShm`  | `send`      | Producer-side `send()` cost under contention          |
+| `CrossProc-1P1C`   | `SpscShm` | `one-way`   | Pub-to-sub delivery, RDTSC timestamp in payload       |
+| `CrossProc-2P1C`   | `MpscShm` | `one-way`   | Pub-to-sub delivery                                   |
+| `CrossProc-1PMC`   | `SpmcShm` | `one-way`   | Pub-to-sub delivery                                   |
+| `CrossProc-PodShm` | `PodShm`  | `broadcast` | Latest-value broadcast; readers may skip ahead        |
+| `RawAtomic`        | —         | `one-way`   | Raw SHM atomic store/load — the hardware floor        |
 
-| Scenario       | Backend | p50        | p99    | p99.9  | Notes                    |
-|----------------|---------|------------|--------|--------|--------------------------|
-| 1 pub, 2 sub   | SpmcShm | **198 ns** | 298 ns | 308 ns | 31 ns framework overhead |
-| 1 pub, 4 sub   | SpmcShm | **236 ns** | 417 ns | 449 ns | Linear scaling           |
-| 1 pub, 8 sub   | SpmcShm | **276 ns** | 510 ns | 549 ns | 8 consumers              |
-| 4 pub, 4 sub   | PodShm  | **304 ns** | 1.5 us | 6.5 us | Broadcast/latest-value   |
-| Raw SHM atomic | —       | **167 ns** | 319 ns | 363 ns | Hardware floor           |
-
-### Robotics Messages (intra-process)
-
-| Message | Size     | Median    | p99   |
-|---------|----------|-----------|-------|
-| CmdVel  | 16 bytes | **20 ns** | 29 ns |
-
-### Real-Time Suitability
-
-All intra-process and SpmcShm cross-process paths are suitable for:
-
-| Control Rate | Budget   | Worst-Case Measured | Result   |
-|--------------|----------|---------------------|----------|
-| 1 kHz        | < 1 ms   | 885 ns (MpmcIntra)  | **PASS** |
-| 10 kHz       | < 100 us | 885 ns (MpmcIntra)  | **PASS** |
-| 100 kHz      | < 10 us  | 885 ns (MpmcIntra)  | **PASS** |
+A `send`-measurement row is *not* an IPC latency: it is the cost of the store
+into the shared-memory slot, with no consumer in the path. Only the `one-way`
+rows are comparable to a DDS end-to-end latency figure. `all_paths_latency`
+prints `MISMATCH` if the live backend differs from the expected one above, which
+is the check that would have caught the withdrawn table.
 
 ## Methodology
 
 - **Timing**: RDTSC with calibrated overhead subtraction (~29 ns overhead per measurement)
-- **Outlier removal**: Tukey IQR fences (1.5x)
+- **Outlier removal**: Tukey IQR fences (1.5x), applied to the **mean and
+  confidence interval only**. `min`, `max`, the median and every percentile are
+  computed from the full, unfiltered sample set — on a real-time path the tail
+  *is* the measurement, and an OS preemption or page fault is the event that
+  misses the deadline, not an artifact to discard.
 - **Confidence intervals**: Bootstrap 95% CI (10K resamples)
 - **CPU pinning**: Producer and consumer pinned to separate physical cores
 - **Warmup**: 5,000 iterations discarded before measurement

--- a/benchmarks/benches/scheduler_jitter.rs
+++ b/benchmarks/benches/scheduler_jitter.rs
@@ -11,25 +11,31 @@ use horus_core::error::HorusResult as Result;
 use horus_core::scheduling::Scheduler;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 // ============================================================================
 // Benchmark Nodes
 // ============================================================================
 
+// `name` is a `&'static str`, not a `String`. Both nodes here used to store a
+// `String` and implement `Node::name` as
+// `Box::leak(self.name.clone().into_boxed_str())`, which allocated and leaked a
+// fresh string every time the scheduler asked a node for its name — once per
+// tick, inside the loop these benchmarks measure. `Node::name` returns `&str`,
+// so the leak was never required, and every construction site passes a literal.
 struct JitterMeasureNode {
-    name: String,
+    name: &'static str,
     tick_count: Arc<AtomicU64>,
     timestamps: Arc<std::sync::Mutex<Vec<Instant>>>,
 }
 
 impl JitterMeasureNode {
-    fn new(name: &str) -> (Self, Arc<AtomicU64>, Arc<std::sync::Mutex<Vec<Instant>>>) {
+    fn new(name: &'static str) -> (Self, Arc<AtomicU64>, Arc<std::sync::Mutex<Vec<Instant>>>) {
         let tick_count = Arc::new(AtomicU64::new(0));
         let timestamps = Arc::new(std::sync::Mutex::new(Vec::with_capacity(2048)));
         (
             Self {
-                name: name.to_string(),
+                name,
                 tick_count: tick_count.clone(),
                 timestamps: timestamps.clone(),
             },
@@ -40,8 +46,8 @@ impl JitterMeasureNode {
 }
 
 impl Node for JitterMeasureNode {
-    fn name(&self) -> &'static str {
-        Box::leak(self.name.clone().into_boxed_str())
+    fn name(&self) -> &str {
+        self.name
     }
     fn init(&mut self) -> Result<()> {
         Ok(())
@@ -53,22 +59,19 @@ impl Node for JitterMeasureNode {
 }
 
 struct HeavyComputeNode {
-    name: String,
+    name: &'static str,
     work_us: u64,
 }
 
 impl HeavyComputeNode {
-    fn new(name: &str, work_us: u64) -> Self {
-        Self {
-            name: name.to_string(),
-            work_us,
-        }
+    fn new(name: &'static str, work_us: u64) -> Self {
+        Self { name, work_us }
     }
 }
 
 impl Node for HeavyComputeNode {
-    fn name(&self) -> &'static str {
-        Box::leak(self.name.clone().into_boxed_str())
+    fn name(&self) -> &str {
+        self.name
     }
     fn init(&mut self) -> Result<()> {
         Ok(())
@@ -121,6 +124,18 @@ fn analyze_jitter(timestamps: &[Instant]) -> Option<JitterStats> {
     })
 }
 
+/// The p99 tick interval, as the `Duration` `iter_custom` wants back.
+///
+/// The failure sentinel is a large finite value, not `f64::MAX`: `f64::MAX as
+/// u64` saturates and would have made a run that collected too few timestamps
+/// indistinguishable from one that collected none.
+fn measured_p99(stats: Option<JitterStats>) -> Duration {
+    match stats {
+        Some(s) => Duration::from_nanos((s.p99_interval_us * 1000.0) as u64),
+        None => Duration::from_secs(1),
+    }
+}
+
 // ============================================================================
 // Benchmarks
 // ============================================================================
@@ -130,50 +145,63 @@ fn bench_new_api_rt_under_compute_load(c: &mut Criterion) {
     group.measurement_time(5_u64.secs());
     group.sample_size(10);
 
+    // `iter_custom`, not `iter`.
+    //
+    // These two used to call `b.iter(|| { ...; run_for(200ms); stats.p99 })`.
+    // Criterion times the closure and does nothing with its return value, so
+    // the reported number was the wall-clock duration of the whole closure —
+    // two `remove_dir_all`s, three node constructions, the scheduler build and
+    // a `run_for` that pins the total at a constant 200 ms by definition. Both
+    // variants therefore reported ~200 ms with near-zero variance and were
+    // indistinguishable however badly the RT node was jittering; the
+    // `analyze_jitter` result, the only quantity of interest, was thrown away.
+    //
+    // `iter_custom` hands back a `Duration` covering `iters` executions, which
+    // Criterion divides by `iters`. Only the measured p99 interval is added to
+    // the total, so setup and teardown no longer contaminate the number.
     group.bench_function("new_api_rt_500hz_with_compute_load", |b| {
-        b.iter(|| {
-            let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("topics"));
-            let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("nodes"));
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("topics"));
+                let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("nodes"));
 
-            let (rt_node, _count, timestamps) = JitterMeasureNode::new("bench_rt");
-            let compute_a = HeavyComputeNode::new("bench_compute_a", 5000); // 5ms work
-            let compute_b = HeavyComputeNode::new("bench_compute_b", 5000);
+                let (rt_node, _count, timestamps) = JitterMeasureNode::new("bench_rt");
+                let compute_a = HeavyComputeNode::new("bench_compute_a", 5000); // 5ms work
+                let compute_b = HeavyComputeNode::new("bench_compute_b", 5000);
 
-            let mut scheduler = Scheduler::new().tick_rate(500_u64.hz());
-            let _ = scheduler.add(rt_node).order(0).rate(500_u64.hz()).build();
-            let _ = scheduler.add(compute_a).order(10).compute().build();
-            let _ = scheduler.add(compute_b).order(11).compute().build();
+                let mut scheduler = Scheduler::new().tick_rate(500_u64.hz());
+                let _ = scheduler.add(rt_node).order(0).rate(500_u64.hz()).build();
+                let _ = scheduler.add(compute_a).order(10).compute().build();
+                let _ = scheduler.add(compute_b).order(11).compute().build();
 
-            scheduler.run_for(200_u64.ms()).unwrap();
+                scheduler.run_for(200_u64.ms()).unwrap();
 
-            let ts = timestamps.lock().unwrap();
-            if let Some(stats) = analyze_jitter(&ts) {
-                // Return p99 as the benchmark metric
-                stats.p99_interval_us
-            } else {
-                f64::MAX
+                let ts = timestamps.lock().unwrap();
+                total += measured_p99(analyze_jitter(&ts));
             }
+            total
         });
     });
 
     group.bench_function("new_api_rt_500hz_no_load", |b| {
-        b.iter(|| {
-            let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("topics"));
-            let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("nodes"));
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("topics"));
+                let _ = std::fs::remove_dir_all(horus_core::memory::shm_base_dir().join("nodes"));
 
-            let (rt_node, _count, timestamps) = JitterMeasureNode::new("bench_rt_solo");
+                let (rt_node, _count, timestamps) = JitterMeasureNode::new("bench_rt_solo");
 
-            let mut scheduler = Scheduler::new().tick_rate(500_u64.hz());
-            let _ = scheduler.add(rt_node).order(0).rate(500_u64.hz()).build();
+                let mut scheduler = Scheduler::new().tick_rate(500_u64.hz());
+                let _ = scheduler.add(rt_node).order(0).rate(500_u64.hz()).build();
 
-            scheduler.run_for(200_u64.ms()).unwrap();
+                scheduler.run_for(200_u64.ms()).unwrap();
 
-            let ts = timestamps.lock().unwrap();
-            if let Some(stats) = analyze_jitter(&ts) {
-                stats.p99_interval_us
-            } else {
-                f64::MAX
+                let ts = timestamps.lock().unwrap();
+                total += measured_p99(analyze_jitter(&ts));
             }
+            total
         });
     });
 

--- a/benchmarks/scripts/check_regression.py
+++ b/benchmarks/scripts/check_regression.py
@@ -15,17 +15,23 @@ Options:
     --output-markdown <path>  Write markdown summary to file
     --absolute-thresholds     Enable absolute latency thresholds for critical paths
 
-Absolute Thresholds (nanoseconds) - CI-safe ceilings (~3x target):
-    - DirectChannel: 20ns (same-thread, target ~3ns)
-    - SpscIntra: 60ns (same-process 1P1C, target ~18ns)
-    - SpmcIntra: 80ns (same-process 1PMC, target ~24ns)
-    - MpscIntra: 80ns (same-process MP1C, target ~26ns)
-    - MpmcIntra: 120ns (same-process MPMC, target ~36ns)
-    - PodShm: 150ns (cross-process POD MPMC, target ~50ns)
-    - MpscShm: 200ns (cross-process MP1C, target ~65ns)
-    - SpmcShm: 200ns (cross-process 1PMC, target ~70ns)
-    - SpscShm: 250ns (cross-process 1P1C, target ~85ns)
-    - MpmcShm: 600ns (cross-process non-POD MPMC, target ~167ns)
+Absolute thresholds are keyed on the exact Criterion benchmark id — the path
+Criterion writes under target/criterion, e.g. "native_shm_latency/small/16B".
+They used to be keyed on backend names (DirectChannel, SpscIntra, PodShm, ...)
+and matched by substring. No Criterion bench emits those names — six of them
+name backends that no longer exist at all — so the substring test was never
+true, zero checks ran, and the gate reported "All benchmarks pass" for every
+change, including one that tripled Topic::send latency. Two consequences of
+that are guarded against below: an id in the table that no run produces is an
+error, and a run in which zero checks fired is an error.
+
+The ceilings themselves are deliberately loose. There is no published
+baseline.json in this tree, so they are provisional: wide enough not to fire on
+a shared CI runner's noise (a suite that fails for reasons outside the
+repository teaches people to ignore it), tight enough to catch an order-of-
+magnitude regression. Tighten them once --save-baseline has produced a real
+baseline; the percentage check against that baseline, not these ceilings, is
+the gate that should catch a 10% regression.
 """
 
 import argparse
@@ -35,34 +41,27 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-# Absolute latency thresholds (nanoseconds) — CI-safe ceilings (~3x target)
+# Absolute latency ceilings (nanoseconds), keyed on the exact Criterion
+# benchmark id. Keys are matched exactly, not by substring: a renamed bench must
+# drop out of the table loudly (see check_absolute_thresholds) rather than
+# silently stop being checked.
 ABSOLUTE_THRESHOLDS = {
-    "DirectChannel": 20,
-    "DirectChannel_unchecked": 20,
-    "SpscIntra": 60,
-    "SpmcIntra": 80,
-    "MpscIntra": 80,
-    "MpmcIntra": 120,
-    "PodShm": 150,
-    "MpscShm": 200,
-    "SpmcShm": 200,
-    "SpscShm": 250,
-    "MpmcShm": 600,
+    "native_shm_latency/small/16B": 500,
+    "native_shm_latency/medium/128B": 700,
+    "native_shm_latency/large/4KB": 3000,
+    "latency_comparison/native_shm_16B": 500,
+    "pubsub_roundtrip/native_roundtrip_16B": 500,
+    "pubsub_roundtrip/native_roundtrip_1KB": 2000,
 }
 
-# Backend descriptions for reporting
-BACKEND_DESCRIPTIONS = {
-    "DirectChannel": "Same-thread pipeline (~3ns)",
-    "DirectChannel_unchecked": "Same-thread unchecked (~3ns)",
-    "SpscIntra": "Same-process 1P-1C (~18ns)",
-    "SpmcIntra": "Same-process 1P-MC (~24ns)",
-    "MpscIntra": "Same-process MP-1C (~26ns)",
-    "MpmcIntra": "Same-process MPMC (~36ns)",
-    "PodShm": "Cross-process POD MPMC (~50ns)",
-    "MpscShm": "Cross-process MP-1C (~65ns)",
-    "SpmcShm": "Cross-process 1P-MC (~70ns)",
-    "SpscShm": "Cross-process 1P-1C (~85ns)",
-    "MpmcShm": "Cross-process non-POD MPMC (~167ns)",
+# What each checked benchmark actually times, for the report.
+BENCH_DESCRIPTIONS = {
+    "native_shm_latency/small/16B": "SHM topic send+recv, 16B POD",
+    "native_shm_latency/medium/128B": "SHM topic send+recv, 128B POD",
+    "native_shm_latency/large/4KB": "SHM topic send+recv, 4KB POD",
+    "latency_comparison/native_shm_16B": "SHM topic send+recv, 16B POD",
+    "pubsub_roundtrip/native_roundtrip_16B": "Pub-sub round trip, 16B",
+    "pubsub_roundtrip/native_roundtrip_1KB": "Pub-sub round trip, 1KB",
 }
 
 
@@ -77,41 +76,44 @@ def find_benchmark_results(criterion_dir: Path) -> Dict[str, Dict]:
         print(f"Warning: Criterion directory not found: {criterion_dir}")
         return results
 
-    # Criterion stores results in: criterion/<group>/<bench>/new/estimates.json
-    for group_dir in criterion_dir.iterdir():
-        if not group_dir.is_dir() or group_dir.name.startswith("."):
+    # Criterion nests one directory per BenchmarkId component, so a bench
+    # declared as BenchmarkId::new("small", "16B") inside group
+    # "native_shm_latency" lands at native_shm_latency/small/16B/new/. The old
+    # two-level `for group_dir / for bench_dir` walk only ever saw the flat
+    # `group/bench` case, so every parameterised benchmark — which is most of
+    # them — was invisible to the checker. Recurse instead, and key each result
+    # on its full Criterion path.
+    for estimates_path in sorted(criterion_dir.rglob("new/estimates.json")):
+        bench_dir = estimates_path.parent.parent
+        parts = bench_dir.relative_to(criterion_dir).parts
+
+        # "report" holds Criterion's generated HTML, not measurements.
+        if not parts or parts[0] == "report" or any(p.startswith(".") for p in parts):
             continue
 
-        for bench_dir in group_dir.iterdir():
-            if not bench_dir.is_dir():
-                continue
+        full_name = "/".join(parts)
 
-            estimates_path = bench_dir / "new" / "estimates.json"
-            if estimates_path.exists():
-                try:
-                    with open(estimates_path) as f:
-                        data = json.load(f)
+        try:
+            with open(estimates_path) as f:
+                data = json.load(f)
 
-                    bench_name = bench_dir.name
-                    group_name = group_dir.name
+            # Extract median (point estimate)
+            median_ns = data.get("median", {}).get("point_estimate", 0)
 
-                    # Extract median (point estimate)
-                    median_ns = data.get("median", {}).get("point_estimate", 0)
+            # Also get mean and stddev if available
+            mean_ns = data.get("mean", {}).get("point_estimate", 0)
+            stddev_ns = data.get("std_dev", {}).get("point_estimate", 0)
 
-                    # Also get mean and stddev if available
-                    mean_ns = data.get("mean", {}).get("point_estimate", 0)
-                    stddev_ns = data.get("std_dev", {}).get("point_estimate", 0)
+            results[full_name] = {
+                "group": parts[0],
+                "name": bench_dir.name,
+                "median_ns": median_ns,
+                "mean_ns": mean_ns,
+                "stddev_ns": stddev_ns,
+            }
 
-                    results[f"{group_name}/{bench_name}"] = {
-                        "group": group_name,
-                        "name": bench_name,
-                        "median_ns": median_ns,
-                        "mean_ns": mean_ns,
-                        "stddev_ns": stddev_ns,
-                    }
-
-                except (json.JSONDecodeError, KeyError) as e:
-                    print(f"Warning: Failed to parse {estimates_path}: {e}")
+        except (json.JSONDecodeError, KeyError) as e:
+            print(f"Warning: Failed to parse {estimates_path}: {e}")
 
     return results
 
@@ -120,19 +122,27 @@ def check_absolute_thresholds(results: Dict[str, Dict]) -> List[Tuple[str, float
     """
     Check results against absolute latency thresholds.
     Returns list of (benchmark, actual_ns, threshold_ns, status) tuples.
+
+    Matching is exact on the full Criterion id. It used to be a substring test
+    against backend names no bench emits, which matched nothing and made the
+    gate unconditionally green. A threshold entry with no matching result is
+    reported as MISSING and counted as a failure, so renaming a bench cannot
+    quietly drop it out of the gate.
     """
     violations = []
 
     for full_name, data in results.items():
-        bench_name = data["name"]
-        median_ns = data["median_ns"]
+        threshold = ABSOLUTE_THRESHOLDS.get(full_name)
+        if threshold is None:
+            continue
 
-        # Check if this benchmark has an absolute threshold
-        for backend_name, threshold in ABSOLUTE_THRESHOLDS.items():
-            if backend_name in bench_name or backend_name in full_name:
-                status = "PASS" if median_ns <= threshold else "FAIL"
-                violations.append((full_name, median_ns, threshold, status))
-                break
+        median_ns = data["median_ns"]
+        status = "PASS" if median_ns <= threshold else "FAIL"
+        violations.append((full_name, median_ns, threshold, status))
+
+    for name, threshold in ABSOLUTE_THRESHOLDS.items():
+        if name not in results:
+            violations.append((name, float("nan"), threshold, "MISSING"))
 
     return violations
 
@@ -184,24 +194,35 @@ def generate_markdown_report(
     # Absolute threshold section
     if absolute_checks:
         lines.append("### Critical Path Latencies\n")
-        lines.append("| Backend | Latency | Threshold | Status |")
-        lines.append("|---------|---------|-----------|--------|")
+        lines.append("| Benchmark | What it times | Latency | Threshold | Status |")
+        lines.append("|-----------|---------------|---------|-----------|--------|")
 
         for full_name, actual, threshold, status in sorted(absolute_checks, key=lambda x: x[0]):
             emoji = "✅" if status == "PASS" else "❌"
-            bench_name = full_name.split("/")[-1]
-            desc = BACKEND_DESCRIPTIONS.get(bench_name, "")
-            lines.append(f"| {bench_name} | {actual:.1f}ns | {threshold}ns | {emoji} {status} |")
+            desc = BENCH_DESCRIPTIONS.get(full_name, "")
+            actual_str = "—" if status == "MISSING" else f"{actual:.1f}ns"
+            lines.append(
+                f"| `{full_name}` | {desc} | {actual_str} | {threshold}ns | {emoji} {status} |"
+            )
 
         lines.append("")
 
         # Check for any failures
         failures = [c for c in absolute_checks if c[3] == "FAIL"]
         if failures:
-            lines.append("⚠️ **Absolute threshold violations detected!** The following backends exceed their maximum allowed latency:\n")
+            lines.append("⚠️ **Absolute threshold violations detected!** The following benchmarks exceed their maximum allowed latency:\n")
             for full_name, actual, threshold, _ in failures:
-                bench_name = full_name.split("/")[-1]
-                lines.append(f"- **{bench_name}**: {actual:.1f}ns (max: {threshold}ns)")
+                lines.append(f"- **`{full_name}`**: {actual:.1f}ns (max: {threshold}ns)")
+            lines.append("")
+
+        # A benchmark that the threshold table names but the run never produced
+        # is a hole in the gate, not a pass: the bench was renamed or removed
+        # and nothing is checking that path any more.
+        missing = [c for c in absolute_checks if c[3] == "MISSING"]
+        if missing:
+            lines.append("⚠️ **Benchmarks in the threshold table produced no results.** They were renamed or removed, and are no longer gated:\n")
+            for full_name, _actual, _threshold, _ in missing:
+                lines.append(f"- **`{full_name}`**")
             lines.append("")
 
     # Percentage regression section
@@ -225,8 +246,10 @@ def generate_markdown_report(
 
         lines.append("")
 
-    # Summary
-    abs_failures = sum(1 for c in absolute_checks if c[3] == "FAIL")
+    # Summary. MISSING counts as a failure: an ungated critical path is not a
+    # pass, and treating it as one is how this gate stayed green for every
+    # change ever made to it.
+    abs_failures = sum(1 for c in absolute_checks if c[3] in ("FAIL", "MISSING"))
     regressions = sum(1 for c in regression_checks if c[4] == "REGRESSION")
 
     if abs_failures > 0 or regressions > 0:
@@ -281,6 +304,17 @@ def main():
         absolute_checks = check_absolute_thresholds(results)
         print(f"Ran {len(absolute_checks)} absolute threshold checks")
 
+        # The whole point of the gate. Absolute checks are on by default, so a
+        # run that fired none of them means the threshold table no longer
+        # matches any benchmark id — which is exactly the state this file was
+        # in, silently, while printing "All benchmarks pass".
+        if not absolute_checks:
+            print(
+                "ERROR: 0 absolute threshold checks ran — the threshold table "
+                "matches no benchmark id.\n  Known ids: " + ", ".join(sorted(results))
+            )
+            sys.exit(1)
+
     if baseline:
         regression_checks = check_percentage_regression(results, baseline, args.threshold)
         print(f"Ran {len(regression_checks)} regression checks")
@@ -296,7 +330,7 @@ def main():
     print("\n" + report)
 
     # Determine exit code
-    abs_failures = sum(1 for c in absolute_checks if c[3] == "FAIL")
+    abs_failures = sum(1 for c in absolute_checks if c[3] in ("FAIL", "MISSING"))
     regressions = sum(1 for c in regression_checks if c[4] == "REGRESSION")
 
     if abs_failures > 0 or regressions > 0:

--- a/benchmarks/scripts/ci_bench.sh
+++ b/benchmarks/scripts/ci_bench.sh
@@ -59,8 +59,15 @@ cargo bench --no-run -p horus_benchmarks 2>&1 | tail -5
 
 # Run criterion benchmarks
 if [ "$QUICK" = true ]; then
+    # Criterion filters on the benchmark *id*, not the source file name. The
+    # filter here read "topic_latency|tensor_alloc_release"; there is no
+    # benchmark id containing "topic_latency" (topic_latency.rs declares the
+    # groups native_shm_latency, latency_comparison and memory_usage), so quick
+    # mode ran only the tensor benchmarks and none of the critical latency paths
+    # it claims to cover — and produced none of the ids check_regression.py
+    # gates on.
     echo "Running critical path benchmarks (quick mode)..."
-    cargo bench -p horus_benchmarks -- "topic_latency|tensor_alloc_release" 2>&1 | tail -20
+    cargo bench -p horus_benchmarks -- "native_shm_latency|latency_comparison|pubsub_roundtrip|tensor_alloc_release" 2>&1 | tail -20
 else
     echo "Running all criterion benchmarks..."
     cargo bench -p horus_benchmarks 2>&1 | tail -40

--- a/benchmarks/src/bin/all_paths_latency.rs
+++ b/benchmarks/src/bin/all_paths_latency.rs
@@ -1764,8 +1764,11 @@ fn print_detail(r: &ScenarioResult) {
     }
 
     let s = r.stats();
+    // `outliers_removed` no longer means "removed from this table": the tail
+    // statistics below are computed from every sample. Only the mean and the
+    // confidence interval exclude them.
     println!(
-        "  Samples: {} (outliers removed: {})",
+        "  Samples: {} ({} excluded from mean/CI as outliers)",
         s.count, s.outliers_removed
     );
 

--- a/benchmarks/src/bin/dds_comparison_benchmark.rs
+++ b/benchmarks/src/bin/dds_comparison_benchmark.rs
@@ -51,6 +51,11 @@ const DEFAULT_ITERATIONS: usize = 100_000;
 /// with `-F dds` and CycloneDDS installed to measure instead of quote.
 const REP2014_SOURCE: &str =
     "ROS 2 REP 2014 (Benchmarking Performance), published reference latencies";
+/// Only the no-`dds` branch quotes iceoryx — the `dds` feature drives
+/// CycloneDDS/FastDDS and never reaches this figure — so the constant carries
+/// the same cfg as its single use site rather than sitting dead under
+/// `--all-features`.
+#[cfg(not(feature = "dds"))]
 const ICEORYX_SOURCE: &str = "eclipse-iceoryx published benchmarks (eclipse.org)";
 const DEFAULT_WARMUP: usize = 10_000;
 
@@ -524,10 +529,19 @@ fn benchmark_cyclonedds(
     _iterations: usize,
     platform: &horus_benchmarks::PlatformInfo,
 ) -> BenchmarkResult {
-    // This would use cyclonedds-rs crate
-    // For now, return a placeholder
+    // This would use cyclonedds-rs crate. Until it does, the only numbers we
+    // have are the same REP 2014 figures the no-`dds` path quotes, so they go
+    // out tagged `Literature` under a `_reference` name. Enabling the feature
+    // must not relabel a quoted figure as a measurement just because the
+    // feature is named for measuring.
     eprintln!("CycloneDDS benchmark not yet implemented");
-    create_reference_result("CycloneDDS_measured", 1500.0, 5000, platform)
+    create_reference_result(
+        "CycloneDDS_reference",
+        1500.0,
+        5000,
+        REP2014_SOURCE,
+        platform,
+    )
 }
 
 #[cfg(feature = "dds")]
@@ -535,8 +549,8 @@ fn benchmark_fastdds(
     _iterations: usize,
     platform: &horus_benchmarks::PlatformInfo,
 ) -> BenchmarkResult {
-    // This would use fastdds-rs crate
-    // For now, return a placeholder
+    // This would use fastdds-rs crate. Same as CycloneDDS above: unimplemented,
+    // so the REP 2014 figure is quoted rather than measured.
     eprintln!("FastDDS benchmark not yet implemented");
-    create_reference_result("FastDDS_measured", 2000.0, 8000, platform)
+    create_reference_result("FastDDS_reference", 2000.0, 8000, REP2014_SOURCE, platform)
 }

--- a/benchmarks/src/bin/iceoryx2_comparison.rs
+++ b/benchmarks/src/bin/iceoryx2_comparison.rs
@@ -5,7 +5,7 @@
 //!
 //! Run: cargo run --release -p horus_benchmarks --bin iceoryx2_comparison --features iceoryx2
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
@@ -290,74 +290,13 @@ fn bench_iox2_throughput_u64() -> f64 {
 // Cross-thread benchmarks (forces SHM/atomic backends)
 // ---------------------------------------------------------------------------
 
-fn bench_horus_cross_thread_u64() -> (u64, u64, u64, u64, u64) {
-    let ready = Arc::new(AtomicBool::new(false));
-    let done = Arc::new(AtomicBool::new(false));
-
-    let ready_pub = ready.clone();
-    let done_pub = done.clone();
-
-    // Publisher thread
-    let pub_handle = thread::spawn(move || {
-        let topic: Topic<u64> = Topic::new("bench.horus.ct.u64").expect("topic");
-        ready_pub.store(true, Ordering::Release);
-
-        // Wait for subscriber to be ready
-        while !ready_pub.load(Ordering::Acquire) {}
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        for i in 0..(WARMUP + ITERATIONS) as u64 {
-            topic.send(i);
-            // Pace to avoid overwhelming ring buffer
-            while topic.recv().is_none() {
-                std::hint::spin_loop();
-            }
-        }
-        done_pub.store(true, Ordering::Release);
-    });
-
-    // Subscriber thread — measures roundtrip on its own topic
-    let sub_handle = thread::spawn(move || {
-        let topic: Topic<u64> = Topic::new("bench.horus.ct.u64.sub").expect("topic");
-        // Give publisher time to create topic first
-        std::thread::sleep(std::time::Duration::from_millis(100));
-
-        let mut latencies = Vec::with_capacity(ITERATIONS);
-
-        // Use a separate ping-pong approach:
-        // Publisher sends on topic A, subscriber reads from topic A
-        // This forces cross-thread atomic path
-        let pub_topic: Topic<u64> = Topic::new("bench.horus.ct.u64").expect("topic");
-
-        for i in 0..(WARMUP + ITERATIONS) {
-            let start = Instant::now();
-            pub_topic.send(i as u64);
-            while pub_topic.recv().is_none() {
-                std::hint::spin_loop();
-            }
-            if i >= WARMUP {
-                latencies.push(start.elapsed().as_nanos() as u64);
-            }
-        }
-
-        latencies
-    });
-
-    // Actually — the above approach has both threads on same Topic which IS cross-thread.
-    // But both threads call send+recv on their own Topic clone, which horus detects as
-    // same-thread (each Topic instance is thread-local).
-    //
-    // For TRUE cross-thread: publisher sends, subscriber on different thread receives.
-    // Let me use a proper ping-pong pattern.
-
-    pub_handle.join().unwrap();
-    let latencies = sub_handle.join().unwrap();
-
-    if latencies.is_empty() {
-        return (0, 0, 0, 0, 0);
-    }
-    compute_stats(latencies)
-}
+// An earlier `bench_horus_cross_thread_u64` lived here. It had both threads
+// calling send+recv on their own `Topic` instance, which horus resolves to the
+// thread-local backend — so it measured the same-thread path twice under a
+// "cross-thread" label, as its own trailing comment admitted. It was never
+// wired into `main`; `bench_horus_cross_thread_pingpong` below is the correct
+// replacement (A sends on one topic, B receives on it and replies on another,
+// which is the only shape that forces the cross-thread SpscShm backend).
 
 /// Cross-thread ping-pong: thread A sends on topic1, thread B receives on topic1,
 /// thread B sends on topic2, thread A receives on topic2. Measures full roundtrip.
@@ -625,7 +564,7 @@ fn bench_horus_mpmc(num_pubs: usize, num_subs: usize) -> (u64, u64, u64, u64, u6
 
     // Subscriber threads — each measures its own receive latency
     let mut sub_handles = Vec::new();
-    for s in 0..num_subs {
+    for _ in 0..num_subs {
         let barrier_s = barrier.clone();
         let total_sent_s = total_sent.clone();
         sub_handles.push(thread::spawn(move || {
@@ -642,6 +581,14 @@ fn bench_horus_mpmc(num_pubs: usize, num_subs: usize) -> (u64, u64, u64, u64, u6
                 if topic.recv().is_some() {
                     latencies.push(t0.elapsed().as_nanos() as u64);
                     received += 1;
+                } else if total_sent_s.load(Ordering::Acquire) >= expected {
+                    // Every publisher has finished and the ring still came up
+                    // empty, so this subscriber's `expected / num_subs` quota is
+                    // never going to arrive: the MPMC split is not guaranteed
+                    // even, and ring overflow can drop messages outright. Stop
+                    // here instead of spinning out the full 30s deadline, which
+                    // is what `total_sent` was counting for.
+                    break;
                 } else {
                     std::hint::spin_loop();
                 }
@@ -662,7 +609,11 @@ fn bench_horus_mpmc(num_pubs: usize, num_subs: usize) -> (u64, u64, u64, u64, u6
 
             for i in 0..msgs_per_pub {
                 topic.send((p * msgs_per_pub + i) as u64);
-                total_sent_p.fetch_add(1, Ordering::Relaxed);
+                // Release pairs with the subscribers' Acquire load: once a
+                // subscriber observes the count reach `expected`, every send
+                // that produced it is already visible, so an empty ring really
+                // does mean nothing more is coming.
+                total_sent_p.fetch_add(1, Ordering::Release);
             }
         }));
     }
@@ -688,7 +639,7 @@ fn bench_iox2_mpmc(num_pubs: usize, num_subs: usize) -> (u64, u64, u64, u64, u64
 
     // Subscriber threads
     let mut sub_handles = Vec::new();
-    for s in 0..num_subs {
+    for _ in 0..num_subs {
         let barrier_s = barrier.clone();
         sub_handles.push(thread::spawn(move || {
             let node = NodeBuilder::new().create::<ipc::Service>().expect("node");

--- a/benchmarks/src/bin/ipc_mpmc_bench.rs
+++ b/benchmarks/src/bin/ipc_mpmc_bench.rs
@@ -7,7 +7,6 @@ use std::time::Instant;
 
 use horus_core::communication::Topic;
 use iceoryx2::prelude::*;
-use serde::{Deserialize, Serialize};
 
 const ITERATIONS: usize = 20_000;
 
@@ -32,6 +31,15 @@ fn main() {
 }
 
 fn bench_horus_xproc_mpmc(num_pubs: usize, num_subs: usize) {
+    // The parent process is the only consumer here, so the topology is
+    // N-producer/single-consumer by construction. Assert rather than quietly
+    // ignore `num_subs`: a 2P/2S call would otherwise be measured as 2P/1S and
+    // reported under the caller's label.
+    assert_eq!(
+        num_subs, 1,
+        "bench_horus_xproc_mpmc only forks publishers; the parent is the sole subscriber"
+    );
+
     // Fork publisher children
     let mut child_pids = Vec::new();
     for p in 0..num_pubs {
@@ -91,9 +99,16 @@ fn bench_horus_xproc_mpmc(num_pubs: usize, num_subs: usize) {
 }
 
 fn bench_horus_xproc_spmc(num_pubs: usize, num_subs: usize) {
+    // Mirror image of the MPMC case: the parent is the only producer, so
+    // `num_pubs` is fixed at 1 rather than silently ignored.
+    assert_eq!(
+        num_pubs, 1,
+        "bench_horus_xproc_spmc only forks subscribers; the parent is the sole publisher"
+    );
+
     // Fork subscriber children that each count messages
     let mut child_pids = Vec::new();
-    for s in 0..num_subs {
+    for _ in 0..num_subs {
         let pid = unsafe { libc::fork() };
         if pid == 0 {
             // Child subscriber
@@ -139,6 +154,13 @@ fn bench_horus_xproc_spmc(num_pubs: usize, num_subs: usize) {
 }
 
 fn bench_iox2_xproc_mpmc(num_pubs: usize, num_subs: usize) {
+    // Same shape as the horus arm above — parent is the sole subscriber — and
+    // the two must agree on topology or the comparison is not like-for-like.
+    assert_eq!(
+        num_subs, 1,
+        "bench_iox2_xproc_mpmc only forks publishers; the parent is the sole subscriber"
+    );
+
     let mut child_pids = Vec::new();
     for p in 0..num_pubs {
         let pid = unsafe { libc::fork() };
@@ -215,8 +237,14 @@ fn bench_iox2_xproc_mpmc(num_pubs: usize, num_subs: usize) {
 }
 
 fn bench_iox2_xproc_spmc(num_pubs: usize, num_subs: usize) {
+    // Parent is the sole publisher, matching bench_horus_xproc_spmc.
+    assert_eq!(
+        num_pubs, 1,
+        "bench_iox2_xproc_spmc only forks subscribers; the parent is the sole publisher"
+    );
+
     let mut child_pids = Vec::new();
-    for s in 0..num_subs {
+    for _ in 0..num_subs {
         let pid = unsafe { libc::fork() };
         if pid == 0 {
             std::thread::sleep(std::time::Duration::from_millis(200));

--- a/benchmarks/src/stats.rs
+++ b/benchmarks/src/stats.rs
@@ -53,28 +53,50 @@ pub struct Statistics {
 
 impl Statistics {
     /// Compute statistics from raw latency samples
+    ///
+    /// `filter_outliers` affects ONLY the central estimates — mean, standard
+    /// deviation and the bootstrap confidence interval. Every order statistic
+    /// (`min`, `max`, `median`, and all percentiles) is computed from the full,
+    /// unfiltered sample set, and `count` is the full sample count.
+    ///
+    /// This used to filter first and then compute everything from what
+    /// survived. Tukey's fence drops every sample outside
+    /// `[Q1 - 1.5*IQR, Q3 + 1.5*IQR]`, so on a tight latency distribution the
+    /// entire tail was deleted before `max`, `p99`, `p99.9` and `p99.99` were
+    /// taken: the reported worst case could not exceed `Q3 + 1.5*IQR` no matter
+    /// what the machine did, and the published "worst-case measured" figures
+    /// and the CI jitter metric derived from `max - min` were truncated by
+    /// construction. For a real-time middleware the tail is the measurement —
+    /// an OS preemption or a page fault on a control loop is precisely the
+    /// event that misses the deadline, not an artifact to be discarded.
     pub fn from_samples(samples: &[u64], confidence_level: f64, filter_outliers: bool) -> Self {
-        let (filtered, outliers_removed) = if filter_outliers {
-            let f = self::filter_outliers(samples);
-            let removed = samples.len() - f.len();
-            (f, removed)
-        } else {
-            (samples.to_vec(), 0)
-        };
-
-        if filtered.is_empty() {
+        if samples.is_empty() {
             return Self::empty(confidence_level);
         }
 
-        let mut sorted = filtered.clone();
+        let mut sorted = samples.to_vec();
         sorted.sort_unstable();
 
-        let count = sorted.len();
-        let mean_val = mean(&sorted);
-        let median_val = median(&sorted);
-        let std_dev_val = std_dev(&sorted);
+        // Samples used for the central estimates only. If the fence would drop
+        // everything, fall back to the full set rather than reporting nothing.
+        let (central, outliers_removed) = if filter_outliers {
+            let f = self::filter_outliers(samples);
+            if f.is_empty() {
+                (sorted.clone(), 0)
+            } else {
+                let removed = samples.len() - f.len();
+                (f, removed)
+            }
+        } else {
+            (sorted.clone(), 0)
+        };
 
-        let (ci_low, ci_high) = bootstrap_ci(&sorted, confidence_level, 10_000);
+        let count = sorted.len();
+        let mean_val = mean(&central);
+        let median_val = median(&sorted);
+        let std_dev_val = std_dev(&central);
+
+        let (ci_low, ci_high) = bootstrap_ci(&central, confidence_level, 10_000);
 
         Self {
             count,
@@ -240,8 +262,12 @@ pub fn bootstrap_ci(samples: &[u64], confidence_level: f64, iterations: usize) -
 
 /// Filter outliers using Tukey's method (IQR-based)
 ///
-/// Removes samples that fall outside [Q1 - 1.5*IQR, Q3 + 1.5*IQR]
-/// This is standard practice in benchmarking to remove measurement artifacts.
+/// Removes samples that fall outside [Q1 - 1.5*IQR, Q3 + 1.5*IQR].
+///
+/// Only ever use this for central estimates (mean, std dev, confidence
+/// interval). Applying it before a tail statistic caps `max`/`p99.9` at the
+/// upper fence, which makes a "worst-case latency" number that cannot be
+/// large — see `Statistics::from_samples`.
 pub fn filter_outliers(samples: &[u64]) -> Vec<u64> {
     if samples.len() < 4 {
         return samples.to_vec();
@@ -669,6 +695,54 @@ mod tests {
         assert!(stats.mean > 0.0);
         assert!(stats.p99 >= stats.p95);
         assert!(stats.ci_low <= stats.ci_high);
+    }
+
+    /// Outlier filtering must never truncate the reported tail.
+    ///
+    /// The old implementation filtered first and computed everything from the
+    /// survivors, so `max` and `p99.9` were capped at Tukey's upper fence and a
+    /// genuine 50 us stall in an otherwise tight distribution simply vanished
+    /// from the "worst case" the benchmarks publish. This asserts the opposite
+    /// of what the code used to do: the stall must still be reported, and only
+    /// the mean may be pulled back toward the body of the distribution.
+    #[test]
+    fn outlier_filtering_does_not_truncate_the_tail() {
+        let mut samples: Vec<u64> = (0..999).map(|x| 100 + (x % 5)).collect();
+        samples.push(50_000); // a real preemption, not a measurement artifact
+
+        let filtered = Statistics::from_samples(&samples, 95.0, true);
+        assert_eq!(
+            filtered.max, 50_000,
+            "max must come from the unfiltered samples"
+        );
+        assert_eq!(
+            filtered.count,
+            samples.len(),
+            "count must be the full sample count"
+        );
+        assert_eq!(
+            filtered.outliers_removed, 1,
+            "the stall is still counted as an outlier for the central estimate"
+        );
+
+        // The tail statistics must be identical with and without filtering;
+        // only the mean/CI may differ.
+        let unfiltered = Statistics::from_samples(&samples, 95.0, false);
+        assert_eq!(filtered.max, unfiltered.max);
+        assert_eq!(filtered.p99, unfiltered.p99);
+        assert_eq!(filtered.p999, unfiltered.p999);
+        assert_eq!(filtered.p9999, unfiltered.p9999);
+        assert!(filtered.mean < unfiltered.mean);
+    }
+
+    /// A zero-width Tukey fence must not swallow the distribution.
+    #[test]
+    fn constant_samples_survive_outlier_filtering() {
+        let samples = vec![7_u64; 8]; // IQR is 0, so the fence is a single point
+        let stats = Statistics::from_samples(&samples, 95.0, true);
+        assert_eq!(stats.count, 8);
+        assert_eq!(stats.max, 7);
+        assert_eq!(stats.min, 7);
     }
 
     #[test]

--- a/examples/record_replay/main.rs
+++ b/examples/record_replay/main.rs
@@ -113,6 +113,40 @@ impl Node for ControllerNode {
     }
 }
 
+/// Run the encoder + controller pair deterministically for 50 ticks and return
+/// every `cmd_vel` command the controller published, as raw f64 bits.
+///
+/// Bits, not floats: determinism means the same value, and `f64` equality would
+/// treat two different NaN payloads as equal while calling `-0.0` and `0.0` the
+/// same. Commands are drained after every tick rather than once at the end — a
+/// topic's ring buffer is bounded, so a single drain at the end would silently
+/// lose the earliest commands and compare only the tail.
+fn run_deterministic_once() -> Result<Vec<u64>> {
+    let mut outputs = Vec::new();
+
+    let mut scheduler = Scheduler::new()
+        .tick_rate(100_u64.hz())
+        .deterministic(true); // SimClock, sequential execution
+
+    // Subscribe before the run, and drop whatever the earlier recording session
+    // left on the topic, so run 2 cannot read run 1's residue.
+    let cmd_monitor: Topic<VelocityCommand> = Topic::new("cmd_vel")?;
+    while cmd_monitor.recv().is_some() {}
+
+    scheduler.add(EncoderNode::new()?).order(0).rate(100_u64.hz()).build()?;
+    scheduler.add(ControllerNode::new()?).order(10).rate(100_u64.hz()).build()?;
+
+    for _ in 0..50 {
+        scheduler.tick_once()?;
+        while let Some(cmd) = cmd_monitor.recv() {
+            outputs.push(cmd.linear.to_bits());
+            outputs.push(cmd.angular.to_bits());
+        }
+    }
+
+    Ok(outputs)
+}
+
 // ============================================================================
 // Main — demonstrates recording, analysis, and deterministic replay
 // ============================================================================
@@ -162,49 +196,34 @@ fn main() -> Result<()> {
     hlog!(info, "=== STEP 3: Deterministic replay ===");
     hlog!(info, "Running the same system deterministically twice...");
 
-    // Run 1
-    let mut outputs_1 = Vec::new();
-    {
-        let mut scheduler = Scheduler::new()
-            .tick_rate(100_u64.hz())
-            .deterministic(true); // SimClock, sequential execution
+    // Both runs are compared on the actual controller output, read back off the
+    // topic the controller publishes to.
+    //
+    // This block used to push the literal `50` — the loop bound — into each
+    // vector and then assert the two vectors were equal, which is
+    // `assert_eq!(vec![50], vec![50])`: a tautology that holds no matter what
+    // the two schedulers computed. It also opened a topic named
+    // "cmd_vel_det_1", which nothing publishes to, and never read it. Copying
+    // that shape into your own system gives you a determinism check that passes
+    // on a system that is not deterministic.
+    let outputs_1 = run_deterministic_once()?;
+    let outputs_2 = run_deterministic_once()?;
 
-        let encoder = EncoderNode::new()?;
-        let controller = ControllerNode::new()?;
-        scheduler.add(encoder).order(0).rate(100_u64.hz()).build()?;
-        scheduler.add(controller).order(10).rate(100_u64.hz()).build()?;
-
-        for _ in 0..50 {
-            scheduler.tick_once()?;
-        }
-
-        // Capture output from cmd_vel topic
-        let cmd_topic: Topic<VelocityCommand> = Topic::new("cmd_vel_det_1")?;
-        outputs_1.push(50); // tick count
-    }
-
-    // Run 2 (identical config)
-    let mut outputs_2 = Vec::new();
-    {
-        let mut scheduler = Scheduler::new()
-            .tick_rate(100_u64.hz())
-            .deterministic(true);
-
-        let encoder = EncoderNode::new()?;
-        let controller = ControllerNode::new()?;
-        scheduler.add(encoder).order(0).rate(100_u64.hz()).build()?;
-        scheduler.add(controller).order(10).rate(100_u64.hz()).build()?;
-
-        for _ in 0..50 {
-            scheduler.tick_once()?;
-        }
-
-        outputs_2.push(50);
-    }
-
-    // Both runs should produce identical results
-    assert_eq!(outputs_1, outputs_2, "Deterministic runs must match!");
-    hlog!(info, "Deterministic replay verified: both runs produced identical results");
+    // An empty capture would make the comparison vacuous again, so require that
+    // the controller actually produced commands before believing the match.
+    assert!(
+        !outputs_1.is_empty(),
+        "captured no controller output — the determinism check would be vacuous"
+    );
+    assert_eq!(
+        outputs_1, outputs_2,
+        "Deterministic runs must match! (comparing raw f64 bits of every cmd_vel command)"
+    );
+    hlog!(
+        info,
+        "Deterministic replay verified: {} commands, bit-identical across both runs",
+        outputs_1.len()
+    );
 
     // ================================================================
     // Summary

--- a/horus/src/lib.rs
+++ b/horus/src/lib.rs
@@ -7,17 +7,10 @@
 //!
 //! ```rust,no_run
 //! use horus::prelude::*;
-//! use serde::{Serialize, Deserialize};
 //!
-//! // Any Serialize + Deserialize type is a valid Topic message. Ready-made
-//! // robotics messages (CmdVel, Imu, …) live in the `horus_robotics` crate; here
-//! // we define one inline to keep the Quick Start self-contained.
-//! #[derive(Clone, Serialize, Deserialize)]
-//! struct CmdVel { linear: f32, angular: f32 }
-//! impl CmdVel {
-//!     fn new(linear: f32, angular: f32) -> Self { Self { linear, angular } }
-//! }
-//!
+//! // Any Serialize + Deserialize type is a valid Topic message, and the
+//! // ready-made robotics messages (CmdVel, Imu, …) are already in scope:
+//! // `horus::prelude` re-exports `horus_robotics::prelude::*`.
 //! pub struct MyNode {
 //!     cmd_pub: Topic<Twist>,
 //! }
@@ -33,7 +26,6 @@
 //!
 //!     fn tick(&mut self) {
 //!         // Twist is the prelude-native velocity command (linear, angular).
-//!         // Robotics-specific messages like CmdVel now live in `horus_robotics`.
 //!         self.cmd_pub.send(Twist::new_2d(0.5, 0.0));
 //!     }
 //! }
@@ -51,7 +43,7 @@
 //! img.fill(&[0, 0, 255]);           // Blue
 //! img.set_pixel(100, 200, &[255, 0, 0]); // Red dot
 //!
-//! // Send — only the 168-byte descriptor goes through the ring buffer
+//! // Send — only the 224-byte descriptor goes through the ring buffer
 //! let topic: Topic<Image> = Topic::new("camera.rgb").unwrap();
 //! topic.send(&img);
 //!
@@ -201,7 +193,13 @@
 //! not Rt. Execution class is determined by the explicit class call, not by `.rate()`.
 //! `.rate()` only auto-derives Rt when no explicit class is set.
 
-/// Framework time API — `horus::now()`, `horus::dt()`, `horus::rng()`, etc.
+/// Framework time API — `horus::time::now()`, `horus::time::dt()`,
+/// `horus::time::rng()`, and friends.
+///
+/// These are module functions: call them through `horus::time::`, or bring them
+/// in with `use horus::time::{now, dt};`. There is no `horus::now()`,
+/// `horus::dt()` or `horus::rng()` — the free functions are not re-exported at
+/// the crate root, and the prelude re-exports only [`TimeStamp`](time::TimeStamp).
 ///
 /// See [`time`] module documentation for details.
 pub mod time;

--- a/horus/tests/test_dx_workflows.rs
+++ b/horus/tests/test_dx_workflows.rs
@@ -315,17 +315,60 @@ fn topic_new_returns_result() {
 
 #[test]
 fn topic_try_send_and_dropped_count() {
-    let topic: Topic<u64> = Topic::with_capacity("test_dx_try_send", 2, None).unwrap();
-    // Fill the ring
-    topic.send(1);
-    topic.send(2);
-    // try_send should fail when full
-    assert!(topic.try_send(3).is_err());
-    // dropped_count reflects send() failures (not try_send — try_send returns the msg)
+    // A full ring only drops if somebody is subscribed to it.
+    //
+    // `send()` is the lossy publish, and on a ring that is full with NOTHING
+    // draining it, `send_lossy_retry` keeps the last N: it retires the oldest
+    // slot and takes it, so the message is delivered and no drop is counted.
+    // That is deliberate — a producer whose subscriber died (or never existed)
+    // must not hold the newest data hostage — and horus_core pins it in
+    // `send_fire_and_forget_keeps_the_newest_on_a_full_unread_ring`. This test
+    // predates that behaviour and used to lean on the old drop-newest path, so
+    // with no subscriber registered it asserted a drop that can no longer
+    // happen.
+    //
+    // Backpressure — and the drop this test is about — exists to protect a real
+    // consumer's unread data, so the subscriber has to be registered BEFORE the
+    // ring fills: `nothing_is_draining()` is only consulted on the full-ring
+    // path. A unique topic name keeps that decision from being made against a
+    // header some earlier run left in /dev/shm (participant registrations and
+    // the stall clock outlive the process that wrote them).
+    let name = format!("test_dx_try_send_{}", std::process::id());
+    let topic: Topic<u64> = Topic::with_capacity(&name, 2, None).unwrap();
+    let subscriber: Topic<u64> = Topic::with_capacity(&name, 2, None).unwrap();
+    // First recv() registers the handle as a consumer; it then never drains,
+    // which is exactly the slow-subscriber case dropped_count() reports on.
+    assert_eq!(subscriber.recv(), None, "a fresh ring starts empty");
+
+    // Fill the ring by sending until it says it is full, rather than assuming a
+    // capacity request of 2 yields exactly two usable slots — `with_capacity`
+    // rounds to a power of two, and the usable window is a property of the
+    // backend that gets selected. The bound only exists so a ring that stopped
+    // applying backpressure fails the assert below instead of looping forever.
+    const FILL_LIMIT: u64 = 64;
+    let mut sent = 0u64;
+    while sent < FILL_LIMIT && topic.try_send(sent).is_ok() {
+        sent += 1;
+    }
+    assert!(
+        sent < FILL_LIMIT,
+        "ring accepted {sent} messages without ever reporting full — try_send has lost its backpressure"
+    );
+
+    // try_send hands the message back instead of dropping it, so a rejected
+    // try_send is not a drop and must not be counted as one.
+    assert_eq!(topic.try_send(sent).unwrap_err(), sent);
     assert_eq!(topic.dropped_count(), 0);
-    // Force a dropped send via the lossy path
-    topic.send(4); // this will spin+yield then drop
-    assert!(topic.dropped_count() > 0 || topic.metrics().send_failures() > 0);
+
+    // send() on a full ring whose subscriber is not draining: spin, yield, then
+    // drop — and that drop is what dropped_count() reports.
+    topic.send(sent);
+    assert!(
+        topic.dropped_count() > 0,
+        "send() on a full ring with a registered subscriber must count the dropped message"
+    );
+    // dropped_count() is the publisher-facing name for the same counter.
+    assert_eq!(topic.metrics().send_failures(), topic.dropped_count());
 }
 
 // ============================================================================

--- a/horus_core/src/actions/client.rs
+++ b/horus_core/src/actions/client.rs
@@ -311,6 +311,22 @@ struct ActionClientInner<A: Action> {
     pump_lock: Mutex<()>,
 }
 
+/// Bookkeeping that must be callable without the payload trait bounds — notably
+/// from `ClientGoalHandle`'s `Drop`, whose bounds are fixed by the struct.
+impl<A: Action> ActionClientInner<A> {
+    /// Drop a goal's bookkeeping entry.
+    ///
+    /// Called when ownership of the goal is provably abandoned — the blocking
+    /// helpers give up on it, or the caller's handle is dropped. `sweep_*` only
+    /// collects goals that reached a TERMINAL status, so a goal that never got
+    /// an answer at all (no server, or a server that dropped it) used to sit in
+    /// the map for the life of the process, and `ActionClientNode::tick` locked
+    /// and scanned every one of those corpses on every tick.
+    fn forget_goal(&self, goal_id: GoalId) {
+        self.goals.write().remove(&goal_id);
+    }
+}
+
 impl<A: Action> ActionClientInner<A>
 where
     A::Goal: Clone + Send + Sync + Serialize + DeserializeOwned + Debug + 'static,
@@ -535,18 +551,6 @@ where
         let state = Arc::new(RwLock::new(ClientGoalState::new()));
         self.goals.write().insert(goal_id, state.clone());
         state
-    }
-
-    /// Drop a goal's bookkeeping entry.
-    ///
-    /// Called when ownership of the goal is provably abandoned — the blocking
-    /// helpers give up on it, or the caller's handle is dropped. `sweep_*` only
-    /// collects goals that reached a TERMINAL status, so a goal that never got
-    /// an answer at all (no server, or a server that dropped it) used to sit in
-    /// the map for the life of the process, and `ActionClientNode::tick` locked
-    /// and scanned every one of those corpses on every tick.
-    fn forget_goal(&self, goal_id: GoalId) {
-        self.goals.write().remove(&goal_id);
     }
 }
 

--- a/horus_core/src/actions/client.rs
+++ b/horus_core/src/actions/client.rs
@@ -245,6 +245,22 @@ where
     }
 }
 
+/// The map entry inside the client exists purely to route status, feedback and
+/// result messages to a handle the caller still holds, so dropping the handle is
+/// the point at which the entry becomes unobservable. Without this, a handle for
+/// a goal that never reaches a terminal status (a server that is down, or one
+/// that silently discards the goal) left an entry in `ActionClientInner::goals`
+/// for the lifetime of the process.
+///
+/// Consequence to be aware of: after the handle is dropped, `goal_status()` and
+/// `active_goals()` on the client no longer report that goal. Keep the handle
+/// alive for as long as you intend to track the goal.
+impl<A: Action> Drop for ClientGoalHandle<A> {
+    fn drop(&mut self) {
+        self.client.forget_goal(self.goal_id);
+    }
+}
+
 impl<A: Action> Debug for ClientGoalHandle<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClientGoalHandle")
@@ -411,6 +427,12 @@ where
                 self.handle_result(result_msg);
             }
         }
+
+        // The sweep used to hang off `handle_status_update`, so it only ever ran
+        // when a status message arrived — exactly the case a dead or silent
+        // server never produces. Running it here means every pump collects
+        // stale entries, whether or not the server is answering.
+        self.sweep_stale_terminal_goals();
     }
 
     /// Handle a status update.
@@ -444,7 +466,6 @@ where
         if update.status == GoalStatus::Rejected {
             self.goals.write().remove(&update.goal_id);
         }
-        self.sweep_stale_terminal_goals();
 
         // Call status callback
         if let Some(ref callback) = *self.status_callback.read() {
@@ -514,6 +535,18 @@ where
         let state = Arc::new(RwLock::new(ClientGoalState::new()));
         self.goals.write().insert(goal_id, state.clone());
         state
+    }
+
+    /// Drop a goal's bookkeeping entry.
+    ///
+    /// Called when ownership of the goal is provably abandoned — the blocking
+    /// helpers give up on it, or the caller's handle is dropped. `sweep_*` only
+    /// collects goals that reached a TERMINAL status, so a goal that never got
+    /// an answer at all (no server, or a server that dropped it) used to sit in
+    /// the map for the life of the process, and `ActionClientNode::tick` locked
+    /// and scanned every one of those corpses on every tick.
+    fn forget_goal(&self, goal_id: GoalId) {
+        self.goals.write().remove(&goal_id);
     }
 }
 
@@ -838,8 +871,13 @@ where
             std::thread::sleep(poll_interval);
         }
 
-        // Timed out - cancel the goal
+        // Timed out - cancel the goal.
+        // Also drop its map entry: neither the id nor the state handle escapes
+        // this function, so after `Err(GoalTimeout)` nothing can ever observe
+        // the entry again and leaving it behind is a pure leak — one per call
+        // for a caller polling a server that is down.
         self.inner.cancel_goal(goal_id);
+        self.inner.forget_goal(goal_id);
         Err(ActionError::GoalTimeout)
     }
 
@@ -893,8 +931,13 @@ where
             std::thread::sleep(poll_interval);
         }
 
-        // Timed out - cancel the goal
+        // Timed out - cancel the goal.
+        // Also drop its map entry: neither the id nor the state handle escapes
+        // this function, so after `Err(GoalTimeout)` nothing can ever observe
+        // the entry again and leaving it behind is a pure leak — one per call
+        // for a caller polling a server that is down.
         self.inner.cancel_goal(goal_id);
+        self.inner.forget_goal(goal_id);
         Err(ActionError::GoalTimeout)
     }
 

--- a/horus_core/src/actions/client.rs
+++ b/horus_core/src/actions/client.rs
@@ -288,12 +288,20 @@ struct ActionClientInner<A: Action> {
     /// Active goal handles
     goals: RwLock<HashMap<GoalId, Arc<RwLock<ClientGoalState<A>>>>>,
 
-    /// Communication links
-    goal_link: RwLock<Option<Topic<GoalRequest<A::Goal>>>>,
-    cancel_link: RwLock<Option<Topic<CancelRequest>>>,
-    result_link: RwLock<Option<Topic<ActionResult<A::Result>>>>,
-    feedback_link: RwLock<Option<Topic<ActionFeedback<A::Feedback>>>>,
-    status_link: RwLock<Option<Topic<GoalStatusUpdate>>>,
+    /// Communication links.
+    ///
+    /// `Mutex`, not `RwLock`: `Topic` is `!Sync`, because `send`/`recv` take
+    /// `&self` and mutate unsynchronised per-handle cursor state. An `RwLock`
+    /// read guard hands out concurrent `&Topic`, which is exactly the race —
+    /// and `RwLock<Option<Topic<..>>>` would no longer even be `Sync`, so
+    /// `Arc<ActionClientInner<A>>` would stop being `Send` and this client
+    /// could not be a `Node`. `Mutex<T>: Sync` needs only `T: Send`, and
+    /// exclusive access is what a `Topic` actually requires.
+    goal_link: Mutex<Option<Topic<GoalRequest<A::Goal>>>>,
+    cancel_link: Mutex<Option<Topic<CancelRequest>>>,
+    result_link: Mutex<Option<Topic<ActionResult<A::Result>>>>,
+    feedback_link: Mutex<Option<Topic<ActionFeedback<A::Feedback>>>>,
+    status_link: Mutex<Option<Topic<GoalStatusUpdate>>>,
 
     /// Callbacks
     feedback_callback: RwLock<Option<FeedbackCallback<A>>>,
@@ -336,11 +344,11 @@ where
     fn new() -> Self {
         Self {
             goals: RwLock::new(HashMap::new()),
-            goal_link: RwLock::new(None),
-            cancel_link: RwLock::new(None),
-            result_link: RwLock::new(None),
-            feedback_link: RwLock::new(None),
-            status_link: RwLock::new(None),
+            goal_link: Mutex::new(None),
+            cancel_link: Mutex::new(None),
+            result_link: Mutex::new(None),
+            feedback_link: Mutex::new(None),
+            status_link: Mutex::new(None),
             feedback_callback: RwLock::new(None),
             result_callback: RwLock::new(None),
             status_callback: RwLock::new(None),
@@ -356,23 +364,23 @@ where
         }
 
         // Create links with proper TopicKind for discovery
-        *self.goal_link.write() = Some(Topic::new_with_kind(
+        *self.goal_link.lock() = Some(Topic::new_with_kind(
             A::goal_topic(),
             TopicKind::ActionGoal as u8,
         )?);
-        *self.cancel_link.write() = Some(Topic::new_with_kind(
+        *self.cancel_link.lock() = Some(Topic::new_with_kind(
             A::cancel_topic(),
             TopicKind::ActionCancel as u8,
         )?);
-        *self.result_link.write() = Some(Topic::new_with_kind(
+        *self.result_link.lock() = Some(Topic::new_with_kind(
             A::result_topic(),
             TopicKind::ActionResult as u8,
         )?);
-        *self.feedback_link.write() = Some(Topic::new_with_kind(
+        *self.feedback_link.lock() = Some(Topic::new_with_kind(
             A::feedback_topic(),
             TopicKind::ActionFeedback as u8,
         )?);
-        *self.status_link.write() = Some(Topic::new_with_kind(
+        *self.status_link.lock() = Some(Topic::new_with_kind(
             A::status_topic(),
             TopicKind::ActionStatus as u8,
         )?);
@@ -397,7 +405,7 @@ where
         let request = GoalRequest::with_priority(goal, priority);
         let goal_id = request.goal_id;
 
-        if let Some(ref link) = *self.goal_link.read() {
+        if let Some(ref link) = *self.goal_link.lock() {
             link.send(request);
 
             log::debug!("ActionClient '{}': Sent goal {}", A::name(), goal_id);
@@ -409,7 +417,7 @@ where
 
     /// Send a cancel request.
     fn cancel_goal(&self, goal_id: GoalId) {
-        if let Some(ref link) = *self.cancel_link.read() {
+        if let Some(ref link) = *self.cancel_link.lock() {
             let request = CancelRequest::new(goal_id);
             link.send(request);
             log::debug!("ActionClient '{}': Sent cancel for {}", A::name(), goal_id);
@@ -424,21 +432,21 @@ where
         let _pump = self.pump_lock.lock();
 
         // Process status updates
-        if let Some(ref link) = *self.status_link.read() {
+        if let Some(ref link) = *self.status_link.lock() {
             while let Some(update) = link.recv() {
                 self.handle_status_update(update);
             }
         }
 
         // Process feedback
-        if let Some(ref link) = *self.feedback_link.read() {
+        if let Some(ref link) = *self.feedback_link.lock() {
             while let Some(feedback_msg) = link.recv() {
                 self.handle_feedback(feedback_msg);
             }
         }
 
         // Process results
-        if let Some(ref link) = *self.result_link.read() {
+        if let Some(ref link) = *self.result_link.lock() {
             while let Some(result_msg) = link.recv() {
                 self.handle_result(result_msg);
             }

--- a/horus_core/src/actions/client.rs
+++ b/horus_core/src/actions/client.rs
@@ -478,7 +478,8 @@ where
         //
         // Goals that go terminal without a result for any other reason — e.g.
         // the server abandoning a non-cooperative goal after `goal_timeout` —
-        // are collected by the sweep below rather than raced here.
+        // are collected by `sweep_stale_terminal_goals`, which every pump runs
+        // at the end of `process_messages`, rather than raced here.
         if update.status == GoalStatus::Rejected {
             self.goals.write().remove(&update.goal_id);
         }
@@ -1136,6 +1137,48 @@ mod tests {
             handle.status(),
             GoalStatus::Succeeded,
             "await_result must pump the client so a standalone goal leaves Pending (F-ACT1)"
+        );
+    }
+
+    /// Regression: the client's goal map must not accumulate entries for goals
+    /// nobody can observe any more. Pruning only ever happened for goals that
+    /// reached a TERMINAL status, so a goal that never got an answer at all —
+    /// a server that is down, the `send_goal_and_wait` timeout path — stayed in
+    /// the map for the life of the process, and `ActionClientNode::tick` locked
+    /// and scanned every one of them on every tick.
+    #[test]
+    fn abandoned_goals_leave_no_entry_in_the_goal_map() {
+        let client = Arc::new(ActionClientInner::<TestAction>::new());
+        let gid = GoalId::new();
+        let state = client.register_goal(gid);
+
+        {
+            let _handle = ClientGoalHandle::<TestAction> {
+                goal_id: gid,
+                priority: GoalPriority::NORMAL,
+                state: state.clone(),
+                client: Arc::clone(&client),
+                sent_at: Instant::now(),
+            };
+            assert_eq!(
+                client.goals.read().len(),
+                1,
+                "the goal is tracked for as long as its handle lives"
+            );
+        }
+        assert!(
+            client.goals.read().is_empty(),
+            "dropping the handle must evict the goal — the entry exists only to \
+             route messages to that handle"
+        );
+
+        // The same eviction the blocking helpers use on their timeout path.
+        let other = GoalId::new();
+        client.register_goal(other);
+        client.forget_goal(other);
+        assert!(
+            client.goals.read().is_empty(),
+            "a goal given up on must not stay in the map"
         );
     }
 

--- a/horus_core/src/actions/macros.rs
+++ b/horus_core/src/actions/macros.rs
@@ -271,22 +271,33 @@ macro_rules! action {
 
     // Runtime snake_case conversion (fallback)
     (@to_snake_case $s:expr) => {{
-        fn to_snake_case(s: &str) -> String {
-            let mut result = String::new();
-            for (i, c) in s.chars().enumerate() {
-                if c.is_uppercase() {
-                    if i > 0 {
-                        result.push('_');
+        // This expression is the whole body of the generated `Action::name()`,
+        // which is called on every goal, every status log line and every
+        // `*_topic()` lookup. It used to allocate a String and `Box::leak` it
+        // on EVERY call — the "done once" comment was wishful thinking, and
+        // because the memory is deliberately leaked the growth was monotonic
+        // and unreclaimable. The `OnceLock` makes the one-leak-per-type claim
+        // true, matching what `service!` already does.
+        static HORUS_ACTION_NAME: ::std::sync::OnceLock<&'static str> =
+            ::std::sync::OnceLock::new();
+        *HORUS_ACTION_NAME.get_or_init(|| {
+            fn to_snake_case(s: &str) -> String {
+                let mut result = String::new();
+                for (i, c) in s.chars().enumerate() {
+                    if c.is_uppercase() {
+                        if i > 0 {
+                            result.push('_');
+                        }
+                        result.push(c.to_ascii_lowercase());
+                    } else {
+                        result.push(c);
                     }
-                    result.push(c.to_ascii_lowercase());
-                } else {
-                    result.push(c);
                 }
+                result
             }
-            result
-        }
-        // Leak to get 'static lifetime (done once per action type)
-        Box::leak(to_snake_case($s).into_boxed_str()) as &'static str
+            // Leaked once per action type to obtain the 'static lifetime.
+            Box::leak(to_snake_case($s).into_boxed_str()) as &'static str
+        })
     }};
 }
 

--- a/horus_core/src/actions/server.rs
+++ b/horus_core/src/actions/server.rs
@@ -1019,11 +1019,7 @@ where
         // canceled before it ever runs. Remove it and finalize as Canceled —
         // otherwise the cancel would be dropped and the goal would run anyway
         // when a slot frees.
-        if let Some(pos) = self
-            .goal_queue
-            .iter()
-            .position(|g| g.goal_id == goal_id)
-        {
+        if let Some(pos) = self.goal_queue.iter().position(|g| g.goal_id == goal_id) {
             let response = if let Some(ref callback) = self.cancel_callback {
                 callback(goal_id)
             } else {
@@ -1074,11 +1070,7 @@ where
         match response {
             CancelResponse::Accept => {
                 if let Some(state) = self.active_goals.get(&goal_id) {
-                    log::info!(
-                        "ActionServer '{}': Canceling goal {}",
-                        A::name(),
-                        goal_id
-                    );
+                    log::info!("ActionServer '{}': Canceling goal {}", A::name(), goal_id);
                     state.cancel_requested.store(true, Ordering::Release);
                 }
             }

--- a/horus_core/src/actions/server.rs
+++ b/horus_core/src/actions/server.rs
@@ -531,6 +531,21 @@ where
 
     /// Handle an incoming goal request.
     fn handle_goal(&mut self, request: GoalRequest<A::Goal>) {
+        // The nil UUID is the cancel-all sentinel on the cancel topic
+        // (`CancelRequest::is_cancel_all`). Goal ids arrive verbatim off the
+        // wire, so nothing else stops a publisher from admitting a goal that
+        // carries it — one that could never be cancelled by id, and that would
+        // put the sentinel into every cancel-all's target set. Refuse it here,
+        // before the counters and the goal callback, so neither `accept_goal`
+        // nor the `Queue` path can ever store it.
+        if request.goal_id.0.is_nil() {
+            self.reject_goal(
+                request.goal_id,
+                "nil goal id is reserved as the cancel-all sentinel",
+            );
+            return;
+        }
+
         self.goals_received.fetch_add(1, Ordering::Relaxed);
 
         log::debug!(
@@ -958,6 +973,16 @@ where
     fn handle_cancel(&mut self, request: CancelRequest) {
         // Cancel-all was advertised by the CLI but never implemented here, so
         // `horus action cancel_goal <name>` (no id) did nothing at all.
+        //
+        // The cancel-all branch used to re-dispatch every collected id through
+        // `handle_cancel(CancelRequest::new(goal_id))`. `is_cancel_all()` is
+        // defined purely as `goal_id.is_nil()`, so a tracked goal carrying the
+        // nil UUID made the synthesized request satisfy `is_cancel_all()` again,
+        // collect the same set, and recurse without bound until the thread's
+        // stack was exhausted (an abort, killing every node in the process).
+        // The per-goal work now lives in `cancel_one`, which takes a bare
+        // `GoalId`: no `CancelRequest` is synthesized anywhere, so nothing can
+        // re-enter this branch regardless of what ids are tracked.
         if request.is_cancel_all() {
             let all: Vec<GoalId> = self
                 .active_goals
@@ -971,15 +996,23 @@ where
                 all.len()
             );
             for goal_id in all {
-                self.handle_cancel(CancelRequest::new(goal_id));
+                self.cancel_one(goal_id);
             }
             return;
         }
 
+        self.cancel_one(request.goal_id);
+    }
+
+    /// Cancel one goal by id, whether it is queued or already running.
+    ///
+    /// Takes the id directly rather than a `CancelRequest` so that the
+    /// cancel-all sentinel can never be re-synthesized on this path.
+    fn cancel_one(&mut self, goal_id: GoalId) {
         log::debug!(
             "ActionServer '{}': Cancel request for goal {}",
             A::name(),
-            request.goal_id
+            goal_id
         );
 
         // A goal still sitting in the queue (accepted-but-not-yet-started) can be
@@ -989,10 +1022,10 @@ where
         if let Some(pos) = self
             .goal_queue
             .iter()
-            .position(|g| g.goal_id == request.goal_id)
+            .position(|g| g.goal_id == goal_id)
         {
             let response = if let Some(ref callback) = self.cancel_callback {
-                callback(request.goal_id)
+                callback(goal_id)
             } else {
                 CancelResponse::Accept
             };
@@ -1003,17 +1036,17 @@ where
                     log::info!(
                         "ActionServer '{}': Canceling queued goal {}",
                         A::name(),
-                        request.goal_id
+                        goal_id
                     );
                     // No result payload — the goal never executed; the terminal
                     // status conveys cancellation to the client.
-                    self.publish_status(request.goal_id, GoalStatus::Canceled);
+                    self.publish_status(goal_id, GoalStatus::Canceled);
                 }
                 CancelResponse::Reject(reason) => {
                     log::debug!(
                         "ActionServer '{}': Cancel rejected for queued goal {}: {}",
                         A::name(),
-                        request.goal_id,
+                        goal_id,
                         reason
                     );
                 }
@@ -1023,28 +1056,28 @@ where
 
         // Otherwise it must be an active goal; signal cooperative cancellation
         // via the shared flag the running callback polls.
-        if !self.active_goals.contains_key(&request.goal_id) {
+        if !self.active_goals.contains_key(&goal_id) {
             log::debug!(
                 "ActionServer '{}': Cancel rejected - goal {} not found",
                 A::name(),
-                request.goal_id
+                goal_id
             );
             return;
         }
 
         let response = if let Some(ref callback) = self.cancel_callback {
-            callback(request.goal_id)
+            callback(goal_id)
         } else {
             CancelResponse::Accept // Accept all cancels by default
         };
 
         match response {
             CancelResponse::Accept => {
-                if let Some(state) = self.active_goals.get(&request.goal_id) {
+                if let Some(state) = self.active_goals.get(&goal_id) {
                     log::info!(
                         "ActionServer '{}': Canceling goal {}",
                         A::name(),
-                        request.goal_id
+                        goal_id
                     );
                     state.cancel_requested.store(true, Ordering::Release);
                 }
@@ -1053,7 +1086,7 @@ where
                 log::debug!(
                     "ActionServer '{}': Cancel rejected for goal {}: {}",
                     A::name(),
-                    request.goal_id,
+                    goal_id,
                     reason
                 );
             }
@@ -1646,6 +1679,52 @@ mod tests {
                 !CancelRequest::new(GoalId::new()).is_cancel_all(),
                 "a v4 goal id must never look like the cancel-all sentinel"
             );
+        }
+    }
+
+    /// A goal carrying the nil UUID must be refused, and cancel-all must not
+    /// recurse.
+    ///
+    /// `is_cancel_all()` is defined purely as `goal_id.is_nil()`, so the old
+    /// cancel-all branch — which re-dispatched every tracked id as a fresh
+    /// `CancelRequest` — recursed without bound the moment any goal held the
+    /// nil id, aborting the process on stack overflow.
+    #[test]
+    fn nil_goal_id_is_refused_and_cancel_all_does_not_recurse() {
+        let mut server = ActionServerBuilder::<TestAction>::new()
+            .on_goal(|_| GoalResponse::Accept)
+            .on_cancel(|_| CancelResponse::Accept)
+            .on_execute(|handle| handle.succeed(TestResult { success: true }))
+            .max_concurrent_goals(Some(1))
+            .preemption_policy(PreemptionPolicy::Queue { max_size: 4 })
+            .build();
+
+        server.handle_goal(GoalRequest {
+            goal_id: GoalId(uuid::Uuid::nil()),
+            goal: TestGoal { target: 1.0 },
+            priority: GoalPriority::default(),
+            timestamp: Duration::from_secs(0),
+        });
+
+        assert!(
+            server.active_goals.is_empty(),
+            "the cancel-all sentinel must never be admitted as a goal"
+        );
+        assert!(
+            server.goal_queue.is_empty(),
+            "the Queue policy must not park the sentinel either"
+        );
+        assert_eq!(
+            server.metrics().goals_rejected,
+            1,
+            "the sentinel goal must be reported as rejected"
+        );
+
+        // Terminates only because cancel-all no longer re-enters itself.
+        server.handle_cancel(CancelRequest::cancel_all());
+
+        for (_id, join) in server.goal_threads.drain() {
+            let _ = join.join();
         }
     }
 

--- a/horus_core/src/communication/mod.rs
+++ b/horus_core/src/communication/mod.rs
@@ -51,31 +51,137 @@ pub use topic::{set_topic_lifecycle_hook, TopicLifecycleEvent};
 // Topic-Node automatic association registry
 pub use topic::{topic_node_registry, NodeTopicRole, TopicAssociation, TopicNodeRegistry};
 
-/// Write raw bytes into the latest slot of a topic SHM file (used by replay).
+/// A writable view of a topic's shared region, opened the way the running
+/// platform actually backs it.
 ///
-/// This is the write counterpart to `read_latest_slot_bytes`.  It writes
-/// `data` into the next slot of the ring buffer and bumps the sequence counter.
-/// Returns `true` on success.
-#[doc(hidden)]
-pub fn write_topic_slot_bytes(path: &std::path::Path, data: &[u8]) -> bool {
+/// This is the write-side counterpart of `topic::header::TopicRegion`, and it
+/// exists for the same reason. The path-based API addresses a topic by its
+/// `topic_shm_path`, which is only a real file where the backend is file-backed:
+/// `/dev/shm/horus_<ns>/topics/<name>` on Linux, `/tmp/…` on macOS and on the
+/// generic fallback. The Windows backend is not a file at all — `ShmRegion::new`
+/// calls `CreateFileMappingW(INVALID_HANDLE_VALUE, …)` for a pagefile-backed
+/// section named `Local\horus_<name>`, and `ShmRegion::backing_path()`
+/// correspondingly reports `None` there. Nothing is ever created at the topic
+/// path, so the `OpenOptions::new().read(true).write(true).open(path)` this
+/// function used to start with failed with `NotFound` and
+/// `write_topic_slot_bytes` returned `false` for every live topic on Windows —
+/// on a platform where the ring itself works. Everything publishing through
+/// this seam went silent there: record/replay, and horus_net's cross-process
+/// tests, which use it as the writer half of the SHM seam.
+///
+/// The read helper cannot simply be reused for this: it hands back a read-only
+/// `memmap2::Mmap` on the file-backed platforms, which is the wrong mapping for
+/// in-place stores. Only the file arm actually differs — the Windows arm is
+/// identical because `ShmRegion::open_existing` already maps the section
+/// `FILE_MAP_ALL_ACCESS`, so one handle serves both directions.
+enum TopicRegionMut {
+    /// A file-backed region (Linux, macOS, the generic fallback), mapped
+    /// read-write.
+    Mapped(memmap2::MmapMut),
+    /// A Windows named section. The handle is held for the life of the view.
+    #[cfg(target_os = "windows")]
+    Section(horus_sys::shm::ShmRegion),
+}
+
+impl std::ops::Deref for TopicRegionMut {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self {
+            Self::Mapped(mmap) => &mmap[..],
+            #[cfg(target_os = "windows")]
+            Self::Section(region) => region.as_slice(),
+        }
+    }
+}
+
+impl std::ops::DerefMut for TopicRegionMut {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        match self {
+            Self::Mapped(mmap) => &mut mmap[..],
+            #[cfg(target_os = "windows")]
+            Self::Section(region) => region.as_slice_mut(),
+        }
+    }
+}
+
+/// Map a topic's shared region read-write, or `None` when it is absent, too
+/// small to hold a header, or unmappable.
+///
+/// Mirrors `topic::header::map_topic_region`, including the guarantee the
+/// caller leans on: the returned view is at least `TOPIC_HEADER_SIZE` bytes.
+///
+/// The file is tried first on every platform, because where one exists it *is*
+/// the region. Only when there is none does the Windows section lookup run, so
+/// nothing about the file-backed platforms changes.
+fn map_topic_region_mut(path: &std::path::Path) -> Option<TopicRegionMut> {
     use memmap2::MmapOptions;
     use std::fs::OpenOptions;
 
-    let file = match OpenOptions::new().read(true).write(true).open(path) {
-        Ok(f) => f,
-        Err(_) => return false,
-    };
-    let meta = match file.metadata() {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-    if meta.len() < topic::header::TOPIC_HEADER_SIZE as u64 {
-        return false;
+    if let Ok(file) = OpenOptions::new().read(true).write(true).open(path) {
+        if file.metadata().ok()?.len() < topic::header::TOPIC_HEADER_SIZE as u64 {
+            return None;
+        }
+        // SAFETY: the file is opened read-write; the mapping is shared, which is
+        // what makes the stores below visible to every other process attached
+        // to the same topic.
+        let mmap = unsafe { MmapOptions::new().map_mut(&file).ok()? };
+        return Some(TopicRegionMut::Mapped(mmap));
     }
-    // SAFETY: file is opened read-write; mmap is used for in-place writes to SHM.
-    let mut mmap = match unsafe { MmapOptions::new().map_mut(&file) } {
-        Ok(m) => m,
-        Err(_) => return false,
+
+    open_named_section_mut(path)
+}
+
+/// Open, writable, the Windows named section a topic path refers to.
+///
+/// `topic_shm_path` is `shm_topics_dir().join(name)` and a topic name may
+/// itself contain separators, so the name is the whole remainder of the path
+/// rather than just its last component — `file_name()` on `robot/cmd_vel`
+/// would ask the kernel for a section called `cmd_vel`, which is either absent
+/// or, worse, a different topic that we would then publish into.
+#[cfg(target_os = "windows")]
+fn open_named_section_mut(path: &std::path::Path) -> Option<TopicRegionMut> {
+    let name = path
+        .strip_prefix(horus_sys::shm::shm_topics_dir())
+        .ok()?
+        .to_str()?;
+    let region =
+        horus_sys::shm::ShmRegion::open_existing(name, topic::header::TOPIC_HEADER_SIZE).ok()?;
+    // `open_existing` already refuses a region smaller than the minimum, but it
+    // falls back to *assuming* the minimum when `VirtualQuery` fails rather
+    // than measuring it. Re-check what we were actually handed, because every
+    // store below is bounds-checked against `len()` and against nothing else.
+    if region.len() < topic::header::TOPIC_HEADER_SIZE {
+        return None;
+    }
+    Some(TopicRegionMut::Section(region))
+}
+
+/// Non-Windows counterpart of the section lookup: every other backend is
+/// file-backed, so a missing file is a missing topic and there is nowhere else
+/// to look.
+#[cfg(not(target_os = "windows"))]
+fn open_named_section_mut(_path: &std::path::Path) -> Option<TopicRegionMut> {
+    None
+}
+
+/// Write raw bytes into the latest slot of a topic's shared region (used by
+/// replay).
+///
+/// This is the write counterpart to `read_latest_slot_bytes`, and it addresses
+/// the topic exactly the way that one does: `path` is the topic's
+/// `topic_shm_path`, which is the backing file itself on Linux, macOS and the
+/// fallback backend, and names the pagefile-backed section on Windows.  It
+/// writes `data` into the next slot of the ring buffer and bumps the sequence
+/// counter.  Returns `true` on success.
+#[doc(hidden)]
+pub fn write_topic_slot_bytes(path: &std::path::Path, data: &[u8]) -> bool {
+    // Map the topic's shared region read-write. File-backed on Linux/macOS, a
+    // named section on Windows; either way at least TOPIC_HEADER_SIZE bytes,
+    // which is what the header reads below assume.
+    let mut mmap = match map_topic_region_mut(path) {
+        Some(m) => m,
+        None => return false,
     };
     let base = mmap.as_mut_ptr();
     let len = mmap.len();

--- a/horus_core/src/communication/pod.rs
+++ b/horus_core/src/communication/pod.rs
@@ -5,7 +5,25 @@
 //! ## Automatic POD Detection
 //!
 //! HORUS automatically detects POD types using `std::mem::needs_drop::<T>()`.
-//! **No registration or special traits required!**
+//! No registration or special traits required.
+//!
+//! ### ⚠️ This detection is a heuristic, and it is not sound for every type
+//!
+//! `!needs_drop` proves a type owns no heap allocation. It does NOT prove every
+//! bit pattern is a valid value of that type. A struct containing a `bool`, a
+//! fieldless enum, or a `NonZeroU32` passes the heuristic and is then
+//! transported by raw byte reinterpretation out of shared memory that a peer
+//! process — possibly a different build, a stale region, or horus_net's
+//! unauthenticated network feed — wrote. Materialising a `bool` holding `0x02`
+//! or an out-of-range discriminant is undefined behaviour, and nothing on this
+//! path validates it.
+//!
+//! Until the zero-copy path is gated on an explicit `PodMessage` opt-in (whose
+//! `bytemuck::Pod` bound rejects exactly these field types at compile time),
+//! **prefer integer fields with explicit encodings over `bool`/enum fields in
+//! messages you intend to send as fixed-size** — `u8` flags, as
+//! `horus_types::diagnostics` already does. This paragraph used to advertise
+//! the heuristic without the caveat.
 //!
 //! ```rust,ignore
 //! // Just define your struct - HORUS auto-detects it as POD
@@ -23,9 +41,11 @@
 //!
 //! A type is POD if:
 //! - `!std::mem::needs_drop::<T>()` - No destructor (no heap pointers)
-//! - `std::mem::size_of::<T>() > 0` - Not a zero-sized type
+//! - `std::mem::size_of::<T>() > 1` - Not a ZST, and not a single byte
 //!
 //! This automatically excludes String, Vec, Box, and any type containing them.
+//! It does NOT exclude a larger type that *contains* a field with a validity
+//! invariant — see the warning above.
 //!
 //! ## Performance Characteristics
 //!
@@ -74,10 +94,27 @@ use crate::core::LogSummary;
 /// - It's not a single byte (excludes `bool` which has validity invariants —
 ///   only 0/1 are valid, arbitrary SHM bytes like 0x02 would be instant UB)
 ///
-/// **Limitation**: This heuristic cannot detect enums with limited discriminant
-/// values or types like `NonZeroU32` that have validity invariants but pass
-/// `!needs_drop`. For such types, use the explicit `PodMessage` trait (which
-/// requires `bytemuck::Pod + Zeroable`) instead of relying on auto-detection.
+/// # Known unsoundness (not a mere limitation)
+///
+/// The `size > 1` filter only rejects types that are *themselves* one byte. A
+/// struct whose FIELD is a `bool`, a fieldless enum, or a `NonZeroU32` is
+/// larger than one byte and has no destructor, so it is classified POD here and
+/// routed to the raw byte-reinterpretation path — which builds a `T` out of
+/// bytes another process wrote, with no validation and no `bytemuck::Pod` bound
+/// to catch it. An invalid `bool` or discriminant is UB the moment it is
+/// materialised.
+///
+/// This cannot be fixed inside this function: dispatch is a runtime `bool` and
+/// `RingTopic<T>` is generic over serde bounds, so there is no `PodMessage`
+/// bound available to test. The real fix is an explicit opt-in registry keyed
+/// on `TypeId`, populated only by types that assert `PodMessage` (and a
+/// `message! { #[fixed] }` macro arm that derives `bytemuck::Pod`, making a
+/// `bool` field a compile error). Until then, callers must not put fields with
+/// validity invariants in fixed-size messages; the module header says so.
+///
+/// The torn-read window is separately closed on the seqlock consumer path,
+/// which keeps a slot copy as `MaybeUninit<T>` until after its stamp re-check
+/// (`simd_aware_read_uninit`), so a discarded torn read never becomes a `T`.
 ///
 /// Types with destructors (String, Vec, Box, etc.) contain heap pointers
 /// that become invalid in cross-process communication, so they're excluded.

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -328,8 +328,8 @@ macro_rules! epoch_guard_recv {
 ///
 /// The refresh itself is decided by wall clock inside `refresh_lease_if_due`;
 /// this counter only keeps the clock read off the per-message hot path. It is
-/// deliberately far smaller than `LEASE_REFRESH_INTERVAL`: the old code
-/// refreshed strictly every 1024 messages, so liveness depended on throughput
+/// deliberately far smaller than the 1024-message interval it replaces: the old
+/// code refreshed strictly every 1024 messages, so liveness depended on throughput
 /// and a slow-but-healthy participant looked expired most of the time. At 64,
 /// a 100 Hz participant reaches the clock check about twice a second against a
 /// 5 s lease.

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -76,7 +76,7 @@ use super::shm_layout::SLOT_WRITING;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::backend::BackendStorage;
-use super::local_state::{EPOCH_CHECK_INTERVAL, LEASE_REFRESH_INTERVAL};
+use super::local_state::EPOCH_CHECK_INTERVAL;
 use super::RingTopic;
 use super::{simd_aware_read, simd_aware_write};
 use crate::utils::unlikely;
@@ -321,32 +321,53 @@ macro_rules! epoch_guard_recv {
 // Housekeeping macros — amortized maintenance after each message
 // ============================================================================
 
+/// How often (in messages) to *consider* refreshing the lease.
+///
+/// The refresh itself is decided by wall clock inside `refresh_lease_if_due`;
+/// this counter only keeps the clock read off the per-message hot path. It is
+/// deliberately far smaller than `LEASE_REFRESH_INTERVAL`: the old code
+/// refreshed strictly every 1024 messages, so liveness depended on throughput
+/// and a slow-but-healthy participant looked expired most of the time. At 64,
+/// a 100 Hz participant reaches the clock check about twice a second against a
+/// 5 s lease.
+const LEASE_CHECK_INTERVAL: u32 = 64;
+
 /// Housekeeping after a successful send or recv: migration check (fast, every
-/// EPOCH_CHECK_INTERVAL msgs) + lease refresh (slower syscall, every
-/// LEASE_REFRESH_INTERVAL msgs).  Used by all dispatched (fn-ptr) send/recv paths.
+/// EPOCH_CHECK_INTERVAL msgs) + lease refresh (clock-gated, considered every
+/// LEASE_CHECK_INTERVAL msgs).  Used by all dispatched (fn-ptr) send/recv paths.
 macro_rules! housekeep_lease {
     ($local:ident, $topic:expr) => {
         $local.msg_counter = $local.msg_counter.wrapping_add(1);
         if unlikely($local.msg_counter & (EPOCH_CHECK_INTERVAL - 1) == 0) {
             $topic.check_migration_periodic();
-            if unlikely($local.msg_counter & (LEASE_REFRESH_INTERVAL - 1) == 0) {
-                $topic.refresh_lease();
+            if unlikely($local.msg_counter & (LEASE_CHECK_INTERVAL - 1) == 0) {
+                $topic.refresh_lease_if_due();
             }
         }
     };
 }
 
-/// Housekeeping on empty recv: epoch check on EVERY empty recv.
+/// Housekeeping on empty recv: epoch check on EVERY empty recv, plus a
+/// clock-gated lease refresh.
 ///
 /// When recv returns None, the topic may be empty because a cross-process
 /// producer joined and this participant hasn't observed the migration epoch
 /// yet (still pointed at the old SHM ring). Checking the SHM
 /// epoch on every empty recv ensures migration is detected immediately.
 /// Cost: one Relaxed atomic load (~1ns) — negligible for polling loops.
+///
+/// The empty path refreshed nothing at all, so a subscriber polling a topic
+/// that has not published yet stopped refreshing the instant it registered and
+/// was permanently lease-expired one timeout later — while still polling. That
+/// is a liveness report about a live process, and slot reclamation used to act
+/// on it.
 macro_rules! housekeep_epoch {
     ($local:ident, $topic:expr) => {
         $local.msg_counter = $local.msg_counter.wrapping_add(1);
         $topic.check_migration_periodic();
+        if unlikely($local.msg_counter & (LEASE_CHECK_INTERVAL - 1) == 0) {
+            $topic.refresh_lease_if_due();
+        }
     };
 }
 
@@ -359,10 +380,11 @@ macro_rules! housekeep_recv {
         // Check SHM epoch on every recv — detects cross-process producers immediately.
         // Cost: one Relaxed atomic load (~1ns), negligible vs the ring buffer read.
         $topic.check_migration_periodic();
-        if $result.is_some() {
-            if unlikely($local.msg_counter & (LEASE_REFRESH_INTERVAL - 1) == 0) {
-                $topic.refresh_lease();
-            }
+        // Refresh on a wall clock, and on the empty path too (see
+        // `housekeep_epoch`): a consumer is just as alive when the ring is
+        // empty as when it is not.
+        if unlikely($local.msg_counter & (LEASE_CHECK_INTERVAL - 1) == 0) {
+            $topic.refresh_lease_if_due();
         }
     };
 }

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -166,22 +166,25 @@ impl SpillDescriptor {
     // `to_tensor` takes &self because SpillDescriptor is not Copy (contains u64 fields
     // that are best borrowed), and the tensor is reconstructed from multiple fields.
     #[allow(clippy::wrong_self_convention)]
+    #[allow(clippy::field_reassign_with_default)]
     #[inline]
     pub fn to_tensor(&self) -> crate::types::Tensor {
-        let mut shape = [0u64; crate::types::tensor::MAX_TENSOR_DIMS];
-        shape[0] = self.size;
-        crate::types::Tensor {
-            pool_id: self.pool_id,
-            slot_id: self.slot_id,
-            generation: self.generation,
-            generation_hi: self.generation_hi,
-            offset: self.offset,
-            size: self.size,
-            dtype: crate::types::TensorDtype::U8,
-            ndim: 1,
-            shape,
-            ..Default::default()
-        }
+        // Built field-by-field rather than with a struct literal: `Tensor`'s
+        // dtype is a private raw byte (so a hostile wire descriptor cannot
+        // materialise an invalid discriminant), and a functional-update literal
+        // requires every field to be visible. The dtype goes through the
+        // accessor.
+        let mut tensor = crate::types::Tensor::default();
+        tensor.pool_id = self.pool_id;
+        tensor.slot_id = self.slot_id;
+        tensor.generation = self.generation;
+        tensor.generation_hi = self.generation_hi;
+        tensor.offset = self.offset;
+        tensor.size = self.size;
+        tensor.set_dtype(crate::types::TensorDtype::U8);
+        tensor.ndim = 1;
+        tensor.shape[0] = self.size;
+        tensor
     }
 }
 

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -487,9 +487,30 @@ fn deserialize_spill_slot<T: DeserializeOwned>(
 fn read_spilled_once<T: DeserializeOwned>(spill: SpillDescriptor, topic_name: &str) -> Option<T> {
     let tensor = spill.to_tensor();
     let pool = super::pool_registry::get_or_create_pool(topic_name);
+    // Pin the slot across the read, exactly as `read_spilled_retained` does.
+    //
+    // "There is exactly one reader" was true and still is; what it did not cover
+    // is the SAME reader arriving at one ring position twice. The first read
+    // released the producer's alloc refcount, `return_slot` freed the slot and
+    // `backend.zero()` began writing volatile zeroes over it — and the second
+    // read then validated a descriptor whose generation had not yet been bumped
+    // (generation moves on alloc, not on free) and handed the region to bincode
+    // while it was being zeroed. That is a data race on the payload itself, and
+    // it is what ThreadSanitizer caught under `auto_grow_cross_thread_no_crash`.
+    //
+    // `try_retain` closes it: it refuses on a zero refcount, so a position that
+    // has already been consumed reads as a clean miss instead of a torn read.
+    if pool.try_retain(&tensor).is_err() {
+        return None;
+    }
     let msg = deserialize_spill_slot::<T>(&pool, &tensor, spill.size as usize);
-    // Single consumer owns the alloc refcount; free it now (gen-checked no-op if stale).
-    pool.release(&tensor);
+    // Two references are outstanding and both are ours to drop: the pin above,
+    // and the producer's alloc refcount that this single consumer inherits. The
+    // second release is the COMM-H3 reclaim that keeps the spill pool from
+    // leaking; together they take the slot to zero and free it, which is the
+    // same end state as the single release this replaced.
+    pool.release(&tensor); // our read pin
+    pool.release(&tensor); // the producer's alloc refcount
     msg
 }
 

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -1791,6 +1791,41 @@ pub(super) fn recv_uninitialized<
     unsafe { (*topic.recv_fn.get())(topic) }
 }
 
+/// Whether this topic should report an endpoint-exhaustion event now.
+///
+/// The two call sites each had `static WARNED: AtomicBool` and warned once per
+/// *process*, forever. The intent was not to flood a hot send loop, and the
+/// effect was that the second topic to run out of endpoints — and every one
+/// after it, for the life of the process — lost its comms in complete silence.
+/// On a robot that is a subsystem going quiet hours after an unrelated warning
+/// scrolled past, which is the failure mode the loud warning exists to prevent.
+///
+/// Keyed by topic and rate-limited per topic instead, so a hot loop still emits
+/// once a minute rather than once ever, and a second topic hitting the same
+/// wall is never masked by the first.
+fn should_report_endpoint_exhaustion(topic: &str) -> bool {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    const QUIET: Duration = Duration::from_secs(60);
+    static LAST: Mutex<Option<HashMap<String, Instant>>> = Mutex::new(None);
+
+    let mut guard = match LAST.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    let seen = guard.get_or_insert_with(HashMap::new);
+    let now = Instant::now();
+    match seen.get(topic) {
+        Some(t) if now.duration_since(*t) < QUIET => false,
+        _ => {
+            seen.insert(topic.to_string(), now);
+            true
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2297,41 +2332,6 @@ mod tests {
             assert_eq!(recovered.generation_hi, 0xCAFE_F00D);
             assert_eq!(recovered.offset, 0x0102_0304_0506_0708);
             assert_eq!(recovered.size, 0x0A0B_0C0D_0E0F_1011);
-        }
-    }
-}
-
-/// Whether this topic should report an endpoint-exhaustion event now.
-///
-/// The two call sites each had `static WARNED: AtomicBool` and warned once per
-/// *process*, forever. The intent was not to flood a hot send loop, and the
-/// effect was that the second topic to run out of endpoints — and every one
-/// after it, for the life of the process — lost its comms in complete silence.
-/// On a robot that is a subsystem going quiet hours after an unrelated warning
-/// scrolled past, which is the failure mode the loud warning exists to prevent.
-///
-/// Keyed by topic and rate-limited per topic instead, so a hot loop still emits
-/// once a minute rather than once ever, and a second topic hitting the same
-/// wall is never masked by the first.
-fn should_report_endpoint_exhaustion(topic: &str) -> bool {
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-    use std::time::{Duration, Instant};
-
-    const QUIET: Duration = Duration::from_secs(60);
-    static LAST: Mutex<Option<HashMap<String, Instant>>> = Mutex::new(None);
-
-    let mut guard = match LAST.lock() {
-        Ok(g) => g,
-        Err(p) => p.into_inner(),
-    };
-    let seen = guard.get_or_insert_with(HashMap::new);
-    let now = Instant::now();
-    match seen.get(topic) {
-        Some(t) if now.duration_since(*t) < QUIET => false,
-        _ => {
-            seen.insert(topic.to_string(), now);
-            true
         }
     }
 }

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -1842,7 +1842,7 @@ mod tests {
         assert_eq!(recovered.slot_id, 7);
         assert_eq!(recovered.offset, 1024);
         assert_eq!(recovered.size, 5000);
-        assert_eq!(recovered.dtype, crate::types::TensorDtype::U8);
+        assert_eq!(recovered.dtype(), crate::types::TensorDtype::U8);
         assert_eq!(recovered.ndim, 1);
         assert_eq!(recovered.shape[0], 5000);
     }
@@ -2258,7 +2258,7 @@ mod tests {
         );
         let spill = SpillDescriptor::from_tensor(&tensor, 100);
         let recovered = spill.to_tensor();
-        assert_eq!(recovered.dtype, crate::types::TensorDtype::U8);
+        assert_eq!(recovered.dtype(), crate::types::TensorDtype::U8);
         assert_eq!(recovered.ndim, 1);
         // shape[0] == size (the serialized byte count)
         assert_eq!(recovered.shape[0], 100);

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -233,8 +233,49 @@ fn spill_to_pool<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static
         .ok()?;
 
     // Copy serialized bytes into the pool slot
-    let dst = pool.data_slice_mut(&tensor).ok()?;
+    let dst = match pool.data_slice_mut(&tensor) {
+        Ok(d) => d,
+        // Give the slot back rather than leaking it: `alloc` left the refcount
+        // at 1 and nothing else will ever drop it (the `?` this replaces
+        // returned `None` with the allocation still outstanding).
+        Err(_) => {
+            pool.release(&tensor);
+            return None;
+        }
+    };
     dst[..bytes.len()].copy_from_slice(bytes);
+
+    // Publish those bytes through the POOL's mapping, not only the ring's.
+    //
+    // The ring publish that follows in every caller (`fence(Release)` + a
+    // Release store of the ready flag / head, matched by an Acquire load in
+    // every recv path) is a correct release/acquire pair — but only on paper,
+    // because the two sides do not touch the same object.  Every `RingTopic`
+    // handle builds its own `ShmRegion`, i.e. its own `mmap` of the topic file,
+    // so two handles in one process release and acquire that flag at two
+    // different virtual addresses of the same physical page.  The hardware still
+    // delivers the bytes; the memory model derives no synchronizes-with from two
+    // distinct atomics, and ThreadSanitizer — which shadows by virtual address —
+    // derived none either.  That is why it reported this `copy_from_slice`
+    // racing `deserialize_spill_slot`'s read of the identical payload, even
+    // though the consumer holds a `try_retain` pin: the pin stops the slot being
+    // freed or reused under the reader, but a pin is not an ordering edge for
+    // bytes written before it was taken.
+    //
+    // The pool is a single process-wide mapping — `pool_registry` hands out one
+    // `Arc<TensorPool>` per topic name — and every reader of a spilled payload
+    // pins the slot with `try_retain` before it touches a byte, which is an
+    // acquire RMW on the slot refcount.  `publish_payload` is the matching
+    // release half, so the copy above is ordered before every consumer's read
+    // through an edge that both the model and the sanitizer can see.
+    if pool.publish_payload(&tensor).is_err() {
+        // Unreachable in practice: the slot was allocated a few lines above and
+        // this thread still holds that reference.  If it ever does happen, drop
+        // the allocation instead of publishing a descriptor to bytes nothing is
+        // ordered against.
+        pool.release(&tensor);
+        return None;
+    }
 
     // The alloc starts at refcount=1. How that refcount is reclaimed depends on
     // the backend (both COMM-H3 — the old "freed when the slot gets reallocated"

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -78,7 +78,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::backend::BackendStorage;
 use super::local_state::EPOCH_CHECK_INTERVAL;
 use super::RingTopic;
-use super::{simd_aware_read, simd_aware_write};
+use super::{simd_aware_read, simd_aware_read_uninit, simd_aware_write};
 use crate::utils::unlikely;
 
 // ============================================================================
@@ -1534,12 +1534,16 @@ pub(super) fn recv_shm_pod_broadcast<
 
     // SAFETY: cached_data_ptr points to SHM data region. index < capacity (mask).
     // The Acquire load above establishes happens-before with the producer's
-    // Release store, so the slot data is fully written. simd_aware_read handles
-    // alignment. The copy may still be torn if a lapping producer overwrites the
-    // slot DURING this read — the re-check below is what detects that.
+    // Release store, so the slot data is fully written. simd_aware_read_uninit
+    // handles alignment. The copy may still be torn if a lapping producer
+    // overwrites the slot DURING this read — the re-check below is what detects
+    // that, which is why the bytes are held as `MaybeUninit<T>` and not yet a
+    // `T`: `is_pod` admits types with validity invariants (a struct with a
+    // `bool` or a fieldless enum field), and materialising torn bytes into such
+    // a `T` would be UB committed before the re-check could reject it.
     let msg = unsafe {
         let base = local.cached_data_ptr as *const T;
-        simd_aware_read(base.add(index))
+        simd_aware_read_uninit(base.add(index))
     };
 
     // Seqlock re-check (Boehm): this Acquire fence pairs with the producer's
@@ -1550,10 +1554,14 @@ pub(super) fn recv_shm_pod_broadcast<
     // existed.
     fence(Ordering::Acquire);
     if ready_ptr.load(Ordering::Relaxed) != v1 {
-        // Overwritten mid-copy. Drop this read; the caller polls again. `msg` is
-        // a POD bitwise copy, so discarding it runs no destructor on torn bytes.
+        // Overwritten mid-copy. Drop the raw bytes; the caller polls again.
+        // `msg` is still `MaybeUninit`, so nothing is dropped and no invalid
+        // value is ever constructed.
         return None;
     }
+    // SAFETY: the stamp re-check above passed, so the slot was NOT overwritten
+    // during the copy and the bytes are the producer's fully-written value.
+    let msg = unsafe { msg.assume_init() };
 
     local.local_tail = tail.wrapping_add(1);
 

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -1009,12 +1009,115 @@ pub struct TopicSlotRead {
     pub topic_kind: u8,
 }
 
-/// Read the latest message payload from a topic's shared-memory backing file.
+/// A read-only view of a topic's shared region, opened the way the running
+/// platform actually backs it.
+///
+/// The path-based readers below address a topic by its `topic_shm_path`, which
+/// was correct back when every backend was a file: `/dev/shm/horus_<ns>/topics/
+/// <name>` on Linux, `/tmp/…` on macOS and on the generic fallback. The Windows
+/// backend is not a file at all — `ShmRegion::new` calls
+/// `CreateFileMappingW(INVALID_HANDLE_VALUE, …)`, a pagefile-backed section
+/// named `Local\horus_<name>`, and `ShmRegion::backing_path()` correspondingly
+/// reports `None` there. Nothing is ever created at the topic path, so
+/// `File::open` failed with `NotFound` and every reader here returned `None`
+/// for every live topic on Windows: `horus topic echo` and `horus topic hz`
+/// printed nothing and horus_net's SHM reader exported nothing, on a platform
+/// where the ring itself works — the cross-process half is fine there, it is
+/// only the region's *address* that differs.
+///
+/// The path stays the public address because it is the address wherever there
+/// is one, and it still *names* the topic where there is not: `topic_shm_path`
+/// is `<topics dir>/<name>`, so the name is recoverable from the path and the
+/// section can be opened by it.
+enum TopicRegion {
+    /// A file-backed region (Linux, macOS, the generic fallback), mapped
+    /// read-only.
+    Mapped(memmap2::Mmap),
+    /// A Windows named section. The handle is held for the life of the view.
+    #[cfg(target_os = "windows")]
+    Section(horus_sys::shm::ShmRegion),
+}
+
+impl std::ops::Deref for TopicRegion {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self {
+            Self::Mapped(mmap) => &mmap[..],
+            #[cfg(target_os = "windows")]
+            Self::Section(region) => region.as_slice(),
+        }
+    }
+}
+
+/// Map a topic's shared region read-only, or `None` when it is absent, too
+/// small to hold a header, or unmappable.
+///
+/// Every reader in this file goes through here, so the guarantee they all rely
+/// on is made once: the returned view is at least `TOPIC_HEADER_SIZE` bytes.
+///
+/// The file is tried first on every platform, because where one exists it *is*
+/// the region. Only when there is none does the Windows section lookup run, so
+/// nothing about the file-backed platforms changes.
+fn map_topic_region(path: &std::path::Path) -> Option<TopicRegion> {
+    use memmap2::MmapOptions;
+    use std::fs::File;
+
+    if let Ok(file) = File::open(path) {
+        if file.metadata().ok()?.len() < TOPIC_HEADER_SIZE as u64 {
+            return None;
+        }
+        // SAFETY: the file is opened read-only; the mapping is read-only.
+        let mmap = unsafe { MmapOptions::new().map(&file).ok()? };
+        return Some(TopicRegion::Mapped(mmap));
+    }
+
+    open_named_section(path)
+}
+
+/// Open the Windows named section a topic path refers to.
+///
+/// `topic_shm_path` is `shm_topics_dir().join(name)` and a topic name may
+/// itself contain separators, so the name is the whole remainder of the path
+/// rather than just its last component — `file_name()` on `robot/cmd_vel`
+/// would ask the kernel for a section called `cmd_vel`, which is either absent
+/// or, worse, a different topic.
+#[cfg(target_os = "windows")]
+fn open_named_section(path: &std::path::Path) -> Option<TopicRegion> {
+    let name = path
+        .strip_prefix(horus_sys::shm::shm_topics_dir())
+        .ok()?
+        .to_str()?;
+    let region = horus_sys::shm::ShmRegion::open_existing(name, TOPIC_HEADER_SIZE).ok()?;
+    // `open_existing` already refuses a region smaller than the minimum, but it
+    // falls back to *assuming* the minimum when `VirtualQuery` fails rather
+    // than measuring it. Re-check what we were actually handed, because the
+    // readers below index into it on the strength of that guarantee.
+    if region.len() < TOPIC_HEADER_SIZE {
+        return None;
+    }
+    Some(TopicRegion::Section(region))
+}
+
+/// Non-Windows counterpart of the section lookup: every other backend is
+/// file-backed, so a missing file is a missing topic and there is nowhere else
+/// to look.
+#[cfg(not(target_os = "windows"))]
+fn open_named_section(_path: &std::path::Path) -> Option<TopicRegion> {
+    None
+}
+
+/// Read the latest message payload from a topic's shared-memory region.
+///
+/// `path` is the topic's `topic_shm_path`. It is the backing file itself on
+/// Linux, macOS and the fallback backend; on Windows, where the region is a
+/// pagefile-backed named section with nothing on disk, it names the section
+/// instead.
 ///
 /// Returns `None` when:
-/// - `path` does not exist or cannot be opened,
-/// - the file is too small to contain a valid header,
-/// - the magic-number check fails (file not a HORUS topic),
+/// - no region exists at `path`, or it cannot be mapped,
+/// - the region is too small to contain a valid header,
+/// - the magic-number check fails (not a HORUS topic),
 /// - `write_idx == last_write_idx` (no new message since the previous call), or
 /// - `write_idx == 0` (no message has ever been written on this topic).
 ///
@@ -1044,17 +1147,10 @@ fn read_slot_inner(
     last_write_idx: u64,
     ordinal: Option<u64>,
 ) -> Option<TopicSlotRead> {
-    use memmap2::MmapOptions;
-    use std::fs::File;
-
-    // ── 1. Open and memory-map the file ──────────────────────────────────────
-    let file = File::open(path).ok()?;
-    let meta = file.metadata().ok()?;
-    if meta.len() < TOPIC_HEADER_SIZE as u64 {
-        return None;
-    }
-    // SAFETY: the file is opened read-only; the mapping is read-only.
-    let mmap = unsafe { MmapOptions::new().map(&file).ok()? };
+    // ── 1. Map the topic's shared region ─────────────────────────────────────
+    // File-backed on Linux/macOS, a named section on Windows; either way at
+    // least TOPIC_HEADER_SIZE bytes, which is what everything below assumes.
+    let mmap = map_topic_region(path)?;
     let base: *const u8 = mmap.as_ptr();
 
     // ── 2. Validate magic ─────────────────────────────────────────────────────
@@ -1337,16 +1433,7 @@ fn slot_stamp(
 /// rates without needing a typed `Topic<T>`.  Returns `None` when the file
 /// cannot be opened, is too small, or has an invalid magic number.
 pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
-    use memmap2::MmapOptions;
-    use std::fs::File;
-
-    let file = File::open(path).ok()?;
-    let meta = file.metadata().ok()?;
-    if meta.len() < TOPIC_HEADER_SIZE as u64 {
-        return None;
-    }
-    // SAFETY: the file is opened read-only; the mapping is read-only.
-    let mmap = unsafe { MmapOptions::new().map(&file).ok()? };
+    let mmap = map_topic_region(path)?;
     let base: *const u8 = mmap.as_ptr();
 
     // SAFETY: mmap is at least TOPIC_HEADER_SIZE (640) bytes.
@@ -1368,15 +1455,7 @@ pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
 /// (offset 56) which is atomically incremented on **every** send() regardless
 /// of backend type. Use this for accurate rate measurement.
 pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
-    use memmap2::MmapOptions;
-    use std::fs::File;
-
-    let file = File::open(path).ok()?;
-    let meta = file.metadata().ok()?;
-    if meta.len() < TOPIC_HEADER_SIZE as u64 {
-        return None;
-    }
-    let mmap = unsafe { MmapOptions::new().map(&file).ok()? };
+    let mmap = map_topic_region(path)?;
     let base: *const u8 = mmap.as_ptr();
 
     let magic = unsafe { std::ptr::read_unaligned(base as *const u64) };
@@ -1424,8 +1503,10 @@ pub struct TopicHeaderInfo {
 /// Callers comparing a type name against a header must compare *this*, not the
 /// full name. Doing otherwise reported a type as mismatching itself:
 ///
-///   Existing type 'ActionFeedback<CancelTopicFeedb',
-///   attempted 'ActionFeedback<CancelTopicFeedback>'
+/// ```text
+/// Existing type 'ActionFeedback<CancelTopicFeedb',
+/// attempted 'ActionFeedback<CancelTopicFeedback>'
+/// ```
 pub(crate) fn type_name_as_stored(name: &str) -> &str {
     const USABLE: usize = 31;
     if name.len() <= USABLE {
@@ -1439,16 +1520,7 @@ pub(crate) fn type_name_as_stored(name: &str) -> &str {
 }
 
 pub fn read_topic_header_info(path: &std::path::Path) -> Option<TopicHeaderInfo> {
-    use memmap2::MmapOptions;
-    use std::fs::File;
-
-    let file = File::open(path).ok()?;
-    let meta = file.metadata().ok()?;
-    if meta.len() < TOPIC_HEADER_SIZE as u64 {
-        return None;
-    }
-    // SAFETY: read-only mmap.
-    let mmap = unsafe { MmapOptions::new().map(&file).ok()? };
+    let mmap = map_topic_region(path)?;
     let base = mmap.as_ptr();
 
     // SAFETY: mmap >= TOPIC_HEADER_SIZE (640) bytes.
@@ -3663,6 +3735,6 @@ mod stored_type_name_tests {
         let name = format!("{}é", "a".repeat(30)); // 'é' straddles byte 30..32
         let stored = type_name_as_stored(&name);
         assert_eq!(stored, "a".repeat(30));
-        assert!(std::str::from_utf8(stored.as_bytes()).is_ok());
+        std::str::from_utf8(stored.as_bytes()).unwrap();
     }
 }

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -1228,10 +1228,27 @@ fn read_slot_inner(
         let data_len =
             unsafe { std::ptr::read_unaligned(mmap.as_ptr().add(len_offset) as *const u64) }
                 as usize;
-        if data_len == 0 || data_offset + data_len > mmap.len() {
+        // `data_offset + data_len` was computed twice, unchecked, on a length
+        // word taken straight out of the file — and release builds do not have
+        // `overflow-checks`. A length near `usize::MAX` wrapped the sum down to
+        // a small number, so `> mmap.len()` passed, and the slice expression
+        // below recomputed the same wrapped value into a range whose start was
+        // past its end: a panic on the reading thread of `horus topic echo` or
+        // horus_net's export reader, plantable by anyone who can write the file.
+        //
+        // `checked_add` removes the wrap. The payload is additionally bounded by
+        // the SLOT, not by the whole mapping, mirroring the writer's own limit
+        // in `write_topic_slot_bytes` — a length larger than a slot can hold was
+        // never written by us. `slot_size >= 16 > SERDE_SLOT_OVERHEAD` is
+        // guaranteed by the `slot_size < 16` check above, so the subtraction
+        // cannot underflow. `get(..)` makes any residual mismatch a `None`
+        // rather than a panic.
+        let max_payload = slot_size - super::shm_layout::SERDE_SLOT_OVERHEAD;
+        let end = data_offset.checked_add(data_len)?;
+        if data_len == 0 || data_len > max_payload || end > mmap.len() {
             return None;
         }
-        mmap[data_offset..data_offset + data_len].to_vec()
+        mmap.get(data_offset..end)?.to_vec()
     };
 
     // Read type_name from header (bytes 216-247, 32 bytes in cache line 4).
@@ -2815,6 +2832,68 @@ mod untrusted_header_tests {
         let path = tmp("bad_cap");
         write_header(&path, 7, 6, 8);
         assert!(read_latest_slot_bytes(&path, 0).is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Build a SERDE-layout topic file with one slot whose length word is
+    /// `data_len`.
+    ///
+    /// Serde slot layout: `[8B ready][8B len][data…]`.
+    fn write_serde_header(path: &std::path::Path, slot_size: u32, data_len: u64) {
+        let capacity: u32 = 1;
+        let total = TOPIC_HEADER_SIZE + (capacity as usize) * 8 + (capacity as usize) * (slot_size as usize);
+        let mut buf = vec![0u8; total];
+        buf[0..8].copy_from_slice(&TOPIC_MAGIC.to_ne_bytes());
+        buf[12..16].copy_from_slice(&8u32.to_ne_bytes()); // type_size (unused on the serde path)
+        buf[20] = POD_NO;
+        buf[56..64].copy_from_slice(&1u64.to_ne_bytes()); // messages_total = 1
+        buf[64..72].copy_from_slice(&1u64.to_ne_bytes()); // sequence_or_head = 1
+        buf[72..76].copy_from_slice(&capacity.to_ne_bytes());
+        buf[76..80].copy_from_slice(&(capacity - 1).to_ne_bytes()); // cap_mask
+        buf[80..84].copy_from_slice(&slot_size.to_ne_bytes());
+        let slot_start = TOPIC_HEADER_SIZE + (capacity as usize) * 8;
+        buf[slot_start + 8..slot_start + 16].copy_from_slice(&data_len.to_ne_bytes());
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&buf).unwrap();
+    }
+
+    /// The serde branch's bounds check was `data_offset + data_len > mmap.len()`,
+    /// computed on a length word taken straight out of the file with no
+    /// `overflow-checks` in release builds. A length near `usize::MAX` wrapped
+    /// the sum to a small number, the guard passed, and the slice expression
+    /// recomputed the same wrapped value — `mmap[656..400]`, a panic on the
+    /// reading thread of `horus topic echo`.
+    #[test]
+    fn a_wrapping_serde_length_is_rejected_not_sliced() {
+        let path = tmp("serde_len_overflow");
+        write_serde_header(&path, 64, 0xFFFF_FFFF_FFFF_FF00);
+        assert!(
+            read_latest_slot_bytes(&path, 0).is_none(),
+            "a length word that overflows the offset arithmetic must be refused"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A length that fits the mapping but not the SLOT is equally impossible to
+    /// have been written (`write_topic_slot_bytes` caps payloads at
+    /// `slot_size - SERDE_SLOT_OVERHEAD`), and would read a neighbouring slot's
+    /// bytes as if they were this message's.
+    #[test]
+    fn a_serde_length_larger_than_the_slot_is_rejected() {
+        let path = tmp("serde_len_over_slot");
+        // slot_size 64 => max payload 48.
+        write_serde_header(&path, 64, 60);
+        assert!(read_latest_slot_bytes(&path, 0).is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The bound must not reject a payload that really fits.
+    #[test]
+    fn a_serde_length_within_the_slot_still_reads() {
+        let path = tmp("serde_len_ok");
+        write_serde_header(&path, 64, 4);
+        let slot = read_latest_slot_bytes(&path, 0).expect("a well-formed serde slot must read");
+        assert_eq!(slot.payload.len(), 4);
         let _ = std::fs::remove_file(&path);
     }
 

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -669,7 +669,8 @@ impl TopicHeader {
 
         // Pass 1: genuinely free slots only. No counter decrement: nothing was
         // registered here.
-        if let Some(i) = self.claim_free_slot(role_bit, counter, pid, thread_hash, now_ms, timeout_ms)
+        if let Some(i) =
+            self.claim_free_slot(role_bit, counter, pid, thread_hash, now_ms, timeout_ms)
         {
             return Ok(i);
         }
@@ -677,7 +678,8 @@ impl TopicHeader {
         // Pass 2: nothing free — retire participants whose process is actually
         // gone (expired lease AND dead pid AND local AND not us), then rescan.
         self.reap_dead_participants(now_ms);
-        if let Some(i) = self.claim_free_slot(role_bit, counter, pid, thread_hash, now_ms, timeout_ms)
+        if let Some(i) =
+            self.claim_free_slot(role_bit, counter, pid, thread_hash, now_ms, timeout_ms)
         {
             return Ok(i);
         }
@@ -2841,7 +2843,9 @@ mod untrusted_header_tests {
     /// Serde slot layout: `[8B ready][8B len][data…]`.
     fn write_serde_header(path: &std::path::Path, slot_size: u32, data_len: u64) {
         let capacity: u32 = 1;
-        let total = TOPIC_HEADER_SIZE + (capacity as usize) * 8 + (capacity as usize) * (slot_size as usize);
+        let total = TOPIC_HEADER_SIZE
+            + (capacity as usize) * 8
+            + (capacity as usize) * (slot_size as usize);
         let mut buf = vec![0u8; total];
         buf[0..8].copy_from_slice(&TOPIC_MAGIC.to_ne_bytes());
         buf[12..16].copy_from_slice(&8u32.to_ne_bytes()); // type_size (unused on the serde path)

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -765,10 +765,11 @@ impl TopicHeader {
     /// * The lease must have expired. This is the cheap filter, and it keeps
     ///   the liveness probe off every participant that is still working.
     /// * The owning process must be gone. An expired lease on its own does NOT
-    ///   mean dead — leases are refreshed once every `LEASE_REFRESH_INTERVAL`
-    ///   (1024) messages, so a healthy 100 Hz subscriber refreshes about every
-    ///   10 s against a 5 s timeout and spends half its life looking expired.
-    ///   Reaping on the lease alone would deregister working subscribers.
+    ///   mean dead. Refresh is clock-gated at half the lease timeout, so a
+    ///   healthy participant stays ahead of expiry whatever its rate — but a
+    ///   participant that is simply idle (no send, no recv) reaches no refresh
+    ///   point at all and will read as expired while perfectly alive. Reaping
+    ///   on the lease alone would deregister it.
     ///
     /// Deliberately NOT reaped: our own process (we cannot tell a departed
     /// thread from a busy one, and `Drop` is the right place for that), and
@@ -2499,17 +2500,29 @@ mod tests {
             .store(1, Ordering::Relaxed); // expired long ago
         h.publisher_count.store(1, Ordering::Relaxed);
 
-        // Register from current thread — should evict the expired slot
+        // INVERTED. This used to assert the new registration took slot 0 — that
+        // an expired lease alone was licence to evict. It is not: a lease is
+        // refreshed by traffic, so a live-but-idle participant, or one whose
+        // refresh point has simply not come round, reads as expired while
+        // perfectly alive. Evicting it deregistered working publishers and
+        // subscribers, which is how `sub_count()` fell to zero under a live
+        // subscriber. Registration now takes a genuinely FREE slot first and
+        // leaves the expired entry alone; an expired slot is considered only
+        // when no free one remains, and then only if its owner is really gone.
         let slot = h.register_producer().unwrap();
-        assert_eq!(slot, 0, "Should reclaim expired slot 0");
-        assert_eq!(
-            h.pub_count(),
-            1,
-            "Old pub decremented, new pub incremented → still 1"
+        assert_ne!(
+            slot, 0,
+            "must not evict an expired slot while others are free"
         );
         assert_eq!(
             h.participants[0].pid.load(Ordering::Relaxed),
-            std::process::id()
+            99999,
+            "the expired participant must be left untouched"
+        );
+        assert_eq!(
+            h.participants[slot].pid.load(Ordering::Relaxed),
+            std::process::id(),
+            "the new producer owns the slot it actually claimed"
         );
     }
 

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -689,7 +689,6 @@ impl TopicHeader {
         // slot is never reclaimed by anything else — and the reaper skips our
         // own pid deliberately, because it cannot tell a departed thread from a
         // busy one. A foreign live pid is never stolen.
-        let me = std::process::id();
         for (i, p) in self.participants.iter().enumerate() {
             if p.active.load(Ordering::Acquire) != 1 {
                 continue;
@@ -697,7 +696,7 @@ impl TopicHeader {
             if !p.is_lease_expired(now_ms) {
                 continue;
             }
-            if p.source_host.load(Ordering::Acquire) != 0 || p.pid.load(Ordering::Acquire) != me {
+            if p.source_host.load(Ordering::Acquire) != 0 || p.pid.load(Ordering::Acquire) != pid {
                 continue;
             }
             if p.active

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -567,6 +567,64 @@ impl TopicHeader {
         self.register_role(2, &self.subscriber_count)
     }
 
+    /// Claim the first slot that is genuinely free (`active == 0`), if any.
+    ///
+    /// Split out of [`Self::register_role`] so the "take an empty seat" pass can
+    /// run twice — once before and once after reaping dead participants —
+    /// without duplicating the CAS protocol.
+    #[allow(clippy::too_many_arguments)]
+    fn claim_free_slot(
+        &self,
+        role_bit: u8,
+        counter: &AtomicU32,
+        pid: u32,
+        thread_hash: u32,
+        now_ms: u64,
+        timeout_ms: u64,
+    ) -> Option<usize> {
+        for (i, p) in self.participants.iter().enumerate() {
+            if p.active.load(Ordering::Acquire) != 0 {
+                continue;
+            }
+            // CAS 0 -> 2 (initializing): exactly one thread wins per slot.
+            if p.active
+                .compare_exchange(0, 2, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                continue;
+            }
+            self.finish_claim(p, role_bit, counter, pid, thread_hash, now_ms, timeout_ms);
+            return Some(i);
+        }
+        None
+    }
+
+    /// Populate a slot this thread has already CAS'd to the initializing
+    /// sentinel (2), and publish it as active.
+    #[allow(clippy::too_many_arguments)]
+    fn finish_claim(
+        &self,
+        p: &ParticipantEntry,
+        role_bit: u8,
+        counter: &AtomicU32,
+        pid: u32,
+        thread_hash: u32,
+        now_ms: u64,
+        timeout_ms: u64,
+    ) {
+        p.pid.store(pid, Ordering::Release);
+        p.thread_id_hash.store(thread_hash, Ordering::Release);
+        p.role.store(role_bit, Ordering::Release);
+        p.refresh_lease(now_ms, timeout_ms);
+        counter.fetch_add(1, Ordering::AcqRel);
+        self.total_participants.fetch_add(1, Ordering::AcqRel);
+        self.last_topology_change_ms
+            .store(now_ms, Ordering::Release);
+        // Finalize: transition from initializing (2) to active (1).
+        // This makes the slot visible with all fields properly set.
+        p.active.store(1, Ordering::Release);
+    }
+
     /// Shared registration logic for producer (role_bit=1) and consumer (role_bit=2).
     fn register_role(&self, role_bit: u8, counter: &AtomicU32) -> HorusResult<usize> {
         let now_ms = current_time_ms();
@@ -591,61 +649,81 @@ impl TopicHeader {
             }
         }
 
-        // Find empty slot or expired lease.
+        // Find a slot, in three passes of decreasing safety.
+        //
+        // This used to be a single scan that claimed the first slot that was
+        // either free OR merely lease-expired, in index order. An expired lease
+        // does NOT mean the owner is gone: leases are refreshed on a message
+        // count, so an idle or slow subscriber spends much of its life looking
+        // expired (`reap_dead_participants` documents exactly this, and refuses
+        // to reap on the lease alone for that reason). The old scan therefore
+        // preferred stealing slot 0 from a live, polling subscriber over taking
+        // one of the free slots behind it — it decremented `subscriber_count`
+        // for a participant that was still reading, after which
+        // `nothing_is_draining` saw `sub_count() == 0` and let the producer
+        // retire unread slots. Silent message loss, with no counter to show it.
         //
         // We use active=2 as an "initializing" sentinel so that a freshly
         // claimed slot (whose lease_expires_ms is still 0) is not mistaken
         // for an expired slot by another thread.
+
+        // Pass 1: genuinely free slots only. No counter decrement: nothing was
+        // registered here.
+        if let Some(i) = self.claim_free_slot(role_bit, counter, pid, thread_hash, now_ms, timeout_ms)
+        {
+            return Ok(i);
+        }
+
+        // Pass 2: nothing free — retire participants whose process is actually
+        // gone (expired lease AND dead pid AND local AND not us), then rescan.
+        self.reap_dead_participants(now_ms);
+        if let Some(i) = self.claim_free_slot(role_bit, counter, pid, thread_hash, now_ms, timeout_ms)
+        {
+            return Ok(i);
+        }
+
+        // Pass 3, last resort: a stale entry belonging to a thread of THIS
+        // process. `Drop for Topic` does not deregister, so a finished thread's
+        // slot is never reclaimed by anything else — and the reaper skips our
+        // own pid deliberately, because it cannot tell a departed thread from a
+        // busy one. A foreign live pid is never stolen.
+        let me = std::process::id();
         for (i, p) in self.participants.iter().enumerate() {
-            let active_val = p.active.load(Ordering::Acquire);
-            if active_val == 2 {
-                continue; // Another thread is initializing this slot
+            if p.active.load(Ordering::Acquire) != 1 {
+                continue;
             }
-            let is_active = active_val != 0;
-            let is_expired = is_active && p.is_lease_expired(now_ms);
-
-            if !is_active || is_expired {
-                // Try to claim the slot via CAS → 2 (initializing).
-                // Exactly one thread wins per slot.
-                let claimed = p
-                    .active
-                    .compare_exchange(active_val, 2, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok();
-
-                if claimed {
-                    // Now that we own the slot, safely decrement the old role counters.
-                    //
-                    // Saturating, because these counters live in shared memory
-                    // that any participant may have been killed in the middle
-                    // of writing: an unmatched `fetch_sub` on a zero counter
-                    // wraps to 4 billion, and every consumer of `sub_count()`
-                    // then believes the topic has four billion subscribers
-                    // forever. There is no honest recovery from that, so the
-                    // floor is enforced at the one place the decrement happens.
-                    if is_expired {
-                        let old_role = p.role.load(Ordering::Acquire);
-                        if old_role & 1 != 0 {
-                            decrement_to_floor(&self.publisher_count);
-                        }
-                        if old_role & 2 != 0 {
-                            decrement_to_floor(&self.subscriber_count);
-                        }
-                    }
-
-                    p.pid.store(pid, Ordering::Release);
-                    p.thread_id_hash.store(thread_hash, Ordering::Release);
-                    p.role.store(role_bit, Ordering::Release);
-                    p.refresh_lease(now_ms, timeout_ms);
-                    counter.fetch_add(1, Ordering::AcqRel);
-                    self.total_participants.fetch_add(1, Ordering::AcqRel);
-                    self.last_topology_change_ms
-                        .store(now_ms, Ordering::Release);
-                    // Finalize: transition from initializing (2) to active (1).
-                    // This makes the slot visible with all fields properly set.
-                    p.active.store(1, Ordering::Release);
-                    return Ok(i);
-                }
+            if !p.is_lease_expired(now_ms) {
+                continue;
             }
+            if p.source_host.load(Ordering::Acquire) != 0 || p.pid.load(Ordering::Acquire) != me {
+                continue;
+            }
+            if p.active
+                .compare_exchange(1, 2, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                continue; // Someone else got there first.
+            }
+
+            // Now that we own the slot, safely decrement the old role counters.
+            //
+            // Saturating, because these counters live in shared memory
+            // that any participant may have been killed in the middle
+            // of writing: an unmatched `fetch_sub` on a zero counter
+            // wraps to 4 billion, and every consumer of `sub_count()`
+            // then believes the topic has four billion subscribers
+            // forever. There is no honest recovery from that, so the
+            // floor is enforced at the one place the decrement happens.
+            let old_role = p.role.load(Ordering::Acquire);
+            if old_role & 1 != 0 {
+                decrement_to_floor(&self.publisher_count);
+            }
+            if old_role & 2 != 0 {
+                decrement_to_floor(&self.subscriber_count);
+            }
+
+            self.finish_claim(p, role_bit, counter, pid, thread_hash, now_ms, timeout_ms);
+            return Ok(i);
         }
 
         // All 16 participant slots occupied by live processes.

--- a/horus_core/src/communication/topic/local_state.rs
+++ b/horus_core/src/communication/topic/local_state.rs
@@ -9,9 +9,13 @@ use super::types::{BackendMode, TopicRole};
 /// Default serialized message slot size (8KB)
 pub(crate) const DEFAULT_SLOT_SIZE: usize = 8 * 1024;
 
-/// Lease refresh interval - refresh every N messages instead of every message
-/// This avoids calling SystemTime::now() syscall on the hot path
-pub(crate) const LEASE_REFRESH_INTERVAL: u32 = 1024;
+// `LEASE_REFRESH_INTERVAL` (1024 messages) lived here. Lease refresh is no
+// longer driven by a message count at all: refreshing strictly every N messages
+// made liveness a function of throughput, so a healthy but slow participant
+// spent most of its life looking expired to the reaper. It is now gated on the
+// wall clock in `RingTopic::refresh_lease_if_due`, which fires at half the
+// lease timeout regardless of rate; `dispatch::LEASE_CHECK_INTERVAL` only keeps
+// the clock read off the per-message hot path.
 
 /// Epoch check interval — reads migration_epoch from SHM header every N messages.
 /// Must be a power of two (used with bitmask).

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -608,17 +608,38 @@ unsafe fn simd_aware_write<T>(dst: *mut T, msg: T) {
 /// `src` must be valid for reads of `size_of::<T>()` bytes and properly aligned.
 #[inline(always)]
 unsafe fn simd_aware_read<T>(src: *const T) -> T {
+    simd_aware_read_uninit(src).assume_init()
+}
+
+/// Copy a slot's bytes out WITHOUT asserting they are a valid `T`.
+///
+/// The seqlock consumers copy a slot that a lapping producer may be
+/// overwriting, then re-check the slot stamp and discard the copy if it was.
+/// Discarding is not enough on its own: producing a `T` from torn bytes is
+/// already undefined behaviour at the moment of materialisation — a `bool` that
+/// reads back as `0x02`, or an enum discriminant out of range, is UB before any
+/// re-check can reject it (see the `is_pod` heuristic in `communication::pod`,
+/// which admits structs containing such fields). Keeping the copy as
+/// `MaybeUninit<T>` until *after* the stamp re-check closes that window: torn
+/// bytes are dropped as raw memory and never become a `T`.
+///
+/// # Safety
+/// `src` must be valid for reads of `size_of::<T>()` bytes and properly aligned.
+/// The caller must only `assume_init()` the result once it has established that
+/// the bytes are a valid, fully-written `T`.
+#[inline(always)]
+unsafe fn simd_aware_read_uninit<T>(src: *const T) -> mem::MaybeUninit<T> {
+    let mut msg = mem::MaybeUninit::<T>::uninit();
     if mem::size_of::<T>() >= SIMD_COPY_THRESHOLD {
-        let mut msg = mem::MaybeUninit::<T>::uninit();
         simd_copy_from_shm(
             src as *const u8,
             msg.as_mut_ptr() as *mut u8,
             mem::size_of::<T>(),
         );
-        msg.assume_init()
     } else {
-        std::ptr::read(src)
+        std::ptr::copy_nonoverlapping(src as *const u8, msg.as_mut_ptr() as *mut u8, mem::size_of::<T>());
     }
+    msg
 }
 
 // ============================================================================

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -33,9 +33,21 @@
 //!
 //! ### Thread-Ownership Contract
 //!
-//! Each `Topic<T>` instance must be used from exactly **one thread**. The type
-//! is `!Send` and `!Sync` by design (contains `UnsafeCell`, raw pointers, and
-//! `Cell`-based local state). This single-thread-per-instance contract enables:
+//! Each `Topic<T>` instance must be used from exactly **one thread at a time**.
+//! The type is `Send` — an owned handle may be moved to another thread, and
+//! `Clone` hands the new thread its own independent state — but it is
+//! deliberately **not** `Sync`: it holds `UnsafeCell`, raw pointers, and
+//! `Cell`-based local state that no lock or atomic protects.
+//!
+//! This paragraph used to claim the type was `!Send` and `!Sync` "by design"
+//! while hand-written `unsafe impl Sync` blocks on `Topic` and `RingTopic`
+//! said the opposite, so safe code could share one `&Topic` across threads and
+//! race the unsynchronised state with no `unsafe` of its own. Those impls are
+//! gone; sharing one handle now requires an explicit lock
+//! (`Mutex<Topic<T>>` — an `RwLock` read guard is NOT enough, it hands out
+//! concurrent `&Topic`) or a per-thread `Clone`.
+//!
+//! This single-thread-per-instance contract enables:
 //!
 //! - **Unsynchronized local state**: `LocalState` uses `Cell` for cached head/tail,
 //!   role tracking, and epoch caching — no atomic overhead on the hot path.
@@ -721,21 +733,21 @@ pub(crate) struct RingTopic<T> {
 // another thread transfers exclusive ownership of its per-instance state.
 unsafe impl<T: Send> Send for RingTopic<T> {}
 
-// SAFETY (Sync): Required so Arc<Topic<T>> can be Send (used in services/actions).
+// There is deliberately NO `Sync` impl here.
 //
-// INVARIANT: Callers must NOT share a single &RingTopic across threads. Each
-// thread must use its own Clone. The UnsafeCell fields (backend, send_fn, recv_fn,
-// local, spill_pool) have NO synchronization — concurrent &self access from
-// multiple threads is UB. The Sync impl is sound only because:
-// 1. Clone creates independent UnsafeCell state (not shared aliases)
-// 2. Shared fields (storage: Arc<ShmRegion>, metrics: Arc<MigrationMetrics>,
-//    process_epoch: Arc<AtomicU64>) use Arc/atomics which are truly Sync
-// 3. All cross-thread usage in the codebase wraps Topic in Arc<RwLock<..>>
+// There used to be one, justified as "required so Arc<Topic<T>> can be Send",
+// with an INVARIANT comment stating that callers must not share a single
+// `&RingTopic` across threads — an invariant the impl itself made
+// unenforceable. `send`/`recv`/`try_send`/`try_recv` all take `&self` and then
+// read-modify-write `local.local_head`, `local.local_tail`, `local.msg_counter`
+// and the cached pointers behind `UnsafeCell`, none of it synchronised, so two
+// threads holding `&Topic` from one `Arc` raced on plain fields — a data race,
+// UB, with no `unsafe` anywhere in the caller. The `Cell`/`UnsafeCell` fields
+// make both types `!Sync` on their own; letting them do so is the fix.
 //
-// TODO: Consider wrapping RingTopic in a newtype that enforces single-thread
-// access and only exposes Arc<Newtype> for cross-thread sharing, eliminating
-// the need for this Sync impl.
-unsafe impl<T: Send + Sync> Sync for RingTopic<T> {}
+// To share one handle, wrap it in an EXCLUSIVE lock (`Mutex<Topic<T>>`; an
+// `RwLock` read guard hands out concurrent `&Topic` and does not satisfy this),
+// or give each thread its own `Clone`, which gets independent local state.
 
 #[allow(private_interfaces)]
 /// Where a consumer's read position lands after a migration resync.
@@ -1131,8 +1143,21 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
             ));
         }
 
-        // Size validation — skip for GenericMessage (variable-size serde container)
-        if !is_generic && is_pod && header.type_size != type_size {
+        // Size validation.
+        //
+        // Deliberately NOT exempt for GenericMessage, unlike the type-NAME check
+        // above. The POD data path addresses slots as
+        // `(cached_data_ptr as *mut T).add(index)` (dispatch.rs), so its stride
+        // is `size_of::<T>()` — it must equal the creator's `type_size` no matter
+        // what the type names say, and a name-based exemption cannot make two
+        // different strides agree. `GenericMessage` is itself POD-classified
+        // (fixed array, no Drop), so the old exemption let a
+        // `Topic<GenericMessage>` (4364 bytes) join a `Topic<CmdVel>` ring
+        // (8 bytes) and write megabytes past the end of the mapping. The header
+        // side of the test matters too: `sync_local` adopts `header.is_pod_type()`
+        // for dispatch selection, so either side being POD puts a raw stride on
+        // this ring.
+        if (is_pod || header.is_pod_type()) && header.type_size != type_size {
             return Err(HorusError::Communication(
                 crate::error::CommunicationError::TopicCreationFailed {
                     topic: name.to_string(),
@@ -2691,7 +2716,9 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> Clone for 
             state: AtomicU8::new(self.state.load(Ordering::Relaxed)),
             // Clone shares the spill pool if one was already created
             spill_pool: std::cell::UnsafeCell::new(
-                // SAFETY: single-thread access (Topic is !Sync for mutation)
+                // SAFETY: `RingTopic` has no `Sync` impl, so `&self` here can
+                // only be held by one thread — this shared borrow of the
+                // `UnsafeCell` cannot alias a concurrent `&mut` from another.
                 unsafe { &*self.spill_pool.get() }.clone(),
             ),
             _marker: PhantomData,
@@ -2807,10 +2834,26 @@ pub struct Topic<T: TopicMessage> {
     last_sent_keepalive: std::cell::Cell<Option<(Arc<TensorPool>, Tensor, Option<Tensor>)>>,
 }
 
-// Safety: Topic delegates to RingTopic which handles synchronization.
-// The pool field is Arc (Send+Sync).
+// SAFETY (Send): an owned `Topic` carries its `RingTopic` (itself `Send`) plus
+// `Cell` state that only this handle touches; the `pool` field is an `Arc`
+// (Send+Sync). Moving the whole handle transfers that state exclusively.
 unsafe impl<T: TopicMessage> Send for Topic<T> where T::Wire: Send {}
-unsafe impl<T: TopicMessage> Sync for Topic<T> where T::Wire: Send + Sync {}
+
+// No `Sync` impl, for the same reason as `RingTopic` above: `send`/`recv` take
+// `&self` and mutate `registered_pub`/`registered_sub`/`owner_attempts` and the
+// `last_sent_keepalive` `Cell`. Two threads sharing one `&Topic<Image>` could
+// both `Cell::replace` the same keep-alive tuple and release the pool slot
+// twice — a use-after-free of shared-memory the subscribers are still reading.
+// `Cell` makes `Topic` `!Sync` all by itself.
+
+// Compile-time guard: `Topic` must stay `Send` (owned handles move between
+// threads all over the tree) even though it is no longer `Sync`. If a future
+// field silently takes `Send` away, this fails to compile here rather than at
+// the far end of a `thread::spawn` in a downstream crate.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<Topic<u64>>();
+};
 
 /// Release a keep-alive tuple `(pool, primary, secondary)` on its own stored
 /// pool. Safe against the drop-oldest ABA: `release` generation-checks and

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -1554,6 +1554,37 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
         }
     }
 
+    /// Refresh this participant's lease only once it is past the halfway point
+    /// to expiry.
+    ///
+    /// The lease used to be refreshed purely on a message count (once every
+    /// 1024 messages), which made liveness a function of throughput rather than
+    /// of time: a 100 Hz subscriber refreshed about every 10 s against a 5 s
+    /// timeout and spent half its life *looking* expired, and a subscriber that
+    /// had not received anything yet never refreshed at all. Everything that
+    /// reads the participant table — `sub_count()`, `detect_optimal_backend`,
+    /// and (before it was fixed) slot reclamation in `register_role` — was then
+    /// making decisions about a live participant it believed was gone.
+    ///
+    /// Callers still gate this behind a small message counter so the clock read
+    /// stays off the per-message hot path; the wall-clock test here is what
+    /// decides whether the store actually happens.
+    #[inline]
+    fn refresh_lease_if_due(&self) {
+        let local = self.local();
+        if local.slot_index < 0 {
+            return;
+        }
+        let header = self.header();
+        let entry = &header.participants[local.slot_index as usize];
+        let timeout = header.lease_timeout();
+        let expires = entry.lease_expires_ms.load(Ordering::Acquire);
+        let now = current_time_ms();
+        if expires == 0 || now.saturating_add(timeout / 2) >= expires {
+            entry.refresh_lease(now, timeout);
+        }
+    }
+
     /// Initialize or re-initialize the per-path optimized backend based on current mode.
     ///
     /// Every topic is SHM-backed, so this creates (or restores) an ShmData backend

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -1606,7 +1606,7 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
         let expires = entry.lease_expires_ms.load(Ordering::Acquire);
         let now = current_time_ms();
         if expires == 0 || now.saturating_add(timeout / 2) >= expires {
-            entry.refresh_lease(now, timeout);
+            self.refresh_lease();
         }
     }
 

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -637,7 +637,11 @@ unsafe fn simd_aware_read_uninit<T>(src: *const T) -> mem::MaybeUninit<T> {
             mem::size_of::<T>(),
         );
     } else {
-        std::ptr::copy_nonoverlapping(src as *const u8, msg.as_mut_ptr() as *mut u8, mem::size_of::<T>());
+        std::ptr::copy_nonoverlapping(
+            src as *const u8,
+            msg.as_mut_ptr() as *mut u8,
+            mem::size_of::<T>(),
+        );
     }
     msg
 }

--- a/horus_core/src/communication/topic/shm_fanout.rs
+++ b/horus_core/src/communication/topic/shm_fanout.rs
@@ -574,7 +574,7 @@ impl ShmFanoutRing {
             }
             std::hint::spin_loop();
             spins += 1;
-            if spins % SPINS_PER_CLOCK_CHECK == 0 && started.elapsed() >= ATTACH_TIMEOUT {
+            if spins.is_multiple_of(SPINS_PER_CLOCK_CHECK) && started.elapsed() >= ATTACH_TIMEOUT {
                 // The owner is never going to finish. Let the caller fall back.
                 return None;
             }

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -4155,16 +4155,24 @@ fn expired_slot_reclaimed_by_new_registration() {
         .store(current_time_ms().saturating_sub(5000), Ordering::Release); // expired 5s ago
     h.publisher_count.store(1, Ordering::Release);
 
-    // New producer registration should reclaim the expired slot
-    let slot = h.register_producer().expect("should reclaim expired slot");
-    assert_eq!(slot, 0, "Should reclaim slot 0 (the expired one)");
-    // Publisher count should remain 1 (decremented old, incremented new)
-    assert_eq!(h.pub_count(), 1);
-    // Verify the slot now has our PID
+    // INVERTED, for the reason spelled out on the twin test in header.rs: an
+    // expired lease is not on its own evidence that a participant is gone.
+    // Leases are refreshed by traffic, so an idle-but-live participant reads as
+    // expired, and evicting it silently deregistered working publishers and
+    // subscribers. A new registration must take a free slot while one exists.
+    let slot = h
+        .register_producer()
+        .expect("a free slot is available, so registration must succeed");
+    assert_ne!(slot, 0, "must not evict slot 0 while free slots remain");
     assert_eq!(
         p.pid.load(Ordering::Acquire),
+        99999,
+        "the expired participant must be left alone"
+    );
+    assert_eq!(
+        h.participants[slot].pid.load(Ordering::Acquire),
         std::process::id(),
-        "Reclaimed slot should have our PID"
+        "the new producer owns the slot it claimed"
     );
 }
 
@@ -4964,9 +4972,11 @@ fn rapid_topology_changes_detected_via_check() {
     }
 }
 
-/// Housekeeping fires after LEASE_REFRESH_INTERVAL (1024) messages on SpscShm.
+/// Housekeeping survives a long send/recv run on SpscShm.
 /// Verified by sending >1024 messages with periodic drain (ring capacity = 512).
-/// In a real robot, lease refresh happens ~once per second at 1kHz.
+/// Lease refresh itself is clock-gated now, so this no longer asserts a
+/// message-count boundary — it asserts the housekeeping path stays healthy
+/// across the volume that used to trigger it.
 #[test]
 fn housekeeping_fires_after_lease_refresh_interval() {
     let name = unique("hkeep_lease");
@@ -8975,13 +8985,16 @@ fn local_state_default_slot_size_is_8kb() {
     assert_eq!(local_state::DEFAULT_SLOT_SIZE, 8 * 1024);
 }
 
-/// LEASE_REFRESH_INTERVAL and EPOCH_CHECK_INTERVAL have expected values.
+/// EPOCH_CHECK_INTERVAL has its expected value and is a power of two — the
+/// housekeeping macros gate on it with a bitmask, so a non-power-of-two would
+/// silently never fire.
+///
+/// The `LEASE_REFRESH_INTERVAL` assertions that used to sit here are gone with
+/// the constant: lease refresh is clock-gated now, not counted.
 #[test]
 fn local_state_constants() {
-    assert_eq!(local_state::LEASE_REFRESH_INTERVAL, 1024);
     assert_eq!(local_state::EPOCH_CHECK_INTERVAL, 4);
     assert!(local_state::EPOCH_CHECK_INTERVAL.is_power_of_two());
-    assert!(local_state::LEASE_REFRESH_INTERVAL.is_power_of_two());
 }
 
 /// LocalState fields can be mutated directly.
@@ -9027,25 +9040,24 @@ fn local_state_epoch_staleness_detection() {
     assert!(is_stale3, "epoch 1 should be stale vs header epoch 2");
 }
 
-/// LocalState msg_counter wraps correctly for lease refresh checks.
+/// LocalState msg_counter is a plain wrapping counter.
+///
+/// This replaces `local_state_msg_counter_lease_refresh_boundary`, which
+/// asserted that `msg_counter % LEASE_REFRESH_INTERVAL == 0` triggered a lease
+/// refresh. That mechanism is gone — refresh is decided by the wall clock in
+/// `refresh_lease_if_due` — so the test was pinning behaviour the code no
+/// longer has. What still matters is that the counter wraps rather than
+/// overflowing, since the housekeeping macros mask it.
 #[test]
-fn local_state_msg_counter_lease_refresh_boundary() {
+fn local_state_msg_counter_wraps_without_overflow() {
     let mut ls = local_state::LocalState::default();
-
-    // Simulate counting up to lease refresh interval
-    for _ in 0..local_state::LEASE_REFRESH_INTERVAL {
-        ls.msg_counter = ls.msg_counter.wrapping_add(1);
-    }
-    assert_eq!(ls.msg_counter, local_state::LEASE_REFRESH_INTERVAL);
-
-    // Check modulo-based refresh trigger
-    let should_refresh = ls.msg_counter % local_state::LEASE_REFRESH_INTERVAL == 0;
-    assert!(should_refresh);
-
-    // One more message — should NOT trigger
+    ls.msg_counter = u32::MAX;
     ls.msg_counter = ls.msg_counter.wrapping_add(1);
-    let should_refresh2 = ls.msg_counter % local_state::LEASE_REFRESH_INTERVAL == 0;
-    assert!(!should_refresh2);
+    assert_eq!(ls.msg_counter, 0, "msg_counter must wrap, not overflow");
+
+    // The epoch gate is a bitmask on this counter, so wrapping must land it
+    // back on a firing boundary rather than skipping one.
+    assert_eq!(ls.msg_counter & (local_state::EPOCH_CHECK_INTERVAL - 1), 0);
 }
 
 // ============================================================================

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -9961,10 +9961,18 @@ fn e2e_registry_write_read_roundtrip() {
     let reg_name = unique("e2e_reg");
     let reg = SchedulerRegistry::open(&reg_name).expect("open registry");
 
-    // Register 3 nodes
-    let idx0 = reg.register_node("motor", 0, 100.0, 0);
-    let idx1 = reg.register_node("sensor", 1, 200.0, 1);
-    let _idx2 = reg.register_node("planner", 5, 10.0, 2);
+    // Register 3 nodes. `register_node` returns Option since overflow past
+    // MAX_REGISTRY_NODES yields None rather than aliasing the last slot; three
+    // nodes in a fresh registry always fit, so unwrapping asserts exactly that.
+    let idx0 = reg
+        .register_node("motor", 0, 100.0, 0)
+        .expect("registry not full");
+    let idx1 = reg
+        .register_node("sensor", 1, 200.0, 1)
+        .expect("registry not full");
+    let _idx2 = reg
+        .register_node("planner", 5, 10.0, 2)
+        .expect("registry not full");
 
     // Update with different metrics
     reg.update_node(idx0, 0, 10000, 0, 0, 0, 0, 800_000, 750_000, 1_500_000, 0);

--- a/horus_core/src/core/node.rs
+++ b/horus_core/src/core/node.rs
@@ -52,7 +52,7 @@ impl LogSummary for crate::types::Tensor {
         format!(
             "Tensor([{}], dtype={:?}, device={}, pool={}/slot={})",
             shape_str.join(", "),
-            self.dtype,
+            self.dtype(),
             self.device(),
             self.pool_id,
             self.slot_id

--- a/horus_core/src/drivers/exec_driver.rs
+++ b/horus_core/src/drivers/exec_driver.rs
@@ -53,6 +53,11 @@ pub struct ExecDriver {
     name: String,
     restart_count: u32,
     started: bool,
+    /// When the next restart attempt becomes due. `tick()` used to `sleep()` the
+    /// backoff inline, which blocks the whole executor thread — every RT node
+    /// sharing that thread misses its deadline for the full delay, up to 30 s.
+    /// The backoff is a deadline now, so `tick()` always returns promptly.
+    next_restart_at: Option<Instant>,
 }
 
 impl ExecDriver {
@@ -64,6 +69,7 @@ impl ExecDriver {
             name: name.into(),
             restart_count: 0,
             started: false,
+            next_restart_at: None,
         }
     }
 
@@ -216,10 +222,40 @@ impl crate::core::Node for ExecDriver {
         if !self.started {
             return;
         }
-        if !self.check_health() && self.restart_count < self.config.max_retries {
+        if self.check_health() {
+            return;
+        }
+
+        // A restart is already scheduled: return immediately until it is due.
+        // This used to be `std::thread::sleep(delay)` right here, on the shared
+        // executor thread, so a flapping device stalled every co-scheduled node
+        // for up to 30 s at a time.
+        if let Some(at) = self.next_restart_at {
+            if Instant::now() < at {
+                return;
+            }
+            self.next_restart_at = None;
+            if let Err(e) = self.launch() {
+                tracing::error!("Exec driver '{}' restart failed: {}", self.name, e);
+            }
+            return;
+        }
+
+        if self.restart_count < self.config.max_retries {
             self.restart_count += 1;
-            let delay = self.config.restart_delay_ms * 2u64.pow(self.restart_count - 1);
-            let delay = delay.min(30_000); // cap at 30s
+            // Clamp the shift BEFORE multiplying. `max_retries` and
+            // `restart_delay_ms` both come straight from horus.toml, so the old
+            // `restart_delay_ms * 2u64.pow(restart_count - 1)` overflowed for a
+            // large-but-plausible `max_retries`: a panic inside tick() in debug,
+            // and in release a wrap to ~0 that turned the backoff into an
+            // unthrottled respawn loop — the exact opposite of the 30 s cap the
+            // comment promised, because `.min(30_000)` was applied too late.
+            let shift = (self.restart_count - 1).min(20);
+            let delay = self
+                .config
+                .restart_delay_ms
+                .saturating_mul(1u64 << shift)
+                .min(30_000);
             tracing::warn!(
                 "Exec driver '{}' crashed, restarting (attempt {}/{}, delay {}ms)",
                 self.name,
@@ -227,14 +263,13 @@ impl crate::core::Node for ExecDriver {
                 self.config.max_retries,
                 delay,
             );
-            std::thread::sleep(Duration::from_millis(delay));
-            if let Err(e) = self.launch() {
-                tracing::error!("Exec driver '{}' restart failed: {}", self.name, e);
-            }
+            self.next_restart_at = Some(Instant::now() + Duration::from_millis(delay));
         }
     }
 
     fn shutdown(&mut self) -> crate::error::Result<()> {
+        // No pending restart survives shutdown.
+        self.next_restart_at = None;
         if let Some(ref mut child) = self.child {
             tracing::info!(
                 "Shutting down exec driver '{}' (PID: {})...",
@@ -343,5 +378,46 @@ mod tests {
         driver.restart_count = 2;
         // At max retries, tick should not increment further
         assert!(driver.restart_count >= driver.config.max_retries);
+    }
+
+    /// Regression: `tick()` must never sleep the executor thread, and the 30 s
+    /// cap must hold for any `max_retries` an operator can put in horus.toml.
+    /// The old code computed `restart_delay_ms * 2u64.pow(restart_count - 1)`
+    /// and only THEN applied `.min(30_000)`, so the multiply overflowed (panic
+    /// in debug, wrap-to-zero in release) well before the cap could apply.
+    #[test]
+    fn restart_backoff_is_non_blocking_and_cannot_overflow() {
+        let config = ExecDriverConfig {
+            path: PathBuf::from("/nonexistent/horus_exec_driver_test_binary"),
+            max_retries: 100,
+            restart_delay_ms: 1000,
+            ..Default::default()
+        };
+        let mut driver = ExecDriver::new("test", config);
+        driver.started = true;
+        // 1000 * 2^79 in the old expression — far past u64::MAX.
+        driver.restart_count = 80;
+
+        let start = Instant::now();
+        driver.tick();
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "tick must schedule the backoff, not sleep through it"
+        );
+        assert_eq!(driver.restart_count, 81);
+        let at = driver
+            .next_restart_at
+            .expect("a crashed driver must have a restart scheduled");
+        assert!(
+            at <= Instant::now() + Duration::from_millis(30_000),
+            "backoff must stay capped at 30s regardless of retry count"
+        );
+
+        // Not yet due: the next tick returns without stacking another attempt.
+        driver.tick();
+        assert_eq!(
+            driver.restart_count, 81,
+            "a pending restart must not accumulate further attempts"
+        );
     }
 }

--- a/horus_core/src/error.rs
+++ b/horus_core/src/error.rs
@@ -731,7 +731,7 @@ pub enum HorusError {
     /// Error with preserved source chain for context propagation.
     /// Use `.horus_context()` on Results to create these.
     ///
-    /// Rendered by [`fmt_contextual`], which suppresses the `Caused by:` clause
+    /// Rendered by `fmt_contextual`, which suppresses the `Caused by:` clause
     /// when it would only restate the message the user has already read.
     #[error(fmt = fmt_contextual)]
     Contextual {

--- a/horus_core/src/memory/rt_allocator.rs
+++ b/horus_core/src/memory/rt_allocator.rs
@@ -62,6 +62,31 @@ pub fn leave_rt_context() {
     RT_NODE_NAME.with(|c| c.set(None));
 }
 
+/// Leaves the RT allocation-free context on drop — including when `tick()`
+/// unwinds.
+///
+/// The executors used to call [`leave_rt_context`] on the straight-line path
+/// after `tick()`, so a panicking tick skipped it: the thread was left with the
+/// RT flag set and, worse, with `RT_NODE_NAME` still holding a raw pointer into
+/// a `&str` whose borrow window had closed. Bracket the tick with this guard
+/// instead and both are cleared on either exit.
+pub struct RtContextGuard(());
+
+impl Drop for RtContextGuard {
+    fn drop(&mut self) {
+        leave_rt_context();
+    }
+}
+
+/// Enter the RT allocation-free context, leaving it when the guard is dropped.
+///
+/// Prefer this over the bare [`enter_rt_context`] / [`leave_rt_context`] pair:
+/// see [`RtContextGuard`] for what the straight-line pair leaks on an unwind.
+pub fn enter_rt_context_guarded(node_name: &str) -> RtContextGuard {
+    enter_rt_context(node_name);
+    RtContextGuard(())
+}
+
 /// Read the current RT node's name from the borrowed pointer set by
 /// [`enter_rt_context`]. Returns `"<unknown>"` if none is set.
 ///
@@ -98,12 +123,23 @@ pub struct RtAwareAllocator;
 
 unsafe impl GlobalAlloc for RtAwareAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if RT_ALLOC_CONTEXT.with(|c| c.get()) {
+        if RT_ALLOC_CONTEXT.with(|c| c.get()) && !std::thread::panicking() {
             // Clear the flag BEFORE building the diagnostic: the panic/eprintln
             // path itself allocates, and if the flag were still set that alloc
             // would re-enter this branch and double-panic into a *process abort*.
             // Clearing it first turns detection into a catchable per-node panic
             // the RT executor can safe — not a whole-robot crash.
+            //
+            // The `!std::thread::panicking()` half of the guard covers a
+            // *different* hazard: when `tick()` panics for any unrelated reason,
+            // the panic runtime allocates (boxing the payload, formatting the
+            // message) while the RT flag is still set, because `leave_rt_context()`
+            // has not run yet. Panicking again from inside that allocation is a
+            // panic-during-panic, which Rust turns into `SIGABRT` — so an ordinary
+            // recoverable node bug became a whole-process abort that
+            // `catch_unwind` never saw. `std::thread::panicking()` reads a
+            // const-initialized thread-local counter that std increments *before*
+            // running the panic hook, and it cannot allocate or re-enter here.
             RT_ALLOC_CONTEXT.with(|c| c.set(false));
             let name = rt_node_name();
             // Write directly to stderr to avoid allocating in the panic message path.
@@ -132,12 +168,9 @@ unsafe impl GlobalAlloc for RtAwareAllocator {
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        if RT_ALLOC_CONTEXT.with(|c| c.get()) {
-            // Clear the flag BEFORE building the diagnostic: the panic/eprintln
-            // path itself allocates, and if the flag were still set that alloc
-            // would re-enter this branch and double-panic into a *process abort*.
-            // Clearing it first turns detection into a catchable per-node panic
-            // the RT executor can safe — not a whole-robot crash.
+        if RT_ALLOC_CONTEXT.with(|c| c.get()) && !std::thread::panicking() {
+            // Flag cleared first, and the `panicking()` guard above — see the
+            // two hazards spelled out in `alloc`.
             RT_ALLOC_CONTEXT.with(|c| c.set(false));
             let name = rt_node_name();
             panic!(
@@ -149,12 +182,9 @@ unsafe impl GlobalAlloc for RtAwareAllocator {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        if RT_ALLOC_CONTEXT.with(|c| c.get()) {
-            // Clear the flag BEFORE building the diagnostic: the panic/eprintln
-            // path itself allocates, and if the flag were still set that alloc
-            // would re-enter this branch and double-panic into a *process abort*.
-            // Clearing it first turns detection into a catchable per-node panic
-            // the RT executor can safe — not a whole-robot crash.
+        if RT_ALLOC_CONTEXT.with(|c| c.get()) && !std::thread::panicking() {
+            // Flag cleared first, and the `panicking()` guard above — see the
+            // two hazards spelled out in `alloc`.
             RT_ALLOC_CONTEXT.with(|c| c.set(false));
             let name = rt_node_name();
             panic!(
@@ -181,6 +211,62 @@ mod tests {
 
     #[test]
     fn test_rt_context_default_off() {
+        assert!(!is_rt_context());
+    }
+
+    #[test]
+    fn rt_context_guard_leaves_on_unwind() {
+        let r = std::panic::catch_unwind(|| {
+            let _guard = enter_rt_context_guarded("guarded_node");
+            assert!(is_rt_context());
+            panic!("tick failed");
+        });
+        assert!(r.is_err());
+        assert!(
+            !is_rt_context(),
+            "the guard must leave the RT context even when tick() unwinds"
+        );
+    }
+
+    /// A panic inside a `.no_alloc()` tick used to be escalated from a caught
+    /// panic to a whole-process `SIGABRT`: the panic runtime allocates while the
+    /// RT flag is still set, `alloc` panicked again, and a panic during a panic
+    /// aborts. This exercises the allocator directly (it is not the global
+    /// allocator in the lib test binary) from inside a `Drop` running on the
+    /// unwinding path, where `std::thread::panicking()` is true. Before the fix
+    /// this test aborted the whole test binary rather than failing.
+    #[test]
+    fn alloc_defers_to_the_system_allocator_while_a_panic_unwinds() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        static ALLOCATED_WHILE_UNWINDING: AtomicBool = AtomicBool::new(false);
+
+        struct AllocOnUnwind;
+        impl Drop for AllocOnUnwind {
+            fn drop(&mut self) {
+                let layout = Layout::from_size_align(64, 8).unwrap();
+                // SAFETY: matched alloc/dealloc of a valid non-zero layout.
+                unsafe {
+                    let p = RtAwareAllocator.alloc(layout);
+                    ALLOCATED_WHILE_UNWINDING.store(!p.is_null(), Ordering::SeqCst);
+                    if !p.is_null() {
+                        RtAwareAllocator.dealloc(p, layout);
+                    }
+                }
+            }
+        }
+
+        let r = std::panic::catch_unwind(|| {
+            let _guard = enter_rt_context_guarded("panicky");
+            let _alloc_on_unwind = AllocOnUnwind;
+            panic!("an ordinary node bug");
+        });
+
+        assert!(r.is_err(), "the original panic must reach catch_unwind");
+        assert!(
+            ALLOCATED_WHILE_UNWINDING.load(Ordering::SeqCst),
+            "an allocation during unwinding must fall through to the system allocator"
+        );
         assert!(!is_rt_context());
     }
 }

--- a/horus_core/src/memory/shm_region.rs
+++ b/horus_core/src/memory/shm_region.rs
@@ -10,48 +10,65 @@ use crate::error::HorusResult;
 /// Delegates to [`horus_sys::shm::ShmRegion`] for platform-specific implementation.
 /// This wrapper converts `anyhow::Error` to `HorusError::Memory` for compatibility
 /// with the horus_core error hierarchy.
+///
+/// The inner region is wrapped in an `UnsafeCell` because [`Self::grow_unchecked`]
+/// mutates it through a shared reference.  It used to be a plain field that
+/// `grow_unchecked` cast from `&T` to `&mut T` — undefined behaviour regardless
+/// of how exclusive the caller's access is, and silenced with
+/// `#[allow(invalid_reference_casting)]`.  `horus_sys::shm::ShmRegion` holds no
+/// `UnsafeCell` of its own, so it is `Freeze`: rustc lowers `&self` with
+/// `noalias readonly` and is entitled to cache `self.0.mmap` / `self.0.size`
+/// across the call.  `grow_unchecked` replaces both (dropping the old `MmapMut`,
+/// i.e. `munmap`), so a cached pointer is a dangling one — a miscompilation
+/// hazard that comes and goes with inlining.  `UnsafeCell` is the only sound
+/// way to mutate behind `&self`, and it also removes the `Freeze` assumption.
 #[derive(Debug)]
-pub struct ShmRegion(horus_sys::shm::ShmRegion);
+pub struct ShmRegion(std::cell::UnsafeCell<horus_sys::shm::ShmRegion>);
 
 impl ShmRegion {
     /// Create or open a shared memory region.
     pub fn new(name: &str, size: usize) -> HorusResult<Self> {
         horus_sys::shm::ShmRegion::new(name, size)
-            .map(Self)
+            .map(|region| Self(std::cell::UnsafeCell::new(region)))
             .map_err(|e| crate::error::HorusError::Memory(e.to_string().into()))
     }
 
     /// Raw pointer to the mapped memory.
     #[inline]
     pub fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr()
+        // SAFETY: see the `Sync` impl below — readers and `grow_unchecked` are
+        // serialized by the caller's exclusive-access contract.
+        unsafe { (*self.0.get()).as_ptr() }
     }
 
     /// View the mapped memory as a byte slice.
     #[inline]
     #[allow(dead_code)]
     pub fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
+        // SAFETY: as for `as_ptr`.
+        unsafe { (*self.0.get()).as_slice() }
     }
 
     /// View the mapped memory as a mutable byte slice.
     #[inline]
     #[allow(dead_code)]
     pub fn as_slice_mut(&mut self) -> &mut [u8] {
-        self.0.as_slice_mut()
+        self.0.get_mut().as_slice_mut()
     }
 
     /// Size of the mapped region in bytes.
     #[inline]
     #[allow(dead_code)]
     pub fn len(&self) -> usize {
-        self.0.len()
+        // SAFETY: as for `as_ptr`.
+        unsafe { (*self.0.get()).len() }
     }
 
     /// Whether this handle is the original creator (responsible for cleanup on drop).
     #[inline]
     pub fn is_owner(&self) -> bool {
-        self.0.is_owner()
+        // SAFETY: as for `as_ptr`.
+        unsafe { (*self.0.get()).is_owner() }
     }
 
     /// Grow the underlying SHM region without reallocating.
@@ -64,20 +81,30 @@ impl ShmRegion {
     /// only called during migration which holds the migration lock.
     ///
     /// Violating this invariant is undefined behavior (data race on mmap).
-    #[allow(invalid_reference_casting)] // Single-thread contract: caller guarantees exclusive access
+    ///
+    /// **Known limitation** — the contract above is *not* enforced anywhere.
+    /// This call replaces the mapping, so every concurrent reader's
+    /// [`as_ptr`](Self::as_ptr) / [`len`](Self::len) result is invalidated.
+    /// Callers must hold the topic header's migration lock across both the grow
+    /// and the re-derivation of any cached pointers; the current callers in
+    /// `communication/topic` do not, which is tracked separately.
     pub unsafe fn grow_unchecked(&self, new_size: usize) -> HorusResult<()> {
         // SAFETY: Caller guarantees exclusive access per the contract above.
-        // UnsafeCell would be preferable but requires restructuring the wrapper
-        // and all callers. The migration lock serializes all grow operations.
-        let ptr = &self.0 as *const horus_sys::shm::ShmRegion as *mut horus_sys::shm::ShmRegion;
-        let inner = &mut *ptr;
-        inner
+        (*self.0.get())
             .grow_unchecked(new_size)
             .map_err(|e| crate::error::HorusError::Memory(e.to_string().into()))
     }
 }
 
-// Thread safety — delegates to horus_sys::shm::ShmRegion which is Send + Sync
+// Thread safety.
+//
+// `UnsafeCell` is `!Sync`, so this impl is load-bearing rather than the
+// redundant delegation its old comment claimed ("delegates to
+// horus_sys::shm::ShmRegion which is Send + Sync").  The real invariant it
+// asserts: every method except `grow_unchecked` only *reads* the inner region,
+// and `grow_unchecked` is `unsafe` precisely because the caller must guarantee
+// no other thread is touching this region while it runs.  Sharing an
+// `Arc<ShmRegion>` across threads is sound only under that contract.
 unsafe impl Send for ShmRegion {}
 unsafe impl Sync for ShmRegion {}
 

--- a/horus_core/src/memory/tensor_handle.rs
+++ b/horus_core/src/memory/tensor_handle.rs
@@ -298,7 +298,7 @@ impl TensorHandle {
     /// Get tensor dtype
     #[inline]
     pub fn dtype(&self) -> TensorDtype {
-        self.tensor.dtype
+        self.tensor.dtype()
     }
 
     /// Get tensor device

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -4633,7 +4633,7 @@ mod tests {
         // An oversized length inside the right slot is rejected as well.
         let mut too_long = a;
         too_long.size = a.size + 1;
-        assert!(pool.data_slice(&too_long).is_err());
+        pool.data_slice(&too_long).unwrap_err();
 
         // A legitimate sub-view of the same slot still works.
         let sub = a.slice_first_dim(0, 32).expect("sub-view");

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -4504,11 +4504,12 @@ mod tests {
             SLOT_FREE,
             "the slot must still be freed after a rejected scrub"
         );
-        // The slot is back on the free stack: the pool can hand it out again.
-        let reused = pool
-            .alloc(&[32], TensorDtype::U8, Device::cpu())
-            .expect("slot must be reallocatable after a rejected scrub");
-        pool.release(&reused);
+        let (_gen, head) =
+            unpack_tagged_head(pool.header().free_stack_head.load(Ordering::Acquire));
+        assert_eq!(
+            head, slot_id,
+            "the slot must still be pushed back onto the free stack"
+        );
         std::fs::remove_file(&pool.shm_path).ok();
     }
 

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -2291,7 +2291,9 @@ mod tests {
     /// `test_alloc_with_timeout_zero_expires_immediately` fail against a 16 MB
     /// leftover while asking for 1 MB. Clean first, so each test creates.
     fn clear_stale_pool(id: u32) {
-        let path = shm_base_dir().join("tensors").join(format!("tensor_pool_{id}"));
+        let path = shm_base_dir()
+            .join("tensors")
+            .join(format!("tensor_pool_{id}"));
         std::fs::remove_file(path).ok();
     }
 

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -296,10 +296,7 @@ impl TensorPool {
                 // depth rather than the only barrier.
                 horus_sys::shm::harden_shm_file(&shm_path);
                 let file = OpenOptions::new().read(true).write(true).open(&shm_path)?;
-                let actual_size = file.metadata()?.len();
-                if actual_size < mmap_size as u64 {
-                    file.set_len(mmap_size as u64)?;
-                }
+                Self::await_pool_file_size(&file, mmap_size as u64, pool_id)?;
                 (file, false)
             }
             Err(e) => return Err(e.into()),
@@ -515,10 +512,7 @@ impl TensorPool {
                 // depth rather than the only barrier.
                 horus_sys::shm::harden_shm_file(&shm_path);
                 let file = OpenOptions::new().read(true).write(true).open(&shm_path)?;
-                let actual_size = file.metadata()?.len();
-                if actual_size < mmap_size as u64 {
-                    file.set_len(mmap_size as u64)?;
-                }
+                Self::await_pool_file_size(&file, mmap_size as u64, pool_id)?;
                 (file, false)
             }
             Err(e) => return Err(e.into()),
@@ -551,6 +545,37 @@ impl TensorPool {
         }
 
         Ok(pool)
+    }
+
+    /// Wait for a pool file created by *another* process to reach `needed` bytes.
+    ///
+    /// This replaced an unconditional `file.set_len(mmap_size)` on the attach
+    /// path. Resizing a file this process did not create is never right: the
+    /// creator's slot array does not move when the file grows, so growing it
+    /// only lets the two processes go on disagreeing about where the data
+    /// region starts — and it did so *before* any header validation, letting a
+    /// mismatched attacher mutate the creator's file on its way to an error.
+    ///
+    /// The creator `set_len()`s to its full geometry immediately after winning
+    /// the `create_new` race, so a short file means either that race is still
+    /// in flight (spin briefly, same ~100ms budget as `validate()`) or the
+    /// creator laid the pool out with a different geometry — which
+    /// `validate_fields()` reports precisely once the header is readable.
+    fn await_pool_file_size(file: &File, needed: u64, pool_id: u32) -> HorusResult<()> {
+        for _ in 0..100 {
+            if file.metadata()?.len() >= needed {
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        Err(HorusError::Config(ConfigError::Other(format!(
+            "Tensor pool {} exists but is only {} bytes, smaller than the {} bytes this \
+             process's configuration requires — the pool was created with a different \
+             geometry (or its creator has not finished initializing it)",
+            pool_id,
+            file.metadata()?.len(),
+            needed
+        ))))
     }
 
     /// Initialize a newly created pool
@@ -651,7 +676,8 @@ impl TensorPool {
         self.validate_fields()
     }
 
-    /// Validate header fields (version, pool_id). Called after magic is confirmed.
+    /// Validate header fields (version, pool_id, geometry). Called after magic
+    /// is confirmed.
     fn validate_fields(&self) -> HorusResult<()> {
         let header = self.header();
 
@@ -666,6 +692,36 @@ impl TensorPool {
             return Err(HorusError::Config(ConfigError::Other(format!(
                 "Tensor pool ID mismatch: expected {}, got {}",
                 self.pool_id, header.pool_id
+            ))));
+        }
+
+        // Geometry must match, and this used to check only version and pool_id.
+        // On the attach path of `new()`, `data_offset` and the whole slot/data
+        // split are derived from *this caller's* `TensorPoolConfig`, never from
+        // the header already in the file. An attacher configured with fewer
+        // slots than the creator computed a smaller `data_offset` and then
+        // bump-allocated tensor bytes directly on top of the creator's
+        // `SlotHeader` array — each side shredding the other's live data, with
+        // the corrupted `offset`/`size` fields then driving out-of-bounds
+        // dereferences. `open()` has always validated geometry (and documents
+        // why); the create-or-attach path must too.
+        if header.max_slots as usize != self.config.max_slots
+            || header.pool_size as usize != self.config.pool_size
+            || header.slot_alignment as usize != self.config.slot_alignment
+        {
+            return Err(HorusError::Config(ConfigError::Other(format!(
+                "Tensor pool {} geometry mismatch: the existing pool has \
+                 (max_slots {}, pool_size {}, slot_alignment {}) but this process requested \
+                 (max_slots {}, pool_size {}, slot_alignment {}). \
+                 Use TensorPool::open() to attach with the pool's own geometry, \
+                 or configure every process identically.",
+                self.pool_id,
+                header.max_slots,
+                header.pool_size,
+                header.slot_alignment,
+                self.config.max_slots,
+                self.config.pool_size,
+                self.config.slot_alignment,
             ))));
         }
 
@@ -1221,6 +1277,26 @@ impl TensorPool {
         self.checked_data_ptr(tensor.offset, tensor.size)
     }
 
+    /// Whether a wire descriptor's byte range lies inside the slot's own region.
+    ///
+    /// `slot.offset`/`slot.size` are what the pool actually handed out; the
+    /// descriptor's pair travelled over a topic and can say anything. A view
+    /// (`Tensor::slice_first_dim`) or a spill (`SpillDescriptor`, whose `size` is
+    /// the serialized length, not the allocation) is a legitimate sub-range, so
+    /// containment — not equality — is the property. Rejects on overflow.
+    #[inline]
+    fn descriptor_within_slot(tensor: &Tensor, slot: &SlotHeader) -> bool {
+        match (
+            tensor.offset.checked_add(tensor.size),
+            slot.offset.checked_add(slot.size),
+        ) {
+            (Some(desc_end), Some(slot_end)) => {
+                tensor.offset >= slot.offset && desc_end <= slot_end
+            }
+            _ => false,
+        }
+    }
+
     /// Bounds-checked `data_base + offset` for the shared mmap data region.
     ///
     /// Returns null if `offset + size` overflows or leaves the data region.
@@ -1294,20 +1370,21 @@ impl TensorPool {
             ));
         }
 
-        // `offset`/`size` arrive over the wire and nothing compared them to what
-        // the pool actually allocated for this slot: a descriptor could name
-        // slot N's live generation while pointing at a different slot's bytes
-        // with an arbitrary length, bounded only by the whole data region. The
-        // check that catches that lived in `validate_descriptor`, which had no
-        // production callers — so it is folded in here, where the slot is
-        // already loaded. `size <= slot.size` rather than `==`: SpillDescriptor
-        // carries a serialized_len that is legitimately smaller than the
-        // allocation, and any range inside the slot is safe.
-        if tensor.offset != slot.offset || tensor.size > slot.size {
+        // `offset`/`size` arrive over the wire, and nothing compared them to what
+        // the pool actually allocated for this slot: a descriptor could name slot
+        // N's live generation while pointing at a *different* slot's bytes with an
+        // arbitrary length, bounded only by the whole data region. The check that
+        // catches that lived in `validate_descriptor`, which had no production
+        // caller at all — so it is folded in here, where the slot is already
+        // loaded. Containment rather than equality: `Tensor::slice_first_dim`
+        // legitimately shifts `offset` and `SpillDescriptor` legitimately carries
+        // a `size` smaller than the allocation, and any range inside this slot's
+        // own region is safe.
+        if !Self::descriptor_within_slot(tensor, slot) {
             return Err(HorusError::Memory(
                 format!(
-                    "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}), \
-                     slot records (offset {}, size {})",
+                    "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}) \
+                     is not contained in slot records (offset {}, size {})",
                     tensor.slot_id, tensor.offset, tensor.size, slot.offset, slot.size
                 )
                 .into(),
@@ -1377,20 +1454,21 @@ impl TensorPool {
             ));
         }
 
-        // `offset`/`size` arrive over the wire and nothing compared them to what
-        // the pool actually allocated for this slot: a descriptor could name
-        // slot N's live generation while pointing at a different slot's bytes
-        // with an arbitrary length, bounded only by the whole data region. The
-        // check that catches that lived in `validate_descriptor`, which had no
-        // production callers — so it is folded in here, where the slot is
-        // already loaded. `size <= slot.size` rather than `==`: SpillDescriptor
-        // carries a serialized_len that is legitimately smaller than the
-        // allocation, and any range inside the slot is safe.
-        if tensor.offset != slot.offset || tensor.size > slot.size {
+        // `offset`/`size` arrive over the wire, and nothing compared them to what
+        // the pool actually allocated for this slot: a descriptor could name slot
+        // N's live generation while pointing at a *different* slot's bytes with an
+        // arbitrary length, bounded only by the whole data region. The check that
+        // catches that lived in `validate_descriptor`, which had no production
+        // caller at all — so it is folded in here, where the slot is already
+        // loaded. Containment rather than equality: `Tensor::slice_first_dim`
+        // legitimately shifts `offset` and `SpillDescriptor` legitimately carries
+        // a `size` smaller than the allocation, and any range inside this slot's
+        // own region is safe.
+        if !Self::descriptor_within_slot(tensor, slot) {
             return Err(HorusError::Memory(
                 format!(
-                    "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}), \
-                     slot records (offset {}, size {})",
+                    "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}) \
+                     is not contained in slot records (offset {}, size {})",
                     tensor.slot_id, tensor.offset, tensor.size, slot.offset, slot.size
                 )
                 .into(),
@@ -1684,6 +1762,20 @@ impl TensorPool {
             let tagged_head = header.free_stack_head.load(Ordering::Acquire);
             let (generation, slot_id) = unpack_tagged_head(tagged_head);
             if slot_id == INVALID_SLOT {
+                return None;
+            }
+            // The free-stack head lives in peer-writable shared memory, so a
+            // corrupt or torn head hands back an arbitrary index that `slot()`
+            // would turn into an out-of-bounds dereference. Every other reader
+            // of a slot index bounds-checks; this one did not.
+            if !self.slot_id_in_range(slot_id) {
+                log::error!(
+                    "tensor pool {}: free stack head names slot {} but the pool has {} slots \
+                     — refusing to allocate; pool metadata is corrupt",
+                    self.pool_id,
+                    slot_id,
+                    self.config.max_slots
+                );
                 return None;
             }
             let slot = self.slot(slot_id);

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -2278,6 +2278,23 @@ mod tests {
 
     // ── validate_descriptor tests ──────────────────────────────────────────
 
+    /// Remove any pool file left behind at `id` before creating one.
+    ///
+    /// Tests pin literal pool ids, and a run that panicked (or was killed)
+    /// before its trailing `remove_file` leaves the SHM file behind. That used
+    /// to be harmless because `TensorPool::new` `set_len()`'d whatever it found
+    /// to the caller's own geometry. It no longer does — resizing a pool this
+    /// process did not create is how one process laid its tensor data on top of
+    /// another's slot headers — so an attacher now ADOPTS the geometry it finds.
+    /// A stale file from a differently-configured run therefore silently gives
+    /// the test a pool with the wrong `max_slots`, which is exactly what made
+    /// `test_alloc_with_timeout_zero_expires_immediately` fail against a 16 MB
+    /// leftover while asking for 1 MB. Clean first, so each test creates.
+    fn clear_stale_pool(id: u32) {
+        let path = shm_base_dir().join("tensors").join(format!("tensor_pool_{id}"));
+        std::fs::remove_file(path).ok();
+    }
+
     fn make_test_pool(id: u32) -> TensorPool {
         let config = TensorPoolConfig {
             pool_size: 1024 * 1024,
@@ -2285,6 +2302,7 @@ mod tests {
             slot_alignment: 64,
             allocator: Default::default(),
         };
+        clear_stale_pool(id);
         TensorPool::new(id, config).expect("Failed to create test pool")
     }
 
@@ -3005,6 +3023,7 @@ mod tests {
             slot_alignment: 64,
             allocator: Default::default(),
         };
+        clear_stale_pool(9791);
         let pool = TensorPool::new(9791, config).expect("Failed to create pool");
 
         // Exhaust the pool

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -1218,6 +1218,69 @@ impl TensorPool {
         }
     }
 
+    /// Publish payload bytes written into `tensor`'s data region.
+    ///
+    /// Call this after filling a freshly allocated slot and *before* handing the
+    /// descriptor to another thread or process.  It establishes the
+    /// happens-before edge that makes those bytes visible to a reader that later
+    /// pins the slot with [`retain`](Self::retain) / [`try_retain`](Self::try_retain).
+    ///
+    /// # Why the pool has to carry this edge itself
+    ///
+    /// `alloc()` stores `refcount = 1` *before* the owner writes a single
+    /// payload byte, so nothing the pool does orders those bytes against a
+    /// reader.  On the topic spill path the ordering came entirely from the
+    /// topic's ring: the producer copies the payload, then `fence(Release)` and
+    /// release-stores the ring slot's ready flag, and the consumer acquire-loads
+    /// that flag before it follows the descriptor.  That argument is only sound
+    /// while both sides operate on ONE object — and they do not.  Every
+    /// `RingTopic` handle builds its own `ShmRegion`, i.e. its own `mmap` of the
+    /// topic file, so two handles in the same process release and acquire the
+    /// ready flag at two *different virtual addresses* backed by the same
+    /// physical page.  Cache coherence still delivers the bytes on real
+    /// hardware, but the abstract machine derives no synchronizes-with from two
+    /// distinct atomics, and ThreadSanitizer — whose shadow memory is keyed by
+    /// virtual address — sees no edge either.  That is what TSan reported as a
+    /// data race between `dispatch::spill_to_pool`'s `copy_from_slice` and the
+    /// consumer's `bincode::deserialize` of the very same payload.
+    ///
+    /// The pool has no such split: `pool_registry` hands every handle in the
+    /// process the same `Arc<TensorPool>`, hence a single mapping.  An edge
+    /// taken here is therefore one both the memory model and the sanitizer can
+    /// follow.
+    ///
+    /// # How the ordering works
+    ///
+    /// This takes a reference and immediately drops it again — the count is
+    /// unchanged, only the ordering matters.  Both halves are `AcqRel`
+    /// compare-exchanges on `refcount`, the same word a reader's pin touches,
+    /// and the first is sequenced after the caller's payload writes, so it is
+    /// the release half.  A reader's pin is itself a read-modify-write, and an
+    /// RMW always reads the latest value in `refcount`'s modification order, so
+    /// it reads from one of these two operations (or from a later RMW in the
+    /// release sequence they head) and synchronizes-with it.  No blind store is
+    /// used: overwriting `refcount` with its current value would race a
+    /// concurrent `retain` from a peer process.
+    ///
+    /// Cost is two uncontended CAS loops — negligible beside the copy that
+    /// precedes it, on a path that is `#[cold]` to begin with.
+    ///
+    /// # Errors
+    ///
+    /// [`HorusError::Memory`] if `tensor` does not name a live allocation in
+    /// this pool: wrong pool id, out-of-range slot, stale generation, or a
+    /// refcount that has already fallen to zero.  On the error path nothing is
+    /// retained and nothing is released, so the caller keeps whatever reference
+    /// it held.
+    pub fn publish_payload(&self, tensor: &Tensor) -> HorusResult<()> {
+        self.try_retain(tensor)?;
+        // Cannot reach zero: `try_retain` just took a reference on top of the
+        // caller's, so this decrement lands on a count of at least two and can
+        // neither free nor scrub the slot.
+        self.release(tensor);
+        Ok(())
+    }
+
     /// Decrement reference count for a tensor.
     ///
     /// If the count reaches zero, the slot is returned to the free list.
@@ -5247,6 +5310,81 @@ mod tests {
         pool.release(&tensor);
         assert_eq!(pool.stats().allocated_slots, 0);
 
+        std::fs::remove_file(&pool.shm_path).ok();
+    }
+
+    #[test]
+    fn publish_payload_leaves_the_refcount_untouched() {
+        // `publish_payload` exists for its ORDERING, not for its accounting: it
+        // retains and releases so that the writes preceding it are ordered before
+        // any reader's pin. If it ever changed the count, the spill path would
+        // either leak the slot (pool fills, large messages silently dropped) or
+        // free it under a live reader.
+        let pool = make_test_pool(8818);
+        let tensor = pool
+            .alloc(&[64], TensorDtype::U8, Device::cpu())
+            .expect("alloc");
+        assert_eq!(pool.refcount(&tensor), 1, "alloc hands back one reference");
+
+        pool.publish_payload(&tensor).expect("publish a live slot");
+        assert_eq!(
+            pool.refcount(&tensor),
+            1,
+            "publish_payload must be refcount-neutral"
+        );
+        assert_eq!(
+            pool.stats().allocated_slots,
+            1,
+            "publish_payload must not free the slot"
+        );
+
+        pool.release(&tensor);
+        std::fs::remove_file(&pool.shm_path).ok();
+    }
+
+    #[test]
+    fn publish_payload_rejects_a_freed_or_stale_slot() {
+        // The spill producer publishes only what it just allocated, so an error
+        // here means the descriptor no longer names that allocation. It must
+        // report rather than silently order nothing — the caller drops the spill
+        // instead of putting a descriptor on the wire for unordered bytes.
+        // max_slots = 1 forces the realloc below to reuse the same slot, so the
+        // stale descriptor names a LIVE slot at the wrong generation — the case
+        // that matters — rather than a still-free one.
+        let config = TensorPoolConfig {
+            pool_size: 1024 * 1024,
+            max_slots: 1,
+            slot_alignment: 64,
+            allocator: Default::default(),
+        };
+        clear_stale_pool(8819);
+        let pool = TensorPool::new(8819, config).expect("create pool");
+
+        let freed = pool
+            .alloc(&[64], TensorDtype::U8, Device::cpu())
+            .expect("alloc");
+        pool.release(&freed);
+        assert!(
+            pool.publish_payload(&freed).is_err(),
+            "a released slot has no payload to publish"
+        );
+
+        // Reallocation bumps the generation, so the old descriptor is stale even
+        // though the slot is live again.
+        let live = pool
+            .alloc(&[64], TensorDtype::U8, Device::cpu())
+            .expect("realloc");
+        assert!(
+            pool.publish_payload(&freed).is_err(),
+            "a stale generation must not publish over the slot's new owner"
+        );
+        assert_eq!(
+            pool.refcount(&live),
+            1,
+            "a rejected publish must not disturb the live allocation's refcount"
+        );
+
+        pool.release(&live);
         std::fs::remove_file(&pool.shm_path).ok();
     }
 }

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -19,12 +19,13 @@
 //! │  ├── slot_alignment: u32                                   │
 //! │  └── next_alloc_offset: AtomicU64                          │
 //! ├────────────────────────────────────────────────────────────┤
-//! │  SlotHeaders[max_slots] (48 bytes each)                    │
+//! │  SlotHeaders[max_slots] (56 bytes each)                    │
 //! │  ├── refcount: AtomicU64                                   │
 //! │  ├── flags: AtomicU32                                      │
 //! │  ├── generation: AtomicU64  (upgraded from U32 in v2)      │
-//! │  ├── offset: u64                                           │
-//! │  ├── size: u64                                             │
+//! │  ├── offset: AtomicU64  (atomic since v4; see SlotHeader)  │
+//! │  ├── size: AtomicU64    (atomic since v4; see SlotHeader)  │
+//! │  ├── capacity: u64      (owner-exclusive, non-atomic)      │
 //! │  └── next_free: AtomicU32                                  │
 //! ├────────────────────────────────────────────────────────────┤
 //! │  Free Stack (lock-free)                                    │
@@ -144,6 +145,36 @@ struct PoolHeader {
 ///
 /// Field ordering ensures `AtomicU64`/`u64` fields land on 8-byte boundaries
 /// without implicit padding.  Changed in POOL_VERSION 3 (refcount upgraded to AtomicU64 from POOL_VERSION 2's 40-byte layout).
+///
+/// # Which fields must be atomic
+///
+/// This header lives in a mapping that peer processes write concurrently, so
+/// "is this field read by anyone other than its exclusive owner?" decides
+/// whether it needs to be an atomic — not whether the value *looks* consistent
+/// on x86.
+///
+/// `offset` and `size` are read by any thread or process holding a wire
+/// descriptor (`data_slice`, `data_slice_mut`, `validate_descriptor`) with no
+/// exclusion against the allocator that writes them, so they are `AtomicU64`.
+/// They were plain `u64` through POOL_VERSION 4 and ThreadSanitizer caught the
+/// resulting race: a publisher inside `alloc()` writing `slot.offset`/`slot.size`
+/// against a subscriber inside `TensorPool::descriptor_within_slot` reading them
+/// off a spilled-message descriptor.  Non-atomic concurrent access is a data
+/// race and therefore UB regardless of the values observed.
+///
+/// `capacity` stays a plain `u64` deliberately.  It is touched at exactly three
+/// places — zeroed in `initialize()` before the pool's magic is published, read
+/// in `alloc()`'s grow-within-capacity reuse test, and written in `alloc()`'s
+/// bump path — and the two `alloc()` sites run only after the thread has won the
+/// Treiber pop for this slot, so no other thread or process may touch the slot
+/// at all.  The release CAS on `free_stack_head` in `return_slot`/`push_free_slot`
+/// and the acquire CAS in `pop_and_claim` carry the previous owner's write to the
+/// next owner, so there is no race to fix and no reason to pay for an atomic.
+///
+/// The `u64` → `AtomicU64` change needs no `POOL_VERSION` bump: `AtomicU64` has
+/// the same size and alignment as `u64`, `SlotHeader` is `repr(C)`, and both
+/// fields already sat on 8-byte boundaries — the SHM bytes are unmoved.  The
+/// `const` assertion below is what actually holds that claim up.
 #[repr(C)]
 struct SlotHeader {
     /// Reference count for this slot.
@@ -161,14 +192,25 @@ struct SlotHeader {
     /// allocations, practical wraparound is impossible.
     generation: AtomicU64,
     /// Byte offset from the data region base to this slot's tensor data.
-    offset: u64,
+    ///
+    /// Atomic because holders of a wire descriptor read it concurrently with
+    /// `alloc()` writing it; see the type-level "Which fields must be atomic".
+    /// Never read on its own — go through `TensorPool::slot_geometry`, which
+    /// pins the `(offset, size)` pair to a generation.
+    offset: AtomicU64,
     /// Logical size of the current allocation, in bytes.
-    size: u64,
+    ///
+    /// Atomic for the same reason as `offset`, and read through the same
+    /// `TensorPool::slot_geometry` pairing helper.
+    size: AtomicU64,
     /// Physical high-water size of this slot's backing region, in bytes — the
     /// largest allocation ever made here (the region is never shrunk). A freed
     /// slot is reused when the new request fits `capacity`, so a grow-after-shrink
     /// reuses this region instead of bumping a fresh one and leaking it (F-MEM1).
     /// Zero until the slot is first bump-allocated.
+    ///
+    /// Plain `u64`, not atomic: only the thread that won this slot's Treiber pop
+    /// ever reads or writes it (see "Which fields must be atomic").
     capacity: u64,
     /// Next free slot index for the Treiber free-stack.
     next_free: AtomicU32,
@@ -178,6 +220,21 @@ struct SlotHeader {
     /// Zero means no owner tracked (pre-v2 pools or freshly initialized).
     owner_pid: AtomicU32,
 }
+
+// The SHM layout is a wire format: every process that attaches computes slot
+// addresses as `slots_offset + slot_id * size_of::<SlotHeader>()`, and a v4 pool
+// written by one build must be readable by another.  Making `offset`/`size`
+// atomic is only a no-op — and only justifies leaving `POOL_VERSION` at 4 — as
+// long as the struct is still 56 bytes with 8-byte alignment.  Assert it here so
+// a future field edit fails the build instead of silently desynchronising two
+// processes' views of the same file.
+const _: () = {
+    assert!(std::mem::size_of::<SlotHeader>() == 56);
+    assert!(std::mem::align_of::<SlotHeader>() == 8);
+    // The property the "no version bump" argument actually rests on.
+    assert!(std::mem::size_of::<AtomicU64>() == std::mem::size_of::<u64>());
+    assert!(std::mem::align_of::<AtomicU64>() == 8);
+};
 
 /// Memory allocator backend for pool data region.
 ///
@@ -607,8 +664,8 @@ impl TensorPool {
             slot.flags.store(SLOT_FREE, Ordering::Release);
             slot.generation.store(0, Ordering::Release);
             slot.owner_pid.store(0, Ordering::Release);
-            slot.offset = 0;
-            slot.size = 0;
+            slot.offset.store(0, Ordering::Release);
+            slot.size.store(0, Ordering::Release);
             slot.capacity = 0;
             // Link this slot on top of the free stack being built.
             slot.next_free.store(stack_head, Ordering::Release);
@@ -842,11 +899,25 @@ impl TensorPool {
         if self.backend.is_shared() {
             let slot = self.slot_mut(slot_id);
             if slot.capacity > 0 && aligned_size as u64 <= slot.capacity {
-                let reused_offset = slot.offset;
+                // Relaxed: we won this slot's Treiber pop, so nobody else may
+                // write it, and `pop_and_claim`'s acquire CAS on `free_stack_head`
+                // already ordered us after the previous owner's release.
+                let reused_offset = slot.offset.load(Ordering::Relaxed);
                 // Bump the generation (ABA / stale-descriptor protection) exactly
                 // as the bump path does, so old Tensor handles are rejected.
+                //
+                // The bump MUST stay ahead of the geometry store below.  It is
+                // what invalidates stale descriptors before the geometry they
+                // describe changes, and it is the seqlock counter that
+                // `slot_geometry` re-checks to rule out a torn `(offset, size)`
+                // pair.  `offset` is deliberately left alone here — the region is
+                // reused as-is — so only `size` moves.
                 let generation_u64 = slot.generation.fetch_add(1, Ordering::AcqRel) + 1;
-                slot.size = size;
+                // Release: a concurrent reader that acquires this store must also
+                // see the generation bump sequenced before it, which is what lets
+                // `slot_geometry` detect that its snapshot came from a newer
+                // allocation.
+                slot.size.store(size, Ordering::Release);
                 slot.owner_pid.store(std::process::id(), Ordering::Release);
                 slot.refcount.store(1, Ordering::Release);
                 slot.flags.store(SLOT_ALLOCATED, Ordering::Release);
@@ -903,13 +974,21 @@ impl TensorPool {
 
         // Initialize slot — bump 64-bit generation counter to prevent ABA.
         // The returned u64 is split into low/high 32-bit halves in Tensor.
+        // The generation bump stays ahead of the geometry stores: it invalidates
+        // stale descriptors before the geometry they name changes, and it is the
+        // seqlock counter `slot_geometry` re-checks after reading the pair.
         let generation_u64 = slot.generation.fetch_add(1, Ordering::AcqRel) + 1;
-        slot.offset = offset as u64;
-        slot.size = size;
+        // Release on both: a reader that acquires either store is thereby ordered
+        // after the `fetch_add` above, so its follow-up generation load cannot
+        // still read the old generation — that is what makes a torn
+        // (new offset, old size) pair detectable rather than silently accepted.
+        slot.offset.store(offset as u64, Ordering::Release);
+        slot.size.store(size, Ordering::Release);
         // Record the physical region size, alongside offset/size so it rides the
         // same free-stack release/acquire that publishes them cross-thread. Only a
         // real bump sets this; the reuse path leaves it intact, preserving the
-        // high-water capacity for future grow-within-capacity reuse.
+        // high-water capacity for future grow-within-capacity reuse. Non-atomic
+        // is correct here: only the slot's exclusive owner ever touches it.
         slot.capacity = aligned_size as u64;
         slot.owner_pid.store(std::process::id(), Ordering::Release);
         slot.refcount.store(1, Ordering::Release);
@@ -1277,6 +1356,62 @@ impl TensorPool {
         self.checked_data_ptr(tensor.offset, tensor.size)
     }
 
+    /// A slot's `(offset, size)` read as one snapshot, pinned to `expected_gen`.
+    ///
+    /// Making the two fields atomic removes the data race but not the *pairing*
+    /// problem: they are two independent atomics, so two plain loads can observe
+    /// a torn pair — a new `offset` with an old `size` — while a peer reallocates
+    /// the slot underneath.  `offset_new + size_old` can describe a region larger
+    /// than anything the pool ever handed out, which is exactly the shape that
+    /// would let a stale descriptor slip through `descriptor_within_slot` and
+    /// read a neighbouring slot's bytes.  So the pair must be read atomically
+    /// *as a pair*, not merely with atomic loads.
+    ///
+    /// `generation` is the seqlock counter that does it, and it works because of
+    /// an invariant the allocator already maintains: **every geometry mutation is
+    /// preceded, in the mutating thread's own program order, by
+    /// `generation.fetch_add(1, AcqRel)`** — the bump path and the
+    /// grow-within-capacity reuse path both do this, `initialize()` runs before
+    /// the pool's magic is published, and nothing else writes geometry.  Given
+    /// that, if one of our acquire loads reads a writer's release store, the
+    /// writer's `fetch_add` happens-before that load and therefore before our
+    /// following generation load; coherence then forbids that load from
+    /// returning the pre-bump value.  Generation only ever increases, so it can
+    /// never come back to `expected_gen`.  An unchanged generation across the
+    /// pair is thus proof that neither field came from a later allocation.
+    ///
+    /// `flags` cannot substitute for the generation here: `pop_and_claim` stores
+    /// `SLOT_ALLOCATED` when it wins the pop, *before* `alloc()` writes the
+    /// geometry, so an ALLOCATED slot is not yet a slot with settled geometry.
+    ///
+    /// Callers must have already compared the slot's generation to the
+    /// descriptor's; this closes the window that opens after that comparison.
+    ///
+    /// Returns `None` if the slot was reallocated during the read, in which case
+    /// the descriptor is stale by definition and there is nothing to validate.
+    ///
+    /// # Not a lifetime guarantee
+    ///
+    /// A `Some` result says the pair was consistent *at the moment it was read*.
+    /// It says nothing about the instant after: a caller that holds no refcount
+    /// on the slot (the spill-descriptor read path is one) can still have the
+    /// region freed, scrubbed and reallocated under the pointer it derives from
+    /// this snapshot.  Preventing that needs the reader to hold a reference, not
+    /// a stronger read here.
+    #[inline]
+    fn slot_geometry(slot: &SlotHeader, expected_gen: u64) -> Option<(u64, u64)> {
+        // Acquire, not Relaxed: the argument above needs each load to
+        // synchronize-with the writer's release store, which is what drags the
+        // writer's preceding generation bump into our happens-before order.
+        let offset = slot.offset.load(Ordering::Acquire);
+        let size = slot.size.load(Ordering::Acquire);
+        // Acquire, and sequenced after both loads: this is the seqlock re-check.
+        if slot.generation.load(Ordering::Acquire) != expected_gen {
+            return None;
+        }
+        Some((offset, size))
+    }
+
     /// Whether a wire descriptor's byte range lies inside the slot's own region.
     ///
     /// `slot.offset`/`slot.size` are what the pool actually handed out; the
@@ -1284,14 +1419,24 @@ impl TensorPool {
     /// (`Tensor::slice_first_dim`) or a spill (`SpillDescriptor`, whose `size` is
     /// the serialized length, not the allocation) is a legitimate sub-range, so
     /// containment — not equality — is the property. Rejects on overflow.
+    ///
+    /// Takes `expected_gen` — the generation the caller has already matched
+    /// against the descriptor — and reads the slot's geometry through
+    /// `slot_geometry`, so a slot reallocated mid-check fails the bound rather
+    /// than being compared against half of two different allocations. That makes
+    /// this strictly stricter than the plain-`u64` version it replaces; it is a
+    /// bounds check against hostile descriptors and must never loosen.
     #[inline]
-    fn descriptor_within_slot(tensor: &Tensor, slot: &SlotHeader) -> bool {
+    fn descriptor_within_slot(tensor: &Tensor, slot: &SlotHeader, expected_gen: u64) -> bool {
+        let Some((slot_offset, slot_size)) = Self::slot_geometry(slot, expected_gen) else {
+            return false;
+        };
         match (
             tensor.offset.checked_add(tensor.size),
-            slot.offset.checked_add(slot.size),
+            slot_offset.checked_add(slot_size),
         ) {
             (Some(desc_end), Some(slot_end)) => {
-                tensor.offset >= slot.offset && desc_end <= slot_end
+                tensor.offset >= slot_offset && desc_end <= slot_end
             }
             _ => false,
         }
@@ -1380,12 +1525,21 @@ impl TensorPool {
         // legitimately shifts `offset` and `SpillDescriptor` legitimately carries
         // a `size` smaller than the allocation, and any range inside this slot's
         // own region is safe.
-        if !Self::descriptor_within_slot(tensor, slot) {
+        if !Self::descriptor_within_slot(tensor, slot, slot_gen) {
+            // The slot geometry quoted here is re-read for the message only, and
+            // Relaxed because a diagnostic string carries no ordering
+            // requirement. It can differ from the pair the check actually
+            // rejected if a peer reallocated the slot in between — which is
+            // itself one of the reasons the check can fail.
             return Err(HorusError::Memory(
                 format!(
                     "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}) \
                      is not contained in slot records (offset {}, size {})",
-                    tensor.slot_id, tensor.offset, tensor.size, slot.offset, slot.size
+                    tensor.slot_id,
+                    tensor.offset,
+                    tensor.size,
+                    slot.offset.load(Ordering::Relaxed),
+                    slot.size.load(Ordering::Relaxed)
                 )
                 .into(),
             ));
@@ -1464,12 +1618,21 @@ impl TensorPool {
         // legitimately shifts `offset` and `SpillDescriptor` legitimately carries
         // a `size` smaller than the allocation, and any range inside this slot's
         // own region is safe.
-        if !Self::descriptor_within_slot(tensor, slot) {
+        if !Self::descriptor_within_slot(tensor, slot, slot_gen) {
+            // The slot geometry quoted here is re-read for the message only, and
+            // Relaxed because a diagnostic string carries no ordering
+            // requirement. It can differ from the pair the check actually
+            // rejected if a peer reallocated the slot in between — which is
+            // itself one of the reasons the check can fail.
             return Err(HorusError::Memory(
                 format!(
                     "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}) \
                      is not contained in slot records (offset {}, size {})",
-                    tensor.slot_id, tensor.offset, tensor.size, slot.offset, slot.size
+                    tensor.slot_id,
+                    tensor.offset,
+                    tensor.size,
+                    slot.offset.load(Ordering::Relaxed),
+                    slot.size.load(Ordering::Relaxed)
                 )
                 .into(),
             ));
@@ -1557,19 +1720,34 @@ impl TensorPool {
             )));
         }
 
+        // 5/6. Offset and size must match the slot's records.
+        //
+        // Read as one generation-pinned pair rather than field-by-field: two
+        // independent loads can straddle a reallocation and compare the
+        // descriptor against half of one allocation and half of the next, which
+        // can pass both equality checks for a slot that is now neither. A slot
+        // that moves under us is a stale descriptor by definition, so say so.
+        let Some((slot_offset, slot_size)) = Self::slot_geometry(slot, slot_gen) else {
+            return Err(HorusError::InvalidDescriptor(format!(
+                "slot {} was freed and reallocated while its descriptor was being validated \
+                 (generation moved past {})",
+                tensor.slot_id, slot_gen
+            )));
+        };
+
         // 5. Offset must match slot's recorded offset
-        if tensor.offset != slot.offset {
+        if tensor.offset != slot_offset {
             return Err(HorusError::InvalidDescriptor(format!(
                 "offset mismatch for slot {}: descriptor has {}, slot records {}",
-                tensor.slot_id, tensor.offset, slot.offset
+                tensor.slot_id, tensor.offset, slot_offset
             )));
         }
 
         // 6. Size must match slot's recorded size
-        if tensor.size != slot.size {
+        if tensor.size != slot_size {
             return Err(HorusError::InvalidDescriptor(format!(
                 "size mismatch for slot {}: descriptor has {}, slot records {}",
-                tensor.slot_id, tensor.size, slot.size
+                tensor.slot_id, tensor.size, slot_size
             )));
         }
 
@@ -1701,17 +1879,26 @@ impl TensorPool {
     #[allow(clippy::mut_from_ref)]
     fn slot_mut(&self, index: u32) -> &mut SlotHeader {
         let offset = self.slots_offset + (index as usize) * std::mem::size_of::<SlotHeader>();
-        // SAFETY: mmap region outlives self. Each slot is accessed exclusively:
-        // - alloc() pops a slot from the atomic Treiber free-stack (only one thread wins)
-        // - release()/return_slot() only touches slots the caller owns (refcount CAS)
-        // - No two threads can hold the same slot_id simultaneously
-        // The non-atomic writes to offset/size are safe because the Treiber stack
-        // SAFETY: returns &mut from &self via mmap raw pointer. Sound because:
-        // (1) slot_mut is never called concurrently for the same slot index —
-        //     atomic CAS on free_stack_head provides mutual exclusion per-slot.
-        // (2) SlotHeader is repr(C) in mmap — Rust aliasing optimizations don't apply
-        //     to memory-mapped regions accessed through raw pointers.
-        // (3) offset is bounds-checked: slot_id < max_slots, verified by caller.
+        // SAFETY: returns &mut from &self via a raw pointer into the mmap. Sound
+        // because:
+        // (1) The *mutating* callers hold the slot exclusively: alloc() only
+        //     reaches a slot it won from the atomic Treiber free-stack, and
+        //     release()/return_slot() only a slot whose refcount CAS it won. So
+        //     no two threads mutate the same slot_id concurrently.
+        // (2) SlotHeader is repr(C) in mmap — Rust aliasing optimizations don't
+        //     apply to memory-mapped regions accessed through raw pointers.
+        // (3) The byte offset is bounds-checked: every caller verifies
+        //     slot_id < max_slots via slot_id_in_range() first.
+        //
+        // What (1) does NOT give — and what an earlier version of this comment
+        // wrongly claimed — is exclusion against *readers*. `slot()` hands out a
+        // shared reference to the same header, and data_slice()/
+        // validate_descriptor() read `offset`/`size` from a descriptor that
+        // arrived over a topic, with no refcount and no lock, while an allocator
+        // is writing them. That is why those two fields are atomics: the writes
+        // here and the reads there genuinely overlap, and ThreadSanitizer proved
+        // it. Any new field that readers touch must be an atomic too; only fields
+        // confined to the slot's exclusive owner (`capacity`) may stay plain.
         unsafe { &mut *(self.mmap.as_ptr().add(offset) as *mut SlotHeader) }
     }
 
@@ -1878,16 +2065,21 @@ impl TensorPool {
         //   1. backend.zero()  — scrub all data bytes
         //   2. slot.flags = SLOT_FREE  — now visible to other allocators
         //   3. push to free stack  — slot becomes allocatable
-        // `slot.offset` / `slot.size` are non-atomic fields living in the shared
-        // mapping, so a peer process, a torn write from a crashed writer, or a
-        // pool laid out with a different geometry can leave them pointing far
-        // outside this mapping.  Snapshot them once and bounds-check before
-        // handing the pointer to `backend.zero()`, which *writes* `size` bytes:
-        // unchecked, this scrub was an arbitrary-address zero-fill.  Snapshot
-        // rather than re-read, so a concurrent peer cannot change the value
-        // between the check and the use.
-        let slot_offset = slot.offset;
-        let slot_size = slot.size;
+        // `slot.offset` / `slot.size` live in the shared mapping, so a peer
+        // process, a crashed writer, or a pool laid out with a different geometry
+        // can leave them pointing far outside this mapping.  Making them atomic
+        // rules out a torn *value*; it does not rule out a hostile one.  Snapshot
+        // them once and bounds-check before handing the pointer to
+        // `backend.zero()`, which *writes* `size` bytes: unchecked, this scrub was
+        // an arbitrary-address zero-fill.  Snapshot rather than re-read, so a
+        // peer cannot change the value between the check and the use.
+        //
+        // Relaxed is enough: we are here only because this thread won the
+        // refcount 1 -> 0 `compare_exchange(AcqRel)`, which already ordered us
+        // after every prior operation on the slot and makes us its sole owner
+        // until it is pushed back onto the free stack below.
+        let slot_offset = slot.offset.load(Ordering::Relaxed);
+        let slot_size = slot.size.load(Ordering::Relaxed);
         let data_size = slot_size as usize;
         if data_size > 0 {
             // Get the data pointer — works for both mmap and non-mmap backends
@@ -4500,7 +4692,7 @@ mod tests {
 
     #[test]
     fn return_slot_skips_the_scrub_when_the_slot_header_is_out_of_range() {
-        // `slot.offset`/`slot.size` are plain u64s in peer-writable shared memory.
+        // `slot.offset`/`slot.size` are peer-writable shared memory.
         // `return_slot` turned them into `data_base + offset` with no bounds check
         // and handed the result to `backend.zero()`, which *writes* `size` bytes —
         // an arbitrary-address zero-fill driven by whatever a peer (or a torn
@@ -4514,8 +4706,8 @@ mod tests {
 
         {
             let slot = pool.slot_mut(slot_id);
-            slot.offset = u64::MAX - 4095;
-            slot.size = 4096;
+            slot.offset.store(u64::MAX - 4095, Ordering::Release);
+            slot.size.store(4096, Ordering::Release);
         }
 
         pool.release(&tensor); // must not fault, and must not zero-fill out of bounds

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -4478,6 +4478,148 @@ mod tests {
     }
 
     #[test]
+    fn return_slot_skips_the_scrub_when_the_slot_header_is_out_of_range() {
+        // `slot.offset`/`slot.size` are plain u64s in peer-writable shared memory.
+        // `return_slot` turned them into `data_base + offset` with no bounds check
+        // and handed the result to `backend.zero()`, which *writes* `size` bytes —
+        // an arbitrary-address zero-fill driven by whatever a peer (or a torn
+        // write, or a geometry-mismatched attacher) left in the header. It must
+        // now skip the scrub and still return the slot to the free stack.
+        let pool = make_test_pool(9975);
+        let tensor = pool
+            .alloc(&[32], TensorDtype::U8, Device::cpu())
+            .expect("alloc");
+        let slot_id = tensor.slot_id;
+
+        {
+            let slot = pool.slot_mut(slot_id);
+            slot.offset = u64::MAX - 4095;
+            slot.size = 4096;
+        }
+
+        pool.release(&tensor); // must not fault, and must not zero-fill out of bounds
+
+        assert_eq!(
+            pool.slot(slot_id).flags.load(Ordering::Acquire),
+            SLOT_FREE,
+            "the slot must still be freed after a rejected scrub"
+        );
+        // The slot is back on the free stack: the pool can hand it out again.
+        let reused = pool
+            .alloc(&[32], TensorDtype::U8, Device::cpu())
+            .expect("slot must be reallocatable after a rejected scrub");
+        pool.release(&reused);
+        std::fs::remove_file(&pool.shm_path).ok();
+    }
+
+    #[test]
+    fn attaching_with_a_different_geometry_is_rejected() {
+        // Two processes calling TensorPool::new() on the same pool_id with
+        // different max_slots used to produce two *different* layouts of the same
+        // file: the attacher derived data_offset from its own config, so its data
+        // region landed on top of the creator's SlotHeader array and each side
+        // shredded the other's live state. validate_fields() checked only version
+        // and pool_id; it must reject any geometry difference.
+        let creator = make_test_pool(9976); // max_slots 8, pool_size 1 MiB
+        let file_len_before = std::fs::metadata(&creator.shm_path).unwrap().len();
+
+        // Fewer slots than the creator: the file is big enough to map, so the
+        // header is readable and validate_fields() must reject the mismatch.
+        let fewer = TensorPool::new(
+            9976,
+            TensorPoolConfig {
+                pool_size: 1024 * 1024,
+                max_slots: 4, // creator laid the file out for 8
+                slot_alignment: 64,
+                allocator: Default::default(),
+            },
+        );
+        assert!(
+            fewer.is_err(),
+            "attaching with a different max_slots must be rejected, not silently re-laid-out"
+        );
+
+        // More slots than the creator: this used to `set_len()` the creator's
+        // file — growing a file this process did not create, before any
+        // validation had run. It must fail and leave the file untouched.
+        let more = TensorPool::new(
+            9976,
+            TensorPoolConfig {
+                pool_size: 1024 * 1024,
+                max_slots: 64,
+                slot_alignment: 64,
+                allocator: Default::default(),
+            },
+        );
+        assert!(more.is_err(), "attaching with more slots must be rejected");
+        assert_eq!(
+            std::fs::metadata(&creator.shm_path).unwrap().len(),
+            file_len_before,
+            "a failed attach must not resize the creator's pool file"
+        );
+
+        // Same geometry still attaches.
+        let same = TensorPool::new(
+            9976,
+            TensorPoolConfig {
+                pool_size: 1024 * 1024,
+                max_slots: 8,
+                slot_alignment: 64,
+                allocator: Default::default(),
+            },
+        );
+        assert!(same.is_ok(), "an identically configured attach must succeed");
+
+        drop(same);
+        std::fs::remove_file(&creator.shm_path).ok();
+    }
+
+    #[test]
+    fn data_slice_rejects_a_descriptor_pointing_outside_its_own_slot() {
+        // A descriptor carries offset/size over the wire. Nothing compared them
+        // to the slot's own records, so a descriptor with slot 0's live
+        // generation but another region's offset/size handed out a slice
+        // spanning other tensors' buffers — bounded only by the whole data
+        // region. The comparison lived in `validate_descriptor`, which had no
+        // production caller.
+        let pool = make_test_pool(9977);
+        let a = pool
+            .alloc(&[64], TensorDtype::U8, Device::cpu())
+            .expect("alloc a");
+        let b = pool
+            .alloc(&[64], TensorDtype::U8, Device::cpu())
+            .expect("alloc b");
+        assert_ne!(a.offset, b.offset, "the two slots must occupy distinct regions");
+
+        let mut forged = a;
+        forged.offset = b.offset; // slot a's identity, slot b's bytes
+        assert!(
+            pool.data_slice(&forged).is_err(),
+            "a descriptor pointing outside its own slot must be rejected"
+        );
+        assert!(
+            pool.data_slice_mut(&forged).is_err(),
+            "the write path must reject it too"
+        );
+
+        // An oversized length inside the right slot is rejected as well.
+        let mut too_long = a;
+        too_long.size = a.size + 1;
+        assert!(pool.data_slice(&too_long).is_err());
+
+        // A legitimate sub-view of the same slot still works.
+        let sub = a.slice_first_dim(0, 32).expect("sub-view");
+        assert!(
+            pool.data_slice(&sub).is_ok(),
+            "a view contained in the slot's own region must still be readable"
+        );
+
+        pool.release(&a);
+        pool.release(&b);
+        std::fs::remove_file(&pool.shm_path).ok();
+    }
+
+    #[test]
     fn alloc_rejects_size_overflowing_alignment() {
         // align_up(u64::MAX, 64) wraps to 0, so alloc would 'succeed' for an
         // impossible u64::MAX-byte allocation (backend.alloc(0) is Ok) and record

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -4569,7 +4569,10 @@ mod tests {
                 allocator: Default::default(),
             },
         );
-        assert!(same.is_ok(), "an identically configured attach must succeed");
+        assert!(
+            same.is_ok(),
+            "an identically configured attach must succeed"
+        );
 
         drop(same);
         std::fs::remove_file(&creator.shm_path).ok();
@@ -4590,7 +4593,10 @@ mod tests {
         let b = pool
             .alloc(&[64], TensorDtype::U8, Device::cpu())
             .expect("alloc b");
-        assert_ne!(a.offset, b.offset, "the two slots must occupy distinct regions");
+        assert_ne!(
+            a.offset, b.offset,
+            "the two slots must occupy distinct regions"
+        );
 
         let mut forged = a;
         forged.offset = b.offset; // slot a's identity, slot b's bytes

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -1217,20 +1217,31 @@ impl TensorPool {
                 .unwrap_or(std::ptr::null_mut());
         }
 
-        // Mmap backends: compute from base + offset. checked_add — a crafted or
-        // corrupt descriptor can carry offset+size that overflows usize, which
-        // would otherwise wrap past the `end > pool_size` gate and yield a valid
-        // base pointer for an out-of-bounds (multi-exabyte) slice.
-        let end = match (tensor.offset as usize).checked_add(tensor.size as usize) {
-            Some(end) => end,
-            None => return std::ptr::null_mut(),
-        };
-        if end > self.config.pool_size {
-            return std::ptr::null_mut();
-        }
+        // Mmap backends: compute from base + offset, bounds-checked.
+        self.checked_data_ptr(tensor.offset, tensor.size)
+    }
 
-        // SAFETY: tensor.offset is within the data region (validated above).
-        unsafe { self.data_base_ptr().add(tensor.offset as usize) as *mut u8 }
+    /// Bounds-checked `data_base + offset` for the shared mmap data region.
+    ///
+    /// Returns null if `offset + size` overflows or leaves the data region.
+    /// `offset`/`size` reach this function straight from a wire descriptor or
+    /// from a `SlotHeader` in peer-writable shared memory, so a crafted or
+    /// torn value can carry an `offset + size` that overflows usize — which
+    /// would otherwise wrap past the `end > pool_size` gate and yield a valid
+    /// base pointer for an out-of-bounds (multi-exabyte) slice.  Every caller
+    /// that turns those two fields into a pointer must come through here; they
+    /// used to be checked in `data_ptr` and *not* in `return_slot`, which is
+    /// how the one site that writes ended up the one site that did not check.
+    #[inline]
+    fn checked_data_ptr(&self, offset: u64, size: u64) -> *mut u8 {
+        let (offset, size) = (offset as usize, size as usize);
+        match offset.checked_add(size) {
+            Some(end) if end <= self.config.pool_size => {
+                // SAFETY: offset..offset+size validated to lie in the data region.
+                unsafe { self.data_base_ptr().add(offset) as *mut u8 }
+            }
+            _ => std::ptr::null_mut(),
+        }
     }
 
     /// Get data as a byte slice.
@@ -1278,6 +1289,26 @@ impl TensorPool {
                     "generation mismatch in data_slice: descriptor generation {} != slot generation {} \
                      (slot was freed and reallocated — stale spill descriptor)",
                     tensor.generation_full(), slot_gen
+                )
+                .into(),
+            ));
+        }
+
+        // `offset`/`size` arrive over the wire and nothing compared them to what
+        // the pool actually allocated for this slot: a descriptor could name
+        // slot N's live generation while pointing at a different slot's bytes
+        // with an arbitrary length, bounded only by the whole data region. The
+        // check that catches that lived in `validate_descriptor`, which had no
+        // production callers — so it is folded in here, where the slot is
+        // already loaded. `size <= slot.size` rather than `==`: SpillDescriptor
+        // carries a serialized_len that is legitimately smaller than the
+        // allocation, and any range inside the slot is safe.
+        if tensor.offset != slot.offset || tensor.size > slot.size {
+            return Err(HorusError::Memory(
+                format!(
+                    "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}), \
+                     slot records (offset {}, size {})",
+                    tensor.slot_id, tensor.offset, tensor.size, slot.offset, slot.size
                 )
                 .into(),
             ));
@@ -1346,6 +1377,26 @@ impl TensorPool {
             ));
         }
 
+        // `offset`/`size` arrive over the wire and nothing compared them to what
+        // the pool actually allocated for this slot: a descriptor could name
+        // slot N's live generation while pointing at a different slot's bytes
+        // with an arbitrary length, bounded only by the whole data region. The
+        // check that catches that lived in `validate_descriptor`, which had no
+        // production callers — so it is folded in here, where the slot is
+        // already loaded. `size <= slot.size` rather than `==`: SpillDescriptor
+        // carries a serialized_len that is legitimately smaller than the
+        // allocation, and any range inside the slot is safe.
+        if tensor.offset != slot.offset || tensor.size > slot.size {
+            return Err(HorusError::Memory(
+                format!(
+                    "descriptor/slot mismatch for slot {}: descriptor (offset {}, size {}), \
+                     slot records (offset {}, size {})",
+                    tensor.slot_id, tensor.offset, tensor.size, slot.offset, slot.size
+                )
+                .into(),
+            ));
+        }
+
         let size = tensor.size as usize;
         let ptr = self.data_ptr(tensor);
         if ptr.is_null() {
@@ -1380,8 +1431,14 @@ impl TensorPool {
     /// Returns `Ok(())` only when all checks pass.
     /// Returns [`HorusError::InvalidDescriptor`] on any violation.
     ///
-    /// Callers **must** call this before invoking [`data_slice`] or
-    /// [`data_slice_mut`] on descriptors received from untrusted processes.
+    /// Note: [`data_slice`] and [`data_slice_mut`] perform the pool_id, slot
+    /// range, generation and offset/size checks themselves, so they are safe on
+    /// an untrusted descriptor without a prior call here.  This function is not
+    /// a precondition for them — it used to claim it was, while having no
+    /// production caller at all.  What it adds over them is check 3, the
+    /// `SLOT_ALLOCATED` flag: deliberately *not* folded into `data_slice`,
+    /// because reading a freed-but-still-mapped slot is a supported diagnostic
+    /// (see `tests/memory_safety.rs`).
     pub fn validate_descriptor(&self, tensor: &Tensor) -> HorusResult<()> {
         // 1. Pool ID
         if tensor.pool_id != self.pool_id {
@@ -1729,7 +1786,17 @@ impl TensorPool {
         //   1. backend.zero()  — scrub all data bytes
         //   2. slot.flags = SLOT_FREE  — now visible to other allocators
         //   3. push to free stack  — slot becomes allocatable
-        let data_size = slot.size as usize;
+        // `slot.offset` / `slot.size` are non-atomic fields living in the shared
+        // mapping, so a peer process, a torn write from a crashed writer, or a
+        // pool laid out with a different geometry can leave them pointing far
+        // outside this mapping.  Snapshot them once and bounds-check before
+        // handing the pointer to `backend.zero()`, which *writes* `size` bytes:
+        // unchecked, this scrub was an arbitrary-address zero-fill.  Snapshot
+        // rather than re-read, so a concurrent peer cannot change the value
+        // between the check and the use.
+        let slot_offset = slot.offset;
+        let slot_size = slot.size;
+        let data_size = slot_size as usize;
         if data_size > 0 {
             // Get the data pointer — works for both mmap and non-mmap backends
             let data_ptr = if !self.backend.is_shared() {
@@ -1739,7 +1806,19 @@ impl TensorPool {
                     .copied()
                     .unwrap_or(std::ptr::null_mut())
             } else {
-                unsafe { self.data_base_ptr().add(slot.offset as usize) as *mut u8 }
+                let p = self.checked_data_ptr(slot_offset, slot_size);
+                if p.is_null() {
+                    log::error!(
+                        "tensor pool {}: slot {} has out-of-range offset {} size {} \
+                         (pool_size {}) — skipping the free-scrub; pool metadata is corrupt",
+                        self.pool_id,
+                        slot_id,
+                        slot_offset,
+                        data_size,
+                        self.config.pool_size
+                    );
+                }
+                p
             };
 
             if !data_ptr.is_null() {

--- a/horus_core/src/params.rs
+++ b/horus_core/src/params.rs
@@ -1444,6 +1444,53 @@ mod tests {
         assert_eq!(v.unwrap().as_bool(), Some(true));
     }
 
+    /// Regression: `load_from_disk` must OVERLAY the file's keys, never replace
+    /// the whole map. It used to do `*params = loaded`, so `horus param load`
+    /// with a small tuning file erased every other parameter — and the
+    /// `save_to_disk()` that follows it persisted the erasure.
+    #[test]
+    fn load_from_disk_overlays_instead_of_replacing() {
+        let params = create_test_params();
+        params.set("gripper_max_current", 3.5_f64).unwrap();
+        params.set("max_speed", 1.0_f64).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("speed_tuning.yaml");
+        std::fs::write(&path, "max_speed: 2.0\n").unwrap();
+
+        params.load_from_disk(&path).unwrap();
+
+        let speed: Option<f64> = params.get("max_speed");
+        assert_eq!(speed, Some(2.0), "the file's key must be applied");
+        let current: Option<f64> = params.get("gripper_max_current");
+        assert_eq!(
+            current,
+            Some(3.5),
+            "a key absent from the file must survive the load"
+        );
+        // The overlay goes through set(), so versions advance as for any change.
+        assert!(
+            params.get_version("max_speed") > 0,
+            "loading a key must bump its version like any other set()"
+        );
+    }
+
+    /// An empty params file means "no overrides", not a parse error — `new()`
+    /// already treats it that way and `load_from_disk` must agree.
+    #[test]
+    fn load_from_disk_tolerates_an_empty_file() {
+        let params = create_test_params();
+        params.set("keep_me", 7_i64).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.yaml");
+        std::fs::write(&path, "").unwrap();
+
+        params.load_from_disk(&path).expect("empty file must load");
+        let kept: Option<i64> = params.get("keep_me");
+        assert_eq!(kept, Some(7));
+    }
+
     #[test]
     fn version_advances_under_concurrent_writes() {
         let params = create_test_params();

--- a/horus_core/src/params.rs
+++ b/horus_core/src/params.rs
@@ -591,14 +591,38 @@ impl RuntimeParams {
         Ok(())
     }
 
-    /// Load parameters from YAML file
+    /// Load parameters from a YAML file, overlaying it onto the current store.
+    ///
+    /// Keys present in the file are set; keys absent from it are left alone.
+    /// This used to be `*params = loaded`, which replaced the WHOLE map — so
+    /// `horus param load ./tuning.yaml` with a one-key file dropped every other
+    /// parameter, and the `save_to_disk()` that follows it wrote that deletion
+    /// back over `.horus/config/params.yaml`. It is the same whole-map-replace
+    /// mistake `new()` documents having fixed for its three layers.
+    ///
+    /// Routing each key through `set()` also restores the read-only check,
+    /// `validate_value`, the version counters and the `on_change` callbacks,
+    /// all of which the direct map assignment bypassed.
+    ///
+    /// Note: because `set()` refuses a read-only or invalid key, a bad file
+    /// aborts the load partway, with the keys before it already applied. That
+    /// matches `new()`'s stance of refusing rather than running on limits
+    /// nobody chose.
     pub fn load_from_disk(&self, path: &Path) -> Result<(), HorusError> {
         if path.exists() {
             let yaml_str = std::fs::read_to_string(path)?;
-            let loaded: BTreeMap<String, Value> = serde_yaml::from_str(&yaml_str)?;
+            // An empty file parses to `null`, not to an empty map — same
+            // treatment as `new()` gives it, so a zero-byte params.yaml is
+            // "no overrides" here too instead of an "invalid type: unit value".
+            let loaded: BTreeMap<String, Value> = if yaml_str.trim().is_empty() {
+                BTreeMap::new()
+            } else {
+                serde_yaml::from_str(&yaml_str)?
+            };
 
-            let mut params = self.params.write()?;
-            *params = loaded;
+            for (key, value) in loaded {
+                self.set(&key, value)?;
+            }
         }
         Ok(())
     }

--- a/horus_core/src/scheduling/async_executor.rs
+++ b/horus_core/src/scheduling/async_executor.rs
@@ -82,15 +82,17 @@ impl AsyncExecutor {
             print_line("[Async I/O] Warning: thread handle already consumed — nothing to join");
             return Vec::new();
         };
-        match handle.join() {
-            Ok(nodes) => nodes,
-            Err(_) => {
-                print_line(
-                    "[Async I/O] Warning: executor thread panicked; its nodes could not be reclaimed",
-                );
-                Vec::new()
-            }
-        }
+        // Bounded join, matching the guarantee RtExecutor::stop documents. A
+        // bare `handle.join()` here hung the entire shutdown whenever an async
+        // node blocked inside `tick()`, because this loop only re-checks
+        // `running` between ticks — and `run_with_filter` calls this before it
+        // shuts down or safes any other node.
+        super::primitives::join_with_timeout(
+            handle,
+            "Async I/O",
+            super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD,
+        )
+        .unwrap_or_default()
     }
 
     /// Main function for the async I/O thread.
@@ -387,8 +389,15 @@ impl AsyncExecutor {
 
 impl Drop for AsyncExecutor {
     fn drop(&mut self) {
+        // Bounded here too: an early return or a panic can drop the executor
+        // without ever calling `stop()`, and an unbounded join on that path
+        // hangs exactly as badly.
         if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+            let _ = super::primitives::join_with_timeout(
+                handle,
+                "Async I/O",
+                super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD,
+            );
         }
     }
 }

--- a/horus_core/src/scheduling/async_executor.rs
+++ b/horus_core/src/scheduling/async_executor.rs
@@ -191,8 +191,13 @@ impl AsyncExecutor {
                 let mut handles = Vec::with_capacity(ready_indices.len());
 
                 for &i in &ready_indices {
-                    // SAFETY: Each task accesses a distinct index into the nodes vec.
-                    // We await all handles before nodes can be mutated again.
+                    // SAFETY: each task gets a `&mut` to a distinct element of
+                    // `nodes`, so the tasks never alias each other. The lifetime
+                    // erasure (spawn_blocking demands 'static) is sound only
+                    // because EVERY handle below is awaited to completion before
+                    // `nodes` is reborrowed or dropped — see the two-phase drain
+                    // after this loop. Reborrowing while a task is still running
+                    // would invalidate that task's pointer.
                     let node_ref = unsafe { &mut *nodes_ptr.add(i) };
                     // FIX #5: the tick runs on a tokio blocking-pool thread, so the
                     // thread-local context is set INSIDE the closure. spawn_blocking
@@ -217,26 +222,40 @@ impl AsyncExecutor {
                     handles.push(handle);
                 }
 
-                // Await all results
+                // Two phases, deliberately. This used to await and process one
+                // handle at a time, but `&mut nodes[i]` goes through
+                // `<Vec<T>>::index_mut`, which takes a unique borrow of the
+                // WHOLE buffer — invalidating every pointer the still-running
+                // sibling tasks derived from `nodes_ptr`. Aliasing UB, and the
+                // resulting `noalias` slice pointer let the compiler reorder
+                // reads of a node another blocking thread was still writing.
+                // `ComputeExecutor::compute_thread_main` gets this right by
+                // joining its crossbeam scope before touching results.
+                //
+                // Draining first also closes the unwind window: no user code
+                // (`on_error`, `apply_failure_policy_after_panic`) runs — and so
+                // cannot unwind and drop `nodes` — while a blocking thread still
+                // holds a pointer into it.
+
+                // Phase 1: drain every handle, touching `nodes` not at all.
+                let mut results = Vec::with_capacity(handles.len());
                 for handle in handles {
                     match handle.await {
-                        Ok(ar) => {
-                            let tr = super::primitives::TickResult {
-                                tick_start: ar.tick_start,
-                                duration: ar.duration,
-                                result: ar.result,
-                            };
-                            Self::process_node_result(
-                                &mut nodes[ar.index],
-                                tr,
-                                &running,
-                                &monitors,
-                            );
-                        }
+                        Ok(ar) => results.push(ar),
                         Err(e) => {
                             print_line(&format!("[AsyncIO] spawn_blocking panicked: {}", e));
                         }
                     }
+                }
+
+                // Phase 2: no task is live any more, so `nodes` may be reborrowed.
+                for ar in results {
+                    let tr = super::primitives::TickResult {
+                        tick_start: ar.tick_start,
+                        duration: ar.duration,
+                        result: ar.result,
+                    };
+                    Self::process_node_result(&mut nodes[ar.index], tr, &running, &monitors);
                 }
 
                 // Sleep until next tick period

--- a/horus_core/src/scheduling/compute_executor.rs
+++ b/horus_core/src/scheduling/compute_executor.rs
@@ -91,15 +91,17 @@ impl ComputeExecutor {
             print_line("[Compute] Warning: thread handle already consumed — nothing to join");
             return Vec::new();
         };
-        match handle.join() {
-            Ok(nodes) => nodes,
-            Err(_) => {
-                print_line(
-                    "[Compute] Warning: executor thread panicked; its nodes could not be reclaimed",
-                );
-                Vec::new()
-            }
-        }
+        // Bounded join, matching the guarantee RtExecutor::stop documents. A
+        // bare `handle.join()` here hung the entire shutdown whenever a compute
+        // node blocked inside `tick()`, because this loop only re-checks
+        // `running` between ticks — and `run_with_filter` calls this before it
+        // shuts down or safes any other node.
+        super::primitives::join_with_timeout(
+            handle,
+            "Compute",
+            super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD,
+        )
+        .unwrap_or_default()
     }
 
     /// Main function for the compute thread.
@@ -413,8 +415,15 @@ impl ComputeExecutor {
 
 impl Drop for ComputeExecutor {
     fn drop(&mut self) {
+        // Bounded here too: an early return or a panic can drop the executor
+        // without ever calling `stop()`, and an unbounded join on that path
+        // hangs exactly as badly.
         if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+            let _ = super::primitives::join_with_timeout(
+                handle,
+                "Compute",
+                super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD,
+            );
         }
     }
 }

--- a/horus_core/src/scheduling/dependency_graph.rs
+++ b/horus_core/src/scheduling/dependency_graph.rs
@@ -200,41 +200,21 @@ impl DependencyGraph {
     pub fn node_count(&self) -> usize {
         self.dep_counts.len()
     }
-
-    /// Find independent RT chains for RT thread pool sizing.
-    ///
-    /// Returns groups of RT node indices where nodes within each group
-    /// are connected by dependencies. Independent groups can run on
-    /// separate RT threads.
-    pub fn independent_chains(&self, rt_node_indices: &[usize]) -> Vec<Vec<usize>> {
-        if rt_node_indices.is_empty() {
-            return Vec::new();
-        }
-        if rt_node_indices.len() == 1 {
-            return vec![rt_node_indices.to_vec()];
-        }
-
-        // Simple approach: each step's RT nodes form independent groups
-        // within that step. Across steps, connected RT nodes are in the same chain.
-        // For now, each RT node that appears in different steps with a dependency
-        // is in the same chain.
-
-        // Start with each RT node in its own chain
-        let mut chain_id: HashMap<usize, usize> = HashMap::new();
-        for (chain, &node) in rt_node_indices.iter().enumerate() {
-            chain_id.insert(node, chain);
-        }
-
-        // Collect chains
-        let mut chains: HashMap<usize, Vec<usize>> = HashMap::new();
-        for &node in rt_node_indices {
-            let id = chain_id[&node];
-            chains.entry(id).or_default().push(node);
-        }
-
-        chains.into_values().collect()
-    }
 }
+
+// `independent_chains` used to live here. It was deleted rather than fixed: it
+// claimed to return "groups of RT node indices where nodes within each group
+// are connected by dependencies", but its body never read `successors`,
+// `dep_counts` or `steps` — it assigned every index a distinct chain id and
+// immediately regrouped by that id, so it always returned N singleton groups
+// and dependent RT nodes were never co-located or sequenced. Its one caller
+// also queried it against the wrong graph: `self.dependency_graph` is rebuilt
+// from `self.nodes` AFTER the execution-class partition, i.e. from the
+// BestEffort set, so the RT indices passed in referred to a different node
+// list entirely. Making the grouping real needs a graph built over the RT node
+// set, an index-driven redistribution, and a topological sort that survives
+// `RtExecutor::start_pool`'s `sort_by_key(priority)` — a design change, not a
+// patch. RT nodes are now documented as always one-per-thread.
 
 /// Error during dependency graph construction.
 #[derive(Debug, Clone)]
@@ -646,30 +626,9 @@ mod tests {
         assert_eq!(graph.steps()[3].len(), 2);
     }
 
-    #[test]
-    fn independent_chains_single_rt() {
-        let nodes = vec![make_registered(
-            TestNode::new("ics_A").publishes("ics_x"),
-            0,
-        )];
-        let graph = DependencyGraph::build(&nodes).unwrap();
-        let chains = graph.independent_chains(&[0]);
-        assert_eq!(chains.len(), 1);
-        assert_eq!(chains[0], vec![0]);
-    }
-
-    #[test]
-    fn independent_chains_multiple_independent() {
-        let nodes = vec![
-            make_registered(TestNode::new("icm_A").publishes("icm_x"), 0),
-            make_registered(TestNode::new("icm_B").publishes("icm_y"), 0),
-            make_registered(TestNode::new("icm_C").publishes("icm_z"), 0),
-        ];
-        let graph = DependencyGraph::build(&nodes).unwrap();
-        let chains = graph.independent_chains(&[0, 1, 2]);
-        // Each node is its own chain (all independent)
-        assert_eq!(chains.len(), 3);
-    }
+    // The two `independent_chains_*` tests that stood here were removed with the
+    // function: both only ever asserted that it returned one singleton group
+    // per index, which is what it did for EVERY input, dependent or not.
 
     #[test]
     fn large_graph_performance() {

--- a/horus_core/src/scheduling/event_executor.rs
+++ b/horus_core/src/scheduling/event_executor.rs
@@ -98,14 +98,23 @@ impl EventExecutor {
     }
 
     /// Stop all watcher threads and reclaim nodes.
+    ///
+    /// Bounded, matching the guarantee `RtExecutor::stop` documents. A bare
+    /// `handle.join()` here hung the whole scheduler shutdown whenever an event
+    /// node blocked inside `tick()`, and `run_with_filter` runs the executor
+    /// stops before it shuts down or safes any other node.
+    ///
+    /// The budget is a single overall deadline rather than one per thread:
+    /// there is a watcher thread PER event node, so a per-thread budget would
+    /// scale the worst case with the node count.
     pub fn stop(mut self) -> Vec<RegisteredNode> {
+        let deadline =
+            std::time::Instant::now() + super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD;
         let mut nodes = Vec::with_capacity(self.handles.len());
         for handle in self.handles.drain(..) {
-            match handle.join() {
-                Ok(node) => nodes.push(node),
-                Err(_) => {
-                    print_line("[Event] Warning: watcher thread panicked during join");
-                }
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if let Some(node) = super::primitives::join_with_timeout(handle, "Event", remaining) {
+                nodes.push(node);
             }
         }
         print_line(&format!(
@@ -318,8 +327,14 @@ impl EventExecutor {
 
 impl Drop for EventExecutor {
     fn drop(&mut self) {
+        // Bounded here too: an early return or a panic can drop the executor
+        // without ever calling `stop()`, and an unbounded join on that path
+        // hangs exactly as badly.
+        let deadline =
+            std::time::Instant::now() + super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD;
         for handle in self.handles.drain(..) {
-            let _ = handle.join();
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let _ = super::primitives::join_with_timeout(handle, "Event", remaining);
         }
     }
 }

--- a/horus_core/src/scheduling/event_executor.rs
+++ b/horus_core/src/scheduling/event_executor.rs
@@ -108,8 +108,7 @@ impl EventExecutor {
     /// there is a watcher thread PER event node, so a per-thread budget would
     /// scale the worst case with the node count.
     pub fn stop(mut self) -> Vec<RegisteredNode> {
-        let deadline =
-            std::time::Instant::now() + super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD;
+        let deadline = std::time::Instant::now() + super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD;
         let mut nodes = Vec::with_capacity(self.handles.len());
         for handle in self.handles.drain(..) {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -330,8 +329,7 @@ impl Drop for EventExecutor {
         // Bounded here too: an early return or a panic can drop the executor
         // without ever calling `stop()`, and an unbounded join on that path
         // hangs exactly as badly.
-        let deadline =
-            std::time::Instant::now() + super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD;
+        let deadline = std::time::Instant::now() + super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD;
         for handle in self.handles.drain(..) {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
             let _ = super::primitives::join_with_timeout(handle, "Event", remaining);

--- a/horus_core/src/scheduling/mod.rs
+++ b/horus_core/src/scheduling/mod.rs
@@ -112,6 +112,15 @@ pub(crate) mod blackbox {
     use serde::{Deserialize, Serialize};
     use std::path::PathBuf;
 
+    /// Mirror of the real `BlackBoxEvent` in `blackbox.rs`.
+    ///
+    /// The call sites that build these events (schedulers, executors, horus_net)
+    /// are *not* feature-gated — they construct `BlackBoxEvent` unconditionally and
+    /// let `record()` throw it away when the feature is off.  That makes this stub a
+    /// silent shadow of the real enum: any variant or field added there but not here
+    /// compiles fine in the default build and only explodes in a
+    /// `--no-default-features` build (E0559/E0599), typically much later in CI.
+    /// Keep the two definitions field-for-field identical.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub enum BlackBoxEvent {
         SchedulerStart {
@@ -135,6 +144,7 @@ pub(crate) mod blackbox {
         NodeError {
             name: String,
             error: String,
+            severity: crate::error::Severity,
         },
         DeadlineMiss {
             name: String,
@@ -153,14 +163,24 @@ pub(crate) mod blackbox {
         EmergencyStop {
             reason: String,
         },
+        NetPeerDiscovered {
+            peer_addr: String,
+            topic_count: usize,
+        },
+        NetPeerLost {
+            peer_addr: String,
+            reason: String,
+        },
+        NetReplicationStarted {
+            peer_count: usize,
+        },
+        NetImportRejected {
+            topic: String,
+            peer_addr: String,
+        },
         Custom {
             category: String,
             message: String,
-        },
-        PodSnapshot {
-            data: Vec<u8>,
-            type_name: String,
-            context: String,
         },
     }
 
@@ -184,7 +204,7 @@ pub(crate) mod blackbox {
         }
         pub fn flush_wal(&mut self) {}
         pub fn record(&mut self, _event: BlackBoxEvent) {}
-        pub fn tick(&mut self) {}
+        pub(crate) fn tick(&mut self) {}
         pub fn events(&self) -> Vec<BlackBoxRecord> {
             Vec::new()
         }
@@ -197,21 +217,22 @@ pub(crate) mod blackbox {
         pub fn load(&mut self) -> std::io::Result<()> {
             Ok(())
         }
-        pub fn record_pod_snapshot<T: crate::communication::PodMessage>(
-            &mut self,
-            _msg: &T,
-            _context: &str,
-        ) {
-        }
-        pub fn read_pod_snapshot<T: crate::communication::PodMessage>(_data: &[u8]) -> Option<T> {
-            None
-        }
         pub fn clear(&mut self) {}
         pub fn len(&self) -> usize {
             0
         }
         pub fn is_empty(&self) -> bool {
             true
+        }
+        /// Always 0 — the stub never buffers, so it can never evict a record.
+        pub fn get_loss_count(&self) -> u64 {
+            0
+        }
+    }
+
+    impl Default for BlackBox {
+        fn default() -> Self {
+            Self::new(0) // Disabled by default
         }
     }
 

--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -274,6 +274,57 @@ pub(crate) fn clear_node_tick_context() {
     crate::core::hlog::clear_node_context();
 }
 
+/// Maximum time an executor thread gets to exit during shutdown before it is
+/// detached.
+///
+/// `RtExecutor::stop` documents the guarantee this constant backs: shutdown
+/// always completes within `SHUTDOWN_TIMEOUT_PER_THREAD x num_threads`, so a
+/// single stalled node cannot block the process from exiting.
+pub(crate) const SHUTDOWN_TIMEOUT_PER_THREAD: Duration = Duration::from_secs(3);
+
+/// Join `handle` with a bounded deadline, returning `None` if it does not
+/// finish in time (the handle is dropped and the thread detached) or panicked.
+///
+/// Every executor must use this rather than a bare `handle.join()`. The
+/// compute, event and async executors used to join unbounded, and their loops
+/// only re-check `running` BETWEEN ticks — so a node blocked inside `tick()`
+/// (an unplugged device read with no timeout, a deadlocked mutex, an infinite
+/// loop) hung the whole shutdown. Because `run_with_filter` calls the executor
+/// stops before `shutdown_filtered_nodes` and `finalize_run`, that also meant
+/// no OTHER node was ever shut down or safed, and the blackbox was never
+/// flushed: the process had to be SIGKILLed with actuators left at their last
+/// commanded value.
+pub(crate) fn join_with_timeout<T>(
+    handle: std::thread::JoinHandle<T>,
+    label: &str,
+    timeout: Duration,
+) -> Option<T> {
+    let start = Instant::now();
+    loop {
+        if handle.is_finished() {
+            return match handle.join() {
+                Ok(v) => Some(v),
+                Err(_) => {
+                    crate::terminal::print_line(&format!("[{label}] thread panicked during stop"));
+                    None
+                }
+            };
+        }
+        if start.elapsed() > timeout {
+            crate::terminal::print_line(&format!(
+                "[{label}] thread did not exit within {timeout:?} — detaching \
+                 (possible stalled tick); its nodes are not reclaimed. The \
+                 thread dies when the process exits."
+            ));
+            // Drop the JoinHandle without joining: the thread keeps running but
+            // no longer holds shutdown hostage.
+            drop(handle);
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 /// Action to take after a budget violation is detected.
 #[derive(Debug)]
 pub(crate) struct BudgetViolationResult {

--- a/horus_core/src/scheduling/registry.rs
+++ b/horus_core/src/scheduling/registry.rs
@@ -7,7 +7,7 @@
 //! metrics directly.
 
 use crate::memory::platform::shm_scheduler_dir;
-use memmap2::MmapMut;
+use memmap2::MmapRaw;
 use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
@@ -135,13 +135,18 @@ pub struct NodeSlotSnapshot {
 /// `write_lock` serializes only the paths that do non-atomic writes
 /// (`init_header`, `register_node`); both run on the main thread at startup.
 ///
-/// `MmapMut` is `Send + Sync`, so keeping it unwrapped preserves this type's
-/// auto traits. Do NOT cache a raw `*mut u8` base pointer in a field — that
-/// would make `SchedulerRegistry` `!Send`/`!Sync`. The base is re-derived per
-/// call instead, which is stable because the region is never remapped or
+/// The mapping is a `MmapRaw`, not a `MmapMut`: `MmapRaw` hands out
+/// `*mut u8` from `&self` with the mapping's own provenance, whereas
+/// `MmapMut` only reaches a mutable pointer through `DerefMut`, i.e. `&mut
+/// self`. Casting `MmapMut::as_ptr()` (a pointer derived from a shared `&[u8]`)
+/// to `*mut` and storing through it is what the previous code did inside the
+/// lock; that is not sound to keep doing once the `&mut` is gone. `MmapRaw` is
+/// `Send + Sync`, so this type's auto traits are preserved; caching a bare
+/// `*mut u8` in a field instead would have made it `!Send`/`!Sync`. The base is
+/// re-derived per call, which is stable because the region is never remapped or
 /// resized after `open()`.
 pub struct SchedulerRegistry {
-    mmap: MmapMut,
+    mmap: MmapRaw,
     write_lock: Mutex<()>,
     path: PathBuf,
 }
@@ -175,14 +180,15 @@ impl SchedulerRegistry {
             file.set_len(REGISTRY_FILE_SIZE as u64)?;
         }
 
-        // SAFETY: file is valid, size set to REGISTRY_FILE_SIZE.
-        let mmap = unsafe {
-            MmapMut::map_mut(&file).map_err(|e| {
-                crate::error::HorusError::Memory(crate::error::MemoryError::MmapFailed {
-                    reason: e.to_string(),
-                })
-            })?
-        };
+        // `MmapRaw::map_raw` is the writable mapping that never materialises a
+        // reference to the region — the right primitive for a shared-memory
+        // area written concurrently by several threads and read by other
+        // processes. It is a safe fn for that reason.
+        let mmap = MmapRaw::map_raw(&file).map_err(|e| {
+            crate::error::HorusError::Memory(crate::error::MemoryError::MmapFailed {
+                reason: e.to_string(),
+            })
+        })?;
 
         let registry = Self {
             mmap,
@@ -200,7 +206,7 @@ impl SchedulerRegistry {
         // Non-atomic writes (version, pid, magic) — serialized against
         // `register_node`. Off the hot path: startup only.
         let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let base = self.mmap.as_ptr() as *mut u8;
+        let base = self.mmap.as_mut_ptr();
         // SAFETY: mmap is at least REGISTRY_FILE_SIZE bytes, HEADER_SIZE=64.
         unsafe {
             // Version first
@@ -230,7 +236,7 @@ impl SchedulerRegistry {
         // non-atomically, and does a load-then-fetch_add on the header count.
         // Startup only, so the lock is off the tick path.
         let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let base = self.mmap.as_ptr() as *mut u8;
+        let base = self.mmap.as_mut_ptr();
 
         // SAFETY: mmap covers REGISTRY_FILE_SIZE bytes.
         let count =
@@ -326,7 +332,7 @@ impl SchedulerRegistry {
         if slot_idx >= MAX_REGISTRY_NODES {
             return;
         }
-        let base = self.mmap.as_ptr() as *mut u8;
+        let base = self.mmap.as_mut_ptr();
         let slot_offset = HEADER_SIZE + slot_idx * SLOT_SIZE;
 
         // SAFETY: slot_idx < MAX, so slot_offset + SLOT_SIZE <= REGISTRY_FILE_SIZE.

--- a/horus_core/src/scheduling/registry.rs
+++ b/horus_core/src/scheduling/registry.rs
@@ -120,8 +120,29 @@ pub struct NodeSlotSnapshot {
 }
 
 /// Live node registry backed by a shared-memory file.
+///
+/// The mapping is held unwrapped rather than behind a `Mutex`. It used to be
+/// `Mutex<MmapMut>`, which put a process-wide `std::sync::Mutex` on
+/// `update_node` — a function called at the end of EVERY tick of EVERY node on
+/// EVERY executor, including the SCHED_FIFO RT threads. An RT thread then
+/// blocked on a futex held by a normal-priority compute or event thread:
+/// textbook priority inversion, on the one path this module promises is never
+/// blocked by compute or event nodes (and which the call sites document as
+/// "~5ns atomic writes"). The lock bought nothing there: every field
+/// `update_node` writes is an atomic at a fixed offset inside a slot owned by
+/// exactly one node, so lock-free concurrent stores are already correct.
+///
+/// `write_lock` serializes only the paths that do non-atomic writes
+/// (`init_header`, `register_node`); both run on the main thread at startup.
+///
+/// `MmapMut` is `Send + Sync`, so keeping it unwrapped preserves this type's
+/// auto traits. Do NOT cache a raw `*mut u8` base pointer in a field — that
+/// would make `SchedulerRegistry` `!Send`/`!Sync`. The base is re-derived per
+/// call instead, which is stable because the region is never remapped or
+/// resized after `open()`.
 pub struct SchedulerRegistry {
-    mmap: Mutex<MmapMut>,
+    mmap: MmapMut,
+    write_lock: Mutex<()>,
     path: PathBuf,
 }
 
@@ -164,7 +185,8 @@ impl SchedulerRegistry {
         };
 
         let registry = Self {
-            mmap: Mutex::new(mmap),
+            mmap,
+            write_lock: Mutex::new(()),
             path,
         };
 
@@ -175,8 +197,10 @@ impl SchedulerRegistry {
     }
 
     fn init_header(&self) {
-        let guard = self.mmap.lock().unwrap_or_else(|e| e.into_inner());
-        let base = guard.as_ptr() as *mut u8;
+        // Non-atomic writes (version, pid, magic) — serialized against
+        // `register_node`. Off the hot path: startup only.
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let base = self.mmap.as_ptr() as *mut u8;
         // SAFETY: mmap is at least REGISTRY_FILE_SIZE bytes, HEADER_SIZE=64.
         unsafe {
             // Version first
@@ -192,16 +216,40 @@ impl SchedulerRegistry {
     }
 
     /// Register a node and return its slot index.
-    pub fn register_node(&self, name: &str, order: u8, rate_hz: f64, execution_class: u8) -> usize {
-        let mut guard = self.mmap.lock().unwrap_or_else(|e| e.into_inner());
-        let base = guard.as_mut_ptr();
+    ///
+    /// Returns `None` when the registry is full: there is no slot to hand out,
+    /// and the caller must not record one.
+    pub fn register_node(
+        &self,
+        name: &str,
+        order: u8,
+        rate_hz: f64,
+        execution_class: u8,
+    ) -> Option<usize> {
+        // Serialized: this writes the name bytes and the class/order fields
+        // non-atomically, and does a load-then-fetch_add on the header count.
+        // Startup only, so the lock is off the tick path.
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let base = self.mmap.as_ptr() as *mut u8;
 
         // SAFETY: mmap covers REGISTRY_FILE_SIZE bytes.
         let count =
             unsafe { (*(base.add(12) as *const AtomicU32)).load(Ordering::Acquire) } as usize;
 
+        // A full registry used to return `MAX_REGISTRY_NODES - 1` — the slot
+        // legitimately owned by node #64. Every node past the 64th was handed
+        // that same index, so they all raced writing each other's tick counts,
+        // health and timings into one slot that still carried node #64's name:
+        // `horus node list` attributed another node's metrics to it, and a
+        // failing node could be masked by a healthy one sharing the slot.
+        // No slot is better than someone else's slot.
         if count >= MAX_REGISTRY_NODES {
-            return count.min(MAX_REGISTRY_NODES - 1);
+            log::warn!(
+                "SHM registry full ({} slots): node '{}' will have no live registry slot",
+                MAX_REGISTRY_NODES,
+                name
+            );
+            return None;
         }
 
         let slot_offset = HEADER_SIZE + count * SLOT_SIZE;
@@ -245,12 +293,18 @@ impl SchedulerRegistry {
             (*(base.add(12) as *const AtomicU32)).fetch_add(1, Ordering::Release);
         }
 
-        count
+        Some(count)
     }
 
     /// Update a node's live metrics (called by scheduler on every tick).
     ///
     /// All writes are `Relaxed` — counters and timing don't need ordering.
+    ///
+    /// This must stay lock-free. It runs on the SCHED_FIFO RT threads, which
+    /// must never block on a futex a normal-priority thread can hold; the
+    /// surrounding RT code uses `try_lock` for the profiler and blackbox for
+    /// exactly this reason. Every store below is an atomic at a fixed offset in
+    /// a slot owned by a single node, so no mutual exclusion is required.
     // 10 arguments mirror distinct fields in the SHM node-registry entry that are
     // updated atomically on every tick. A wrapper struct would add a stack copy
     // on the hot path with no semantic benefit.
@@ -272,8 +326,7 @@ impl SchedulerRegistry {
         if slot_idx >= MAX_REGISTRY_NODES {
             return;
         }
-        let guard = self.mmap.lock().unwrap_or_else(|e| e.into_inner());
-        let base = guard.as_ptr() as *mut u8;
+        let base = self.mmap.as_ptr() as *mut u8;
         let slot_offset = HEADER_SIZE + slot_idx * SLOT_SIZE;
 
         // SAFETY: slot_idx < MAX, so slot_offset + SLOT_SIZE <= REGISTRY_FILE_SIZE.
@@ -490,7 +543,7 @@ mod tests {
     fn register_single_node_roundtrip() {
         let name = test_name("single");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        let idx = reg.register_node("motor_ctrl", 0, 100.0, 0);
+        let idx = reg.register_node("motor_ctrl", 0, 100.0, 0).expect("registry not full");
         assert_eq!(idx, 0, "first node should get slot 0");
 
         let slots = SchedulerRegistry::read_all_slots(&name).expect("read");
@@ -512,11 +565,11 @@ mod tests {
         let name = test_name("multi");
         let reg = SchedulerRegistry::open(&name).expect("open");
 
-        let idx0 = reg.register_node("motor", 0, 100.0, 0);
-        let idx1 = reg.register_node("sensor", 1, 200.0, 1);
-        let idx2 = reg.register_node("planner", 5, 10.0, 2);
-        let idx3 = reg.register_node("logger", 10, 1.0, 4);
-        let idx4 = reg.register_node("telemetry", 20, 0.5, 3);
+        let idx0 = reg.register_node("motor", 0, 100.0, 0).expect("registry not full");
+        let idx1 = reg.register_node("sensor", 1, 200.0, 1).expect("registry not full");
+        let idx2 = reg.register_node("planner", 5, 10.0, 2).expect("registry not full");
+        let idx3 = reg.register_node("logger", 10, 1.0, 4).expect("registry not full");
+        let idx4 = reg.register_node("telemetry", 20, 0.5, 3).expect("registry not full");
 
         assert_eq!(idx0, 0);
         assert_eq!(idx1, 1);
@@ -542,7 +595,7 @@ mod tests {
     fn update_node_changes_visible() {
         let name = test_name("update");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        let idx = reg.register_node("sensor", 1, 200.0, 1);
+        let idx = reg.register_node("sensor", 1, 200.0, 1).expect("registry not full");
 
         reg.update_node(
             idx, 2,         // health: Unhealthy
@@ -574,7 +627,7 @@ mod tests {
     fn update_node_multiple_times() {
         let name = test_name("multi_upd");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        let idx = reg.register_node("ctrl", 0, 100.0, 0);
+        let idx = reg.register_node("ctrl", 0, 100.0, 0).expect("registry not full");
 
         for tick in 1..=10u64 {
             reg.update_node(idx, 0, tick * 100, 0, 0, 0, 0, 500, 500, 500, 0);
@@ -593,7 +646,8 @@ mod tests {
         let name = test_name("trunc");
         let reg = SchedulerRegistry::open(&name).expect("open");
         let long_name = "X".repeat(60);
-        reg.register_node(&long_name, 0, 50.0, 0);
+        reg.register_node(&long_name, 0, 50.0, 0)
+            .expect("registry not full");
 
         let slots = SchedulerRegistry::read_all_slots(&name).expect("read");
         assert_eq!(
@@ -624,7 +678,7 @@ mod tests {
     fn remove_deletes_file() {
         let name = test_name("rm");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        reg.register_node("node", 0, 10.0, 0);
+        reg.register_node("node", 0, 10.0, 0).expect("registry not full");
         let path = shm_scheduler_dir().join(&name);
         assert!(path.exists());
 
@@ -651,6 +705,44 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// Regression: nodes past the 64th must get NO slot rather than a shared
+    /// one. `register_node` used to return `MAX_REGISTRY_NODES - 1` when full,
+    /// so every overflow node aliased slot 63 and race-wrote node #64's live
+    /// metrics under node #64's name.
+    #[test]
+    fn registry_overflow_returns_none_instead_of_aliasing_the_last_slot() {
+        let name = test_name("overflow");
+        let reg = SchedulerRegistry::open(&name).expect("open");
+
+        for i in 0..MAX_REGISTRY_NODES {
+            let slot = reg
+                .register_node(&format!("node_{i}"), 0, 100.0, 0)
+                .expect("registry has room");
+            assert_eq!(slot, i, "node {i} should get slot {i}");
+        }
+
+        assert!(
+            reg.register_node("overflow_node", 0, 100.0, 0).is_none(),
+            "the 65th node must get no slot, not slot 63"
+        );
+
+        let slots = SchedulerRegistry::read_all_slots(&name).expect("read");
+        assert_eq!(slots.len(), MAX_REGISTRY_NODES);
+        let names: std::collections::HashSet<&str> =
+            slots.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names.len(),
+            MAX_REGISTRY_NODES,
+            "every occupied slot must still name a distinct node"
+        );
+        assert!(
+            !names.contains("overflow_node"),
+            "the rejected node must not have overwritten anyone"
+        );
+
+        reg.remove().expect("cleanup");
+    }
+
     // ── Cross-process simulation ───────────────────────────────────────
 
     #[test]
@@ -660,8 +752,8 @@ mod tests {
         let name = test_name("xproc");
         let reg = SchedulerRegistry::open(&name).expect("open");
 
-        reg.register_node("motor", 0, 100.0, 0);
-        reg.register_node("sensor", 1, 200.0, 1);
+        reg.register_node("motor", 0, 100.0, 0).expect("registry not full");
+        reg.register_node("sensor", 1, 200.0, 1).expect("registry not full");
         reg.update_node(0, 0, 10000, 0, 0, 0, 0, 800_000, 750_000, 1_500_000, 0);
         reg.update_node(1, 1, 20000, 5, 3, 1, 0, 400_000, 380_000, 900_000, 0);
 
@@ -689,8 +781,10 @@ mod tests {
         let reg1 = SchedulerRegistry::open(&name1).expect("open 1");
         let reg2 = SchedulerRegistry::open(&name2).expect("open 2");
 
-        reg1.register_node("node_a", 0, 50.0, 0);
-        reg2.register_node("node_b", 0, 60.0, 0);
+        reg1.register_node("node_a", 0, 50.0, 0)
+            .expect("registry not full");
+        reg2.register_node("node_b", 0, 60.0, 0)
+            .expect("registry not full");
 
         let all = SchedulerRegistry::read_all_registries();
         let found_a = all

--- a/horus_core/src/scheduling/registry.rs
+++ b/horus_core/src/scheduling/registry.rs
@@ -549,7 +549,9 @@ mod tests {
     fn register_single_node_roundtrip() {
         let name = test_name("single");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        let idx = reg.register_node("motor_ctrl", 0, 100.0, 0).expect("registry not full");
+        let idx = reg
+            .register_node("motor_ctrl", 0, 100.0, 0)
+            .expect("registry not full");
         assert_eq!(idx, 0, "first node should get slot 0");
 
         let slots = SchedulerRegistry::read_all_slots(&name).expect("read");
@@ -571,11 +573,21 @@ mod tests {
         let name = test_name("multi");
         let reg = SchedulerRegistry::open(&name).expect("open");
 
-        let idx0 = reg.register_node("motor", 0, 100.0, 0).expect("registry not full");
-        let idx1 = reg.register_node("sensor", 1, 200.0, 1).expect("registry not full");
-        let idx2 = reg.register_node("planner", 5, 10.0, 2).expect("registry not full");
-        let idx3 = reg.register_node("logger", 10, 1.0, 4).expect("registry not full");
-        let idx4 = reg.register_node("telemetry", 20, 0.5, 3).expect("registry not full");
+        let idx0 = reg
+            .register_node("motor", 0, 100.0, 0)
+            .expect("registry not full");
+        let idx1 = reg
+            .register_node("sensor", 1, 200.0, 1)
+            .expect("registry not full");
+        let idx2 = reg
+            .register_node("planner", 5, 10.0, 2)
+            .expect("registry not full");
+        let idx3 = reg
+            .register_node("logger", 10, 1.0, 4)
+            .expect("registry not full");
+        let idx4 = reg
+            .register_node("telemetry", 20, 0.5, 3)
+            .expect("registry not full");
 
         assert_eq!(idx0, 0);
         assert_eq!(idx1, 1);
@@ -601,7 +613,9 @@ mod tests {
     fn update_node_changes_visible() {
         let name = test_name("update");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        let idx = reg.register_node("sensor", 1, 200.0, 1).expect("registry not full");
+        let idx = reg
+            .register_node("sensor", 1, 200.0, 1)
+            .expect("registry not full");
 
         reg.update_node(
             idx, 2,         // health: Unhealthy
@@ -633,7 +647,9 @@ mod tests {
     fn update_node_multiple_times() {
         let name = test_name("multi_upd");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        let idx = reg.register_node("ctrl", 0, 100.0, 0).expect("registry not full");
+        let idx = reg
+            .register_node("ctrl", 0, 100.0, 0)
+            .expect("registry not full");
 
         for tick in 1..=10u64 {
             reg.update_node(idx, 0, tick * 100, 0, 0, 0, 0, 500, 500, 500, 0);
@@ -684,7 +700,8 @@ mod tests {
     fn remove_deletes_file() {
         let name = test_name("rm");
         let reg = SchedulerRegistry::open(&name).expect("open");
-        reg.register_node("node", 0, 10.0, 0).expect("registry not full");
+        reg.register_node("node", 0, 10.0, 0)
+            .expect("registry not full");
         let path = shm_scheduler_dir().join(&name);
         assert!(path.exists());
 
@@ -758,8 +775,10 @@ mod tests {
         let name = test_name("xproc");
         let reg = SchedulerRegistry::open(&name).expect("open");
 
-        reg.register_node("motor", 0, 100.0, 0).expect("registry not full");
-        reg.register_node("sensor", 1, 200.0, 1).expect("registry not full");
+        reg.register_node("motor", 0, 100.0, 0)
+            .expect("registry not full");
+        reg.register_node("sensor", 1, 200.0, 1)
+            .expect("registry not full");
         reg.update_node(0, 0, 10000, 0, 0, 0, 0, 800_000, 750_000, 1_500_000, 0);
         reg.update_node(1, 1, 20000, 5, 3, 1, 0, 400_000, 380_000, 900_000, 0);
 

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -2417,7 +2417,12 @@ mod tests {
         );
         // Check that within each 3-node cycle, priority order is maintained
         // (prio_0, prio_10, prio_20) repeating
-        for chunk in recorded.chunks_exact(3) {
+        // `as_chunks::<3>()` rather than `chunks_exact(3)`: the chunk size is a
+        // constant, so this yields `&[String; 3]` and the indexing below is
+        // bounds-checked at compile time. clippy 1.98 lints the `chunks_exact`
+        // form for exactly this reason.
+        let (cycles, _partial) = recorded.as_chunks::<3>();
+        for chunk in cycles {
             assert_eq!(chunk[0], "prio_0", "first in cycle should be prio_0");
             assert_eq!(chunk[1], "prio_10", "second in cycle should be prio_10");
             assert_eq!(chunk[2], "prio_20", "third in cycle should be prio_20");

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -153,37 +153,17 @@ impl RtExecutor {
     /// Shutdown always completes within `SHUTDOWN_TIMEOUT_PER_THREAD × num_threads`.
     /// A single stalled node cannot block the process from exiting.
     pub fn stop(mut self) -> Vec<RegisteredNode> {
-        /// Maximum time to wait for each RT thread to exit during shutdown.
-        /// If a thread doesn't exit within this time, it is detached.
-        const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
-
+        // The bounded-join loop lives in `primitives::join_with_timeout` so the
+        // compute, event and async executors — which used to join unbounded —
+        // back the same guarantee from one implementation.
         let mut all_nodes = Vec::new();
         for (i, handle) in std::mem::take(&mut self.handles).into_iter().enumerate() {
-            let start = Instant::now();
-            loop {
-                if handle.is_finished() {
-                    match handle.join() {
-                        Ok(nodes) => all_nodes.extend(nodes),
-                        Err(_) => {
-                            print_line(&format!("[RT-thread] Thread {} panicked during stop", i));
-                        }
-                    }
-                    break;
-                }
-                if start.elapsed() > SHUTDOWN_TIMEOUT {
-                    print_line(&format!(
-                        "[RT-thread] Thread {} did not exit within {:?} — \
-                         detaching (possible stalled tick). The thread will be \
-                         terminated when the process exits.",
-                        i, SHUTDOWN_TIMEOUT
-                    ));
-                    // Drop JoinHandle without joining. The thread continues
-                    // running but dies when the process exits. Nodes on this
-                    // thread are lost (not returned to the scheduler).
-                    drop(handle);
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(10));
+            if let Some(nodes) = super::primitives::join_with_timeout(
+                handle,
+                &format!("RT-thread {i}"),
+                super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD,
+            ) {
+                all_nodes.extend(nodes);
             }
         }
         all_nodes

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -961,6 +961,25 @@ impl SafetyMonitor {
     }
 
     /// Check tick budget for a node — records timing data and checks overrun.
+    ///
+    /// This is pure accounting: it records the timing sample and reports the
+    /// violation to the caller. It does NOT escalate.
+    ///
+    /// It used to emergency-stop the whole robot whenever the overrunning node
+    /// was in `critical_nodes`. That set is populated by
+    /// `Scheduler::apply_safety_config` for EVERY RT node as soon as any
+    /// `.watchdog()` is configured, and `NodeRegistration::finalize` derives a
+    /// tick budget of 80% of the period for every `.rate()` node — so a single
+    /// microsecond of ordinary RT jitter latched a fleet-wide e-stop, silently
+    /// overriding the node's own `BudgetPolicy::Warn` (the documented default:
+    /// "log the violation but take no corrective action"). `critical_nodes`
+    /// means "has a watchdog", not "any timing blip is fatal".
+    ///
+    /// Escalation belongs to the paths that actually read configuration: the
+    /// `BudgetPolicy` dispatch in `rt_executor.rs` and
+    /// `Scheduler::check_timing_violations`, the graduated ladder via
+    /// `evaluate_degradation`, and the 3x-timeout watchdog e-stop in
+    /// `check_watchdogs_graduated`.
     pub(crate) fn check_tick_budget(
         &self,
         node_name: &str,
@@ -971,20 +990,9 @@ impl SafetyMonitor {
             .lock()
             .check_budget(node_name, execution_time);
 
-        if let Err(ref violation) = result {
-            let is_critical = self
-                .critical_nodes
-                .read()
-                .contains(&violation.node_name().to_string());
-            if is_critical {
-                self.budget_enforcer.lock().mark_critical_overrun();
-                self.trigger_emergency_stop(format!(
-                    "Critical node {} exceeded tick budget: {:?} > {:?}",
-                    violation.node_name(),
-                    violation.actual(),
-                    violation.budget()
-                ));
-            }
+        // Still counted for reporting — only the escalation is gone.
+        if result.is_err() && self.critical_nodes.read().contains(&node_name.to_string()) {
+            self.budget_enforcer.lock().mark_critical_overrun();
         }
 
         result
@@ -993,12 +1001,23 @@ impl SafetyMonitor {
     /// Record a deadline miss with severity tracking.
     ///
     /// Tracks per-node: total misses, consecutive misses, worst miss duration.
-    /// Triggers emergency stop for critical nodes or when total exceeds max.
+    /// Triggers emergency stop only when the process-wide total crosses
+    /// `max_deadline_misses`.
     pub(crate) fn record_deadline_miss(&self, node_name: &str) {
         self.record_deadline_miss_with_severity(node_name, 0);
     }
 
     /// Record a deadline miss with a specific severity (how far past deadline, in μs).
+    ///
+    /// Like `check_tick_budget`, this used to e-stop immediately whenever the
+    /// missing node was in `critical_nodes` — i.e. on the first miss of any
+    /// node reachable from a `.watchdog()` call. That contradicted
+    /// `Miss::Warn` (the `#[default]`, documented "log warning and continue
+    /// normally") and made the whole graduated ladder dead code, since
+    /// `DegradationPolicy` only starts acting at `warn_after: 3` consecutive
+    /// misses. Per-node escalation is the caller's job, via the `Miss` policy
+    /// dispatch and `evaluate_degradation`; only the `max_deadline_misses`
+    /// ceiling — an explicitly configured number — stops the robot here.
     pub(crate) fn record_deadline_miss_with_severity(&self, node_name: &str, severity_us: u64) {
         let misses = self.deadline_misses.fetch_add(1, Ordering::SeqCst) + 1;
 
@@ -1007,10 +1026,7 @@ impl SafetyMonitor {
             .lock()
             .record_deadline_miss(node_name, severity_us);
 
-        let is_critical = self.critical_nodes.read().contains(&node_name.to_string());
-        if is_critical {
-            self.trigger_emergency_stop(format!("Critical node {} missed deadline", node_name));
-        } else if misses >= self.max_deadline_misses {
+        if misses >= self.max_deadline_misses {
             self.trigger_emergency_stop(format!("Too many deadline misses: {}", misses));
         }
     }

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -3070,7 +3070,10 @@ mod tests {
         // to the policy dispatch, the `max_deadline_misses` ceiling and the 3x
         // watchdog expiry.
         let result = monitor.check_tick_budget("safety_ctrl", 200_u64.us());
-        assert!(result.is_err(), "the overrun is still reported to the caller");
+        assert!(
+            result.is_err(),
+            "the overrun is still reported to the caller"
+        );
         assert!(
             !monitor.is_emergency_stop(),
             "a watchdogged node is not a must-never-miss node: one overrun \

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -1480,19 +1480,58 @@ mod tests {
         reader.join().unwrap();
     }
 
-    /// Smoke-test that a critical-node deadline miss still triggers emergency
-    /// stop after the RwLock refactor.
+    /// Inverted: this test used to assert that one deadline miss by a node in
+    /// `critical_nodes` latched an emergency stop. `critical_nodes` only means
+    /// "this node has a watchdog" — every RT node lands there as soon as any
+    /// `.watchdog()` is configured — so that made a single tick of jitter
+    /// fatal and overrode the node's own `Miss::Warn` policy. A watchdogged
+    /// node is not a must-never-miss node; escalation is the caller's, via the
+    /// Miss policy, the degradation ladder, or the `max_deadline_misses`
+    /// ceiling.
     #[test]
-    fn test_critical_node_deadline_miss_triggers_emergency_stop() {
+    fn test_critical_node_deadline_miss_does_not_trigger_emergency_stop() {
         let monitor = SafetyMonitor::new(100);
         monitor.add_critical_node("critical".to_string(), 1_u64.secs());
 
         assert!(!monitor.is_emergency_stop());
         monitor.record_deadline_miss("critical");
         assert!(
-            monitor.is_emergency_stop(),
-            "Emergency stop should be set after critical node deadline miss"
+            !monitor.is_emergency_stop(),
+            "A single deadline miss by a watchdogged node must not e-stop the robot"
         );
+    }
+
+    /// Regression for the same defect on the budget path: a watchdogged node
+    /// that overruns its tick budget once — the common case, since
+    /// `NodeRegistration::finalize` derives a budget of 80% of the period for
+    /// every `.rate()` node — must be reported to the caller and must NOT
+    /// escalate on its own. With `BudgetPolicy::Warn` / `Miss::Warn` the
+    /// graduated ladder is what eventually reacts, and only at `warn_after`.
+    #[test]
+    fn test_watchdogged_node_survives_first_budget_overrun() {
+        let monitor = SafetyMonitor::new(100);
+        monitor.add_critical_node("motor".to_string(), 500_u64.ms());
+        monitor.set_tick_budget("motor".to_string(), 800_u64.us());
+
+        // 810µs against an 800µs budget: ordinary RT jitter.
+        let result = monitor.check_tick_budget("motor", 810_u64.us());
+        assert!(result.is_err(), "the overrun must still be reported");
+        assert!(
+            !monitor.is_emergency_stop(),
+            "a single budget overrun must not e-stop the robot"
+        );
+
+        // The ladder stays quiet below warn_after (default 3) and only warns
+        // when it is reached.
+        assert!(matches!(
+            monitor.evaluate_degradation("motor", 1, Some(1000.0)),
+            DegradationAction::None
+        ));
+        assert!(matches!(
+            monitor.evaluate_degradation("motor", 3, Some(1000.0)),
+            DegradationAction::Warn(_)
+        ));
+        assert!(!monitor.is_emergency_stop());
     }
 
     /// check_watchdogs() with 100 watchdogs must complete in < 1μs on average
@@ -2339,16 +2378,23 @@ mod tests {
         assert!(monitor.is_emergency_stop());
     }
 
+    /// Inverted alongside `test_critical_node_deadline_miss_does_not_trigger_emergency_stop`:
+    /// watchdog membership is no longer an escalation trigger, so neither a
+    /// watchdogged nor a plain node e-stops on a single miss. The e-stop now
+    /// comes from the explicitly configured `max_deadline_misses` ceiling.
     #[test]
-    fn test_emergency_stop_from_critical_node_miss() {
-        let monitor = SafetyMonitor::new(100);
+    fn test_deadline_misses_estop_only_at_the_configured_ceiling() {
+        let monitor = SafetyMonitor::new(3);
         monitor.add_critical_node("balance_controller".to_string(), Duration::from_millis(100));
 
-        // Non-critical miss — no estop
         monitor.record_deadline_miss("arm_controller");
         assert!(!monitor.is_emergency_stop());
 
-        // Critical miss — estop
+        // A watchdogged node missing once is no longer fatal either.
+        monitor.record_deadline_miss("balance_controller");
+        assert!(!monitor.is_emergency_stop());
+
+        // Third miss reaches max_deadline_misses = 3 — that is what stops us.
         monitor.record_deadline_miss("balance_controller");
         assert!(monitor.is_emergency_stop());
     }

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -3054,14 +3054,28 @@ mod tests {
         monitor.add_critical_node("safety_ctrl".to_string(), 1_u64.secs());
         monitor.set_tick_budget("safety_ctrl".to_string(), 100_u64.us());
 
-        // Within budget — no estop
+        // Within budget — no violation, no estop
         let _ = monitor.check_tick_budget("safety_ctrl", 50_u64.us());
         assert!(!monitor.is_emergency_stop());
 
-        // Over budget on critical node — estop
+        // INVERTED. This used to assert that one budget overrun by a node in
+        // `critical_nodes` latched an emergency stop. That was the defect:
+        // `critical_nodes` holds every node with a watchdog, and `.rate()`
+        // auto-derives a budget at 80% of the period, so a single page fault
+        // or IRQ stopped the robot — overriding the node's own
+        // `BudgetPolicy::Warn` default ("log the violation but take no
+        // corrective action") before the caller could consult it, and making
+        // the graduated-degradation ladder unreachable. `check_tick_budget` is
+        // pure accounting now: it reports the violation and leaves escalation
+        // to the policy dispatch, the `max_deadline_misses` ceiling and the 3x
+        // watchdog expiry.
         let result = monitor.check_tick_budget("safety_ctrl", 200_u64.us());
-        assert!(result.is_err());
-        assert!(monitor.is_emergency_stop());
+        assert!(result.is_err(), "the overrun is still reported to the caller");
+        assert!(
+            !monitor.is_emergency_stop(),
+            "a watchdogged node is not a must-never-miss node: one overrun \
+             must not stop the robot"
+        );
     }
 
     /// Timing ring stats with a single sample.

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -2663,13 +2663,21 @@ impl Scheduler {
                                         crate::scheduling::types::ExecutionClass::BestEffort => 4,
                                     };
                                     let rate = node.rate_hz.unwrap_or(0.0);
-                                    let slot = reg.register_node(
+                                    // `register_node` returns None when the SHM
+                                    // registry is full. Recording a slot anyway
+                                    // used to alias every overflow node onto
+                                    // slot 63. With no entry here,
+                                    // `SharedMonitors::update_registry` and
+                                    // `update_registry_slot` both return early,
+                                    // so the node simply has no live slot.
+                                    if let Some(slot) = reg.register_node(
                                         &node.name,
                                         node.priority as u8,
                                         rate,
                                         exec_class,
-                                    );
-                                    self.registry_slots.insert(node.name.to_string(), slot);
+                                    ) {
+                                        self.registry_slots.insert(node.name.to_string(), slot);
+                                    }
                                 }
                             }
                             Some(Arc::new(reg))

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -2800,46 +2800,27 @@ impl Scheduler {
 
                     // Split RT nodes into isolated threads for safety.
                     //
-                    // DEFAULT: One thread per RT node. If node A stalls in tick(),
+                    // One thread per RT node, always. If node A stalls in tick(),
                     // node B keeps ticking on its own thread. This prevents a single
                     // stalled node from blocking all RT siblings — critical for robots
                     // where each actuator must be independently controllable.
                     //
-                    // If a dependency graph is available AND has explicit ordering
-                    // constraints, nodes with dependencies are grouped into chains
-                    // (sequential on same thread). Independent nodes get their own threads.
-                    let rt_chains = if let Some(ref graph) = self.dependency_graph {
-                        let rt_indices: Vec<usize> = (0..groups.rt_nodes.len()).collect();
-                        let chain_groups = graph.independent_chains(&rt_indices);
-                        if chain_groups.len() > 1 {
-                            print_line(&format!(
-                                "RT executor: {} independent chains → {} threads",
-                                chain_groups.len(),
-                                chain_groups.len()
-                            ));
-                            // Distribute nodes into chain groups
-                            let mut chains: Vec<Vec<super::types::RegisteredNode>> =
-                                chain_groups.iter().map(|_| Vec::new()).collect();
-                            let mut rt_nodes = groups.rt_nodes;
-                            // Reverse so we can pop from the end
-                            rt_nodes.reverse();
-                            for (chain_idx, group) in chain_groups.iter().enumerate() {
-                                for _ in group {
-                                    if let Some(node) = rt_nodes.pop() {
-                                        chains[chain_idx].push(node);
-                                    }
-                                }
-                            }
-                            chains
-                        } else {
-                            // Single chain from dependency graph — isolate each node
-                            groups.rt_nodes.into_iter().map(|n| vec![n]).collect()
-                        }
-                    } else {
-                        // No dependency graph — isolate each RT node on its own thread.
-                        // This is the safe default: a stalled node cannot block siblings.
-                        groups.rt_nodes.into_iter().map(|n| vec![n]).collect()
-                    };
+                    // This block used to claim that dependent RT nodes were grouped
+                    // into chains and ticked sequentially on one thread. They never
+                    // were: `DependencyGraph::independent_chains` read no edges and
+                    // returned one singleton group per node for every input, and it
+                    // was queried against the post-partition graph, whose indices
+                    // describe the BestEffort nodes, not these. The dead branch and
+                    // its "N independent chains" log line are gone; the behaviour is
+                    // unchanged.
+                    //
+                    // Consequence, stated plainly: the executor provides NO ordering
+                    // guarantee between RT nodes. An RT consumer may read its RT
+                    // producer's previous-tick value. Nodes that need ordering must
+                    // be in the same execution class as each other and sequenced by
+                    // the main loop, or synchronise through the data they exchange.
+                    let rt_chains: Vec<Vec<super::types::RegisteredNode>> =
+                        groups.rt_nodes.into_iter().map(|n| vec![n]).collect();
 
                     rt_executor = Some(
                         super::rt_executor::RtExecutor::start_pool(
@@ -3034,8 +3015,18 @@ impl Scheduler {
         if let Err(e) = ctrlc::set_handler(move || {
             print_line("\nCtrl+C received! Shutting down HORUS scheduler...");
             running.store(false, Ordering::SeqCst);
-            std::thread::spawn(|| {
-                std::thread::sleep(2_u64.secs());
+            // The force-exit grace must EXCEED the orderly shutdown budget, or
+            // it kills a shutdown that was still within it. It was 2s while
+            // every executor is allowed up to `SHUTDOWN_TIMEOUT_PER_THREAD`
+            // (3s) to reclaim a stalled thread, so a single stalled tick meant
+            // the process was force-exited before `shutdown_filtered_nodes`
+            // ever ran — no node shut down, no actuator safed, no blackbox
+            // flush. Doubling the per-thread budget covers one stalled executor
+            // class with headroom; a graph that stalls several RT threads at
+            // once can still exceed it, and is force-exited as before.
+            let grace = super::primitives::SHUTDOWN_TIMEOUT_PER_THREAD * 2;
+            std::thread::spawn(move || {
+                std::thread::sleep(grace);
                 print_line("Force terminating - cleaning up session...");
                 // Clean up session before forced exit to prevent stale files
                 Self::cleanup_session();

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -3936,7 +3936,7 @@ impl Scheduler {
         if !suggestions.is_empty() {
             crate::terminal::eprint_line("\nSuggestions:");
             for s in &suggestions {
-                crate::terminal::eprint_line(&s);
+                crate::terminal::eprint_line(s);
             }
         }
 

--- a/horus_core/src/services/client.rs
+++ b/horus_core/src/services/client.rs
@@ -21,9 +21,10 @@
 //! println!("3 + 4 = {}", response.sum);
 //! ```
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -34,6 +35,27 @@ use crate::error::{HorusResult, RetryConfig};
 use crate::services::types::{
     Service, ServiceError, ServiceRequest, ServiceResponse, ServiceResult,
 };
+
+// ─── Response demultiplexing ──────────────────────────────────────────────────
+
+/// Responses that arrived for a *sibling* pending call, parked by request id
+/// until the handle waiting for them asks.
+///
+/// One `AsyncServiceClient` has one response topic, and `Topic::recv()` is a
+/// destructive, cursor-advancing read. Each handle used to `recv()` for itself
+/// and simply drop anything whose `request_id` did not match — so with two
+/// calls in flight, whichever handle was polled first ate the other's response
+/// and the other timed out on a request the server had answered. This map is
+/// where a response goes instead of on the floor.
+type ResponseInbox<Res> = Arc<Mutex<HashMap<u64, (ServiceResponse<Res>, Instant)>>>;
+
+/// How long an unclaimed parked response is kept before it is evicted.
+///
+/// Bounds the inbox: a handle can be dropped or leaked without ever collecting
+/// its response, and nothing else would ever remove that entry. Comfortably
+/// longer than any sane call timeout, short enough that a long-running node
+/// does not accumulate.
+const INBOX_TTL: Duration = Duration::from_secs(60);
 
 // ─── Request ID generator ─────────────────────────────────────────────────────
 
@@ -245,7 +267,16 @@ where
     Res: Clone + Debug + Send + Sync + Serialize + DeserializeOwned + 'static,
 {
     request_id: u64,
-    res_topic: Arc<Topic<ServiceResponse<Res>>>,
+    /// This handle's OWN response-topic handle.
+    ///
+    /// Owned, not `Arc`-shared: `Topic` is `!Sync`, and two handles polled from
+    /// two threads through one `Arc` was a data race on the ring's
+    /// unsynchronised local cursor. `Clone` gives each handle independent local
+    /// state, and cross-handle correlation is done by `inbox` below rather than
+    /// by sharing the cursor.
+    res_topic: Topic<ServiceResponse<Res>>,
+    /// Shared with the client and every sibling handle — see [`ResponseInbox`].
+    inbox: ResponseInbox<Res>,
     sent_at: Instant,
     timeout: Duration,
     poll_interval: Duration,
@@ -263,22 +294,48 @@ where
     /// - `Err(Timeout)` — deadline exceeded.
     /// - `Err(ServiceFailed)` — server returned an error.
     pub fn check(&mut self) -> ServiceResult<Option<Res>> {
-        if self.sent_at.elapsed() >= self.timeout {
-            return Err(ServiceError::Timeout);
+        // A poisoned inbox mutex means some other handle panicked while holding
+        // it; the map itself is still a valid `HashMap`, and refusing to answer
+        // a completed call because of that would be worse than the panic.
+        let mut inbox = self.inbox.lock().unwrap_or_else(|e| e.into_inner());
+
+        // A sibling handle may already have parked our response.
+        let mut found = inbox.remove(&self.request_id).map(|(r, _)| r);
+        if found.is_none() {
+            // Drain the topic rather than peeking at one message: park every
+            // non-matching response for the handle that is waiting on it. The
+            // old code returned `Ok(None)` on a mismatch, which DISCARDED a
+            // sibling's response — that handle then timed out on a request the
+            // server had answered correctly.
+            while let Some(resp) = self.res_topic.recv() {
+                if resp.request_id == self.request_id {
+                    found = Some(resp);
+                    break;
+                }
+                inbox.insert(resp.request_id, (resp, Instant::now()));
+            }
+        }
+        // Bound memory: drop parked responses nobody ever claimed.
+        inbox.retain(|_, (_, at)| at.elapsed() < INBOX_TTL);
+        drop(inbox);
+
+        if let Some(resp) = found {
+            return if resp.ok {
+                Ok(Some(resp.payload.ok_or(ServiceError::ServiceFailed(
+                    "server returned ok=true but no payload".to_string(),
+                ))?))
+            } else {
+                Err(ServiceError::ServiceFailed(
+                    resp.error.unwrap_or_else(|| "unknown error".to_string()),
+                ))
+            };
         }
 
-        if let Some(resp) = self.res_topic.recv() {
-            if resp.request_id == self.request_id {
-                return if resp.ok {
-                    Ok(Some(resp.payload.ok_or(ServiceError::ServiceFailed(
-                        "server returned ok=true but no payload".to_string(),
-                    ))?))
-                } else {
-                    Err(ServiceError::ServiceFailed(
-                        resp.error.unwrap_or_else(|| "unknown error".to_string()),
-                    ))
-                };
-            }
+        // Deadline is tested AFTER the drain, so a response that landed just
+        // before the deadline is delivered instead of being reported as a
+        // timeout it beat.
+        if self.sent_at.elapsed() >= self.timeout {
+            return Err(ServiceError::Timeout);
         }
         Ok(None)
     }
@@ -299,15 +356,30 @@ where
     }
 }
 
+impl<Res> Drop for PendingServiceCall<Res>
+where
+    Res: Clone + Debug + Send + Sync + Serialize + DeserializeOwned + 'static,
+{
+    fn drop(&mut self) {
+        // An abandoned handle must not leave its own parked response sitting in
+        // the shared inbox for the whole TTL.
+        if let Ok(mut inbox) = self.inbox.lock() {
+            inbox.remove(&self.request_id);
+        }
+    }
+}
+
 /// Non-blocking service client.
 ///
 /// Sends a request and returns a [`PendingServiceCall`] handle that can be
 /// checked each tick without blocking the scheduler.
 pub struct AsyncServiceClient<S: Service> {
     req_topic: Topic<ServiceRequest<S::Request>>,
-    res_topic: Arc<Topic<ServiceResponse<S::Response>>>,
+    res_topic: Topic<ServiceResponse<S::Response>>,
     response_topic_name: String,
     poll_interval: Duration,
+    /// Shared with every handle this client hands out — see [`ResponseInbox`].
+    inbox: ResponseInbox<S::Response>,
 }
 
 impl<S: Service> AsyncServiceClient<S>
@@ -326,12 +398,13 @@ where
         // Per-client response topic for async client
         let client_id = next_client_id();
         let response_topic_name = format!("{}.{}", S::response_topic(), client_id);
-        let res_topic = Arc::new(Topic::new(&response_topic_name)?);
+        let res_topic = Topic::new(&response_topic_name)?;
         Ok(Self {
             req_topic,
             res_topic,
             response_topic_name,
             poll_interval,
+            inbox: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -351,7 +424,10 @@ where
         });
         PendingServiceCall {
             request_id,
+            // A fresh `Topic` clone, not a shared `Arc`: each handle gets its
+            // own read cursor and stays `!Sync`-safe on its own thread.
             res_topic: self.res_topic.clone(),
+            inbox: Arc::clone(&self.inbox),
             sent_at: Instant::now(),
             timeout,
             poll_interval: self.poll_interval,
@@ -608,6 +684,67 @@ mod tests {
         let result = pending.check();
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
+    }
+
+    /// Regression: two calls in flight, answered out of order, polled out of
+    /// order — both must resolve.
+    ///
+    /// `check()` used to `recv()` one message and, if the `request_id` did not
+    /// match, return `Ok(None)` — dropping a sibling's response permanently.
+    /// Polling `b` first (so `b` drains `a`'s response) and then `a` reproduced
+    /// it: `a` timed out on a request that had been answered. The shared inbox
+    /// parks a non-matching response for the handle waiting on it.
+    #[test]
+    fn concurrent_pending_calls_do_not_eat_each_others_responses() {
+        let mut client = AsyncServiceClient::<CliTestService>::new().unwrap();
+        let mut a = client.call_async(CliTestReq { value: 1 }, Duration::from_secs(5));
+        let mut b = client.call_async(CliTestReq { value: 2 }, Duration::from_secs(5));
+
+        // Establish both read cursors before anything is published, which is
+        // what a node polling its handles every tick does.
+        assert!(a.check().unwrap().is_none());
+        assert!(b.check().unwrap().is_none());
+
+        // Stand in for the server: publish both responses on the client's own
+        // response topic, `a`'s first.
+        let responder: Topic<ServiceResponse<CliTestRes>> =
+            Topic::new(&client.response_topic_name).unwrap();
+        responder.send(ServiceResponse::success(
+            a.request_id,
+            CliTestRes { result: 10 },
+        ));
+        responder.send(ServiceResponse::success(
+            b.request_id,
+            CliTestRes { result: 20 },
+        ));
+
+        // Poll in REVERSE submission order, exactly as a node ticking two
+        // handles would be free to do.
+        let mut got_a = None;
+        let mut got_b = None;
+        for _ in 0..200 {
+            if got_b.is_none() {
+                got_b = b.check().expect("b must not error");
+            }
+            if got_a.is_none() {
+                got_a = a.check().expect("a must not error");
+            }
+            if got_a.is_some() && got_b.is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        assert_eq!(
+            got_a.map(|r| r.result),
+            Some(10),
+            "handle a's response was consumed by a sibling handle"
+        );
+        assert_eq!(
+            got_b.map(|r| r.result),
+            Some(20),
+            "handle b's response was consumed by a sibling handle"
+        );
     }
 
     #[test]

--- a/horus_core/src/types/costmap_descriptor.rs
+++ b/horus_core/src/types/costmap_descriptor.rs
@@ -366,11 +366,11 @@ mod tests {
         let cm = CostMapDescriptor::new(grid_t, cost_t, 0.1, 100, 100);
 
         // Grid tensor is I8
-        assert_eq!(cm.grid_tensor().dtype, TensorDtype::I8);
+        assert_eq!(cm.grid_tensor().dtype(), TensorDtype::I8);
         assert_eq!(cm.grid_tensor().shape(), &[100, 100]);
 
         // Cost tensor is U8
-        assert_eq!(cm.cost_tensor().dtype, TensorDtype::U8);
+        assert_eq!(cm.cost_tensor().dtype(), TensorDtype::U8);
         assert_eq!(cm.cost_tensor().shape(), &[100, 100]);
 
         // They have different slot IDs

--- a/horus_core/src/types/depth_image_descriptor.rs
+++ b/horus_core/src/types/depth_image_descriptor.rs
@@ -111,13 +111,13 @@ impl DepthImageDescriptor {
     /// Whether depth values are in meters (F32).
     #[inline]
     pub fn is_meters(&self) -> bool {
-        self.inner.dtype == TensorDtype::F32
+        self.inner.dtype() == TensorDtype::F32
     }
 
     /// Whether depth values are in millimeters (U16).
     #[inline]
     pub fn is_millimeters(&self) -> bool {
-        self.inner.dtype == TensorDtype::U16
+        self.inner.dtype() == TensorDtype::U16
     }
 
     /// Depth scale (mm per unit).

--- a/horus_core/src/types/dtype.rs
+++ b/horus_core/src/types/dtype.rs
@@ -362,7 +362,11 @@ mod tests {
             (11, TensorDtype::U64),
             (12, TensorDtype::Bool),
         ] {
-            assert_eq!(dtype as u8, expected_byte, "byte repr mismatch for {:?}", dtype);
+            assert_eq!(
+                dtype as u8, expected_byte,
+                "byte repr mismatch for {:?}",
+                dtype
+            );
             assert_eq!(
                 TensorDtype::from_raw(expected_byte),
                 dtype,

--- a/horus_core/src/types/dtype.rs
+++ b/horus_core/src/types/dtype.rs
@@ -3,7 +3,7 @@
 //! Provides the canonical enumeration of supported tensor element types
 //! with conversions to/from DLPack codes, numpy type strings, and string parsing.
 
-use bytemuck::{Pod, Zeroable};
+use bytemuck::Zeroable;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -24,7 +24,8 @@ pub(crate) mod dlpack_codes {
 /// Data type for tensor elements
 ///
 /// Matches common ML framework dtypes for seamless interop.
-/// repr(u8) with values 0-12 for Pod safety.
+/// `repr(u8)` with values 0-12.  Wire structs store the raw discriminant
+/// byte and launder it through [`TensorDtype::from_raw`].
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TensorDtype {
@@ -57,8 +58,16 @@ pub enum TensorDtype {
     Bool = 12,
 }
 
-// Safety: TensorDtype is repr(u8) with valid values 0-12, all bit patterns in that range are valid
-unsafe impl Pod for TensorDtype {}
+// `Pod` used to be implemented here, and it was never sound: `Pod` promises that
+// EVERY bit pattern of the type's size is a valid value, and only 13 of the 256
+// byte values name a variant.  The impl licensed `bytemuck::from_bytes` and the
+// bare `ptr::read` recv path to materialise a `TensorDtype` straight out of
+// peer-writable shared memory, so a byte outside 0..=12 produced an invalid
+// discriminant — undefined behaviour, because an exhaustive `match` may lower to
+// an unguarded jump table indexed by it.  Wire structs now hold the raw byte and
+// launder it through `from_raw()`.
+//
+// `Zeroable` is sound and stays: discriminant 0 is `F32`.
 unsafe impl Zeroable for TensorDtype {}
 
 impl TensorDtype {
@@ -323,22 +332,21 @@ mod tests {
         assert_eq!(TensorDtype::I64.numpy_typestr(), "<i8");
     }
 
+    /// This test used to roundtrip every variant through `bytemuck::bytes_of` /
+    /// `bytemuck::from_bytes`, which only compiled because of the unsound
+    /// `unsafe impl Pod for TensorDtype`.  `Pod` is gone; the property it was
+    /// really pinning — the on-wire byte value of each variant — is checked here
+    /// through the discriminant cast and `from_raw`, which is how wire structs
+    /// read the byte now.
     #[test]
-    fn test_dtype_pod_soundness() {
+    fn test_dtype_wire_byte_repr() {
         // TensorDtype is repr(u8), so each variant occupies exactly 1 byte
         assert_eq!(std::mem::size_of::<TensorDtype>(), 1);
         assert_eq!(std::mem::align_of::<TensorDtype>(), 1);
 
-        let dtype = TensorDtype::F32;
-        let bytes = bytemuck::bytes_of(&dtype);
-        assert_eq!(bytes.len(), 1);
-        assert_eq!(bytes[0], 0); // F32 = 0
+        assert_eq!(TensorDtype::F32 as u8, 0);
+        assert_eq!(TensorDtype::U8 as u8, 8);
 
-        let dtype2 = TensorDtype::U8;
-        let bytes2 = bytemuck::bytes_of(&dtype2);
-        assert_eq!(bytes2[0], 8); // U8 = 8
-
-        // Roundtrip every variant through bytemuck
         for (expected_byte, dtype) in [
             (0u8, TensorDtype::F32),
             (1, TensorDtype::F64),
@@ -354,10 +362,19 @@ mod tests {
             (11, TensorDtype::U64),
             (12, TensorDtype::Bool),
         ] {
-            let b = bytemuck::bytes_of(&dtype);
-            assert_eq!(b[0], expected_byte, "byte repr mismatch for {:?}", dtype);
-            let recovered: &TensorDtype = bytemuck::from_bytes(b);
-            assert_eq!(*recovered, dtype, "roundtrip failed for {:?}", dtype);
+            assert_eq!(dtype as u8, expected_byte, "byte repr mismatch for {:?}", dtype);
+            assert_eq!(
+                TensorDtype::from_raw(expected_byte),
+                dtype,
+                "roundtrip failed for {:?}",
+                dtype
+            );
+        }
+
+        // Every byte that names no variant must launder to the F32 fallback
+        // rather than becoming an invalid discriminant.
+        for raw in (TensorDtype::MAX_DISCRIMINANT + 1)..=u8::MAX {
+            assert_eq!(TensorDtype::from_raw(raw), TensorDtype::F32);
         }
     }
 

--- a/horus_core/src/types/image_descriptor.rs
+++ b/horus_core/src/types/image_descriptor.rs
@@ -39,8 +39,18 @@ pub struct ImageDescriptor {
     timestamp_ns: u64,
     /// Bytes per row (may include padding for alignment)
     step: u32,
-    /// Pixel encoding format
-    encoding: ImageEncoding,
+    /// Pixel encoding format, held as the raw `repr(u8)` discriminant byte.
+    ///
+    /// This was `encoding: ImageEncoding`, and it was unsound: the descriptor is
+    /// read byte-for-byte out of peer-writable shared memory, so a byte outside
+    /// `0..=ImageEncoding::MAX_DISCRIMINANT` materialised an invalid enum
+    /// discriminant — undefined behaviour committed *before* any sanitiser could
+    /// run.  Read it through [`ImageDescriptor::encoding`], which launders the
+    /// byte via `ImageEncoding::from_raw`.  Same offset and size, so the
+    /// 224-byte wire layout is unchanged; `serde` still names the field
+    /// `encoding` and still writes the enum form.
+    #[serde(rename = "encoding", with = "encoding_serde")]
+    encoding_raw: u8,
     #[serde(skip)]
     _pad: [u8; 3],
     /// Frame ID (camera identifier, null-terminated)
@@ -49,7 +59,27 @@ pub struct ImageDescriptor {
     _reserved: [u8; 8],
 }
 
-// Safety: Image is repr(C), all fields are Pod, no implicit padding.
+/// Serde bridge for the raw encoding byte.
+///
+/// The discriminant is stored as a `u8` (see `encoding_raw`), but the serde form
+/// must stay byte-for-byte what it was when the field held an `ImageEncoding`,
+/// so recordings and JSON written by older builds still load.
+mod encoding_serde {
+    use super::ImageEncoding;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(raw: &u8, serializer: S) -> Result<S::Ok, S::Error> {
+        ImageEncoding::from_raw(*raw).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u8, D::Error> {
+        Ok(ImageEncoding::deserialize(deserializer)? as u8)
+    }
+}
+
+// Safety: Image is repr(C), every field is a plain integer or an array of them
+// (the encoding discriminant is a raw `u8` precisely so that all 256 byte values
+// really are valid, as `Pod` requires), no implicit padding.
 // 168 + 8 + 4 + 1 + 3 + 32 + 8 = 224 bytes, 224 % 8 = 0.
 unsafe impl Zeroable for ImageDescriptor {}
 unsafe impl Pod for ImageDescriptor {}
@@ -60,7 +90,7 @@ impl Default for ImageDescriptor {
             inner: Tensor::default(),
             timestamp_ns: 0,
             step: 0,
-            encoding: ImageEncoding::Rgb8,
+            encoding_raw: ImageEncoding::Rgb8 as u8,
             _pad: [0; 3],
             frame_id: [0; 32],
             _reserved: [0; 8],
@@ -71,12 +101,14 @@ impl Default for ImageDescriptor {
 impl ImageDescriptor {
     /// Sanitize an ImageDescriptor read from untrusted bytes (SHM, network, file).
     ///
-    /// Clamps inner tensor fields and encoding to valid ranges.
+    /// Clamps inner tensor fields and normalises the raw encoding byte.
+    /// [`encoding`](Self::encoding) already launders the byte on every read —
+    /// this only makes the *stored* byte agree, so a descriptor forwarded on the
+    /// wire carries the clamped value.
     #[inline]
     pub fn sanitize_from_shm(&mut self) {
         self.inner.sanitize_from_shm();
-        let enc_raw = unsafe { *(&self.encoding as *const ImageEncoding as *const u8) };
-        self.encoding = ImageEncoding::from_raw(enc_raw);
+        self.encoding_raw = self.encoding() as u8;
     }
 
     /// Create a new image descriptor from pre-built tensor + metadata.
@@ -108,7 +140,7 @@ impl ImageDescriptor {
             inner: tensor,
             timestamp_ns: 0,
             step,
-            encoding,
+            encoding_raw: encoding as u8,
             _pad: [0; 3],
             frame_id: [0; 32],
             _reserved: [0; 8],
@@ -122,7 +154,7 @@ impl ImageDescriptor {
         } else {
             1
         };
-        let encoding = ImageEncoding::from_dtype_channels(tensor.dtype, channels);
+        let encoding = ImageEncoding::from_dtype_channels(tensor.dtype(), channels);
         Self::new(tensor, encoding)
     }
 
@@ -161,7 +193,7 @@ impl ImageDescriptor {
     /// Pixel encoding format.
     #[inline]
     pub fn encoding(&self) -> ImageEncoding {
-        self.encoding
+        ImageEncoding::from_raw(self.encoding_raw)
     }
 
     /// Bytes per row.

--- a/horus_core/src/types/image_descriptor.rs
+++ b/horus_core/src/types/image_descriptor.rs
@@ -24,7 +24,7 @@ use super::tensor::Tensor;
 /// inner:        Tensor  (168 bytes)
 /// timestamp_ns: u64          (8 bytes)
 /// step:         u32          (4 bytes)
-/// encoding:     ImageEncoding(1 byte, repr(u8))
+/// encoding_raw: u8           (1 byte, ImageEncoding discriminant)
 /// _pad:         [u8; 3]      (3 bytes)
 /// frame_id:     [u8; 32]     (32 bytes)
 /// _reserved:    [u8; 8]      (8 bytes)
@@ -211,6 +211,36 @@ impl ImageDescriptor {
 mod tests {
     use super::*;
     use crate::types::{Device, TensorDtype};
+
+    /// `ImageDescriptor` used to carry `encoding: ImageEncoding` under
+    /// `unsafe impl Pod`, so a descriptor byte-copied out of peer-writable SHM
+    /// could hold a discriminant no variant names — undefined behaviour the
+    /// moment `bytes_per_pixel()` matched on it.  The byte is private and
+    /// laundered now, and it must still sit at the same wire offset.
+    #[test]
+    fn an_invalid_encoding_byte_is_laundered_and_stays_at_its_wire_offset() {
+        const ENCODING_BYTE_OFFSET: usize = 180; // 168 (Tensor) + 8 (ts) + 4 (step)
+
+        let tensor = Tensor::new(1, 0, 0, 0, &[8, 8, 1], TensorDtype::U8, Device::cpu());
+        let mut img = ImageDescriptor::new(tensor, ImageEncoding::Mono8);
+        assert_eq!(
+            bytemuck::bytes_of(&img)[ENCODING_BYTE_OFFSET],
+            ImageEncoding::Mono8 as u8,
+            "the encoding discriminant must stay at wire offset 180"
+        );
+
+        img.encoding_raw = 0xC0; // names no variant
+        assert_eq!(
+            img.encoding(),
+            ImageEncoding::Rgb8,
+            "a discriminant no variant names must read back as the Rgb8 fallback"
+        );
+        img.sanitize_from_shm();
+        assert_eq!(
+            bytemuck::bytes_of(&img)[ENCODING_BYTE_OFFSET],
+            ImageEncoding::Rgb8 as u8
+        );
+    }
 
     #[test]
     fn test_image_size_and_alignment() {

--- a/horus_core/src/types/image_encoding.rs
+++ b/horus_core/src/types/image_encoding.rs
@@ -4,7 +4,7 @@
 //! so both `horus_core` (for `Topic<Image>`) and `horus_robotics` (for
 //! `CompressedImage`, `CameraInfo`) can reference it.
 
-use bytemuck::{Pod, Zeroable};
+use bytemuck::Zeroable;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -13,7 +13,8 @@ use super::dtype::TensorDtype;
 /// Image encoding formats
 ///
 /// Represents the pixel format and data layout of image data.
-/// `repr(u8)` for Pod safety — stored inline in fixed-size descriptors.
+/// `repr(u8)` — stored inline in fixed-size descriptors as the raw
+/// discriminant byte, laundered through [`ImageEncoding::from_raw`] on read.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ImageEncoding {
@@ -42,8 +43,16 @@ pub enum ImageEncoding {
     Depth16 = 10,
 }
 
-// Safety: ImageEncoding is repr(u8) with valid values 0-10.
-unsafe impl Pod for ImageEncoding {}
+// `Pod` used to be implemented here, and it was never sound: `Pod` promises that
+// EVERY bit pattern of the type's size is a valid value, and only 11 of the 256
+// byte values name a variant.  The impl licensed `bytemuck::from_bytes` and the
+// bare `ptr::read` recv path to materialise an `ImageEncoding` straight out of
+// peer-writable shared memory, so a byte outside 0..=10 produced an invalid
+// discriminant — undefined behaviour, because `bytes_per_pixel()`'s exhaustive
+// `match` may lower to an unguarded jump table indexed by it.  `ImageDescriptor`
+// now holds the raw byte and launders it through `from_raw()`.
+//
+// `Zeroable` is sound and stays: discriminant 0 is `Mono8`.
 unsafe impl Zeroable for ImageEncoding {}
 
 impl ImageEncoding {
@@ -189,18 +198,20 @@ mod tests {
         );
     }
 
+    /// This test used to roundtrip every variant through `bytemuck::bytes_of` /
+    /// `bytemuck::from_bytes`, which only compiled because of the unsound
+    /// `unsafe impl Pod for ImageEncoding`.  `Pod` is gone; the property it was
+    /// really pinning — the on-wire byte value of each variant — is checked here
+    /// through the discriminant cast and `from_raw`, which is how
+    /// `ImageDescriptor` reads the byte now.
     #[test]
-    fn test_encoding_pod_soundness() {
+    fn test_encoding_wire_byte_repr() {
         // ImageEncoding is repr(u8): 1 byte, 1-byte alignment
         assert_eq!(std::mem::size_of::<ImageEncoding>(), 1);
         assert_eq!(std::mem::align_of::<ImageEncoding>(), 1);
 
-        let enc = ImageEncoding::Rgb8;
-        let bytes = bytemuck::bytes_of(&enc);
-        assert_eq!(bytes.len(), 1);
-        assert_eq!(bytes[0], 2); // Rgb8 = 2
+        assert_eq!(ImageEncoding::Rgb8 as u8, 2);
 
-        // Roundtrip every variant through bytemuck
         for (expected_byte, enc) in [
             (0u8, ImageEncoding::Mono8),
             (1, ImageEncoding::Mono16),
@@ -214,10 +225,19 @@ mod tests {
             (9, ImageEncoding::BayerRggb8),
             (10, ImageEncoding::Depth16),
         ] {
-            let b = bytemuck::bytes_of(&enc);
-            assert_eq!(b[0], expected_byte, "byte repr mismatch for {:?}", enc);
-            let recovered: &ImageEncoding = bytemuck::from_bytes(b);
-            assert_eq!(*recovered, enc, "roundtrip failed for {:?}", enc);
+            assert_eq!(enc as u8, expected_byte, "byte repr mismatch for {:?}", enc);
+            assert_eq!(
+                ImageEncoding::from_raw(expected_byte),
+                enc,
+                "roundtrip failed for {:?}",
+                enc
+            );
+        }
+
+        // Every byte that names no variant must launder to the Rgb8 fallback
+        // rather than becoming an invalid discriminant.
+        for raw in (ImageEncoding::MAX_DISCRIMINANT + 1)..=u8::MAX {
+            assert_eq!(ImageEncoding::from_raw(raw), ImageEncoding::Rgb8);
         }
     }
 

--- a/horus_core/src/types/mod.rs
+++ b/horus_core/src/types/mod.rs
@@ -68,7 +68,7 @@ macro_rules! impl_tensor_accessors {
         /// Element data type.
         #[inline]
         pub fn dtype(&self) -> $crate::types::TensorDtype {
-            self.inner.dtype
+            self.inner.dtype()
         }
 
         /// Total bytes of data.

--- a/horus_core/src/types/tensor.rs
+++ b/horus_core/src/types/tensor.rs
@@ -64,8 +64,16 @@ pub struct Tensor {
     pub size: u64,
 
     // === Tensor metadata (8 bytes) ===
-    /// Element data type
-    pub dtype: TensorDtype,
+    /// Element data type, held as the raw `repr(u8)` discriminant byte.
+    ///
+    /// This was `pub dtype: TensorDtype`, and it was unsound: the descriptor is
+    /// read byte-for-byte out of peer-writable shared memory, so a byte outside
+    /// `0..=TensorDtype::MAX_DISCRIMINANT` materialised an invalid enum
+    /// discriminant — undefined behaviour committed *before* any sanitiser
+    /// could run.  The byte is private now and every reader goes through
+    /// [`Tensor::dtype`], which launders it via `TensorDtype::from_raw`.
+    /// Same offset and size, so the 168-byte wire layout is unchanged.
+    dtype_raw: u8,
     /// Number of dimensions (1-8)
     pub ndim: u8,
     /// Device type: 0=CPU, 1=CUDA (part of flattened Device)
@@ -83,7 +91,9 @@ pub struct Tensor {
 }
 
 // Safety: Tensor is repr(C) with explicit padding, no implicit padding exists.
-// All fields are Pod types (u8, u32, u64, [u8; N], [u64; N], TensorDtype which is repr(u8)).
+// Every field is a plain integer or an array of them (u8, u32, u64, [u64; N]) —
+// including the dtype discriminant, which is stored as a raw `u8` precisely so
+// that every one of the 256 byte values really is valid, as `Pod` requires.
 unsafe impl Pod for Tensor {}
 unsafe impl Zeroable for Tensor {}
 
@@ -96,7 +106,7 @@ impl Default for Tensor {
             generation_hi: 0,
             offset: 0,
             size: 0,
-            dtype: TensorDtype::F32,
+            dtype_raw: TensorDtype::F32 as u8,
             ndim: 0,
             device_type: DEVICE_TYPE_CPU,
             _pad1: 0,
@@ -108,16 +118,44 @@ impl Default for Tensor {
 }
 
 impl Tensor {
+    /// Element data type.
+    ///
+    /// Launders the stored discriminant byte through [`TensorDtype::from_raw`],
+    /// so a corrupt or hostile wire descriptor yields `F32` rather than an
+    /// invalid enum value.  This is the only way to read the dtype.
+    #[inline]
+    pub const fn dtype(&self) -> TensorDtype {
+        TensorDtype::from_raw(self.dtype_raw)
+    }
+
+    /// Set the element data type.
+    #[inline]
+    pub fn set_dtype(&mut self, dtype: TensorDtype) {
+        self.dtype_raw = dtype as u8;
+    }
+
+    /// Plant a raw discriminant byte, valid or not.
+    ///
+    /// **Test-only**: deliberately `#[doc(hidden)]` — the same pattern as
+    /// `SharedLogBuffer::corrupt_slot_seqlock`.  Tests outside this crate use it
+    /// to simulate the corrupt wire descriptor that the private `dtype_raw`
+    /// field otherwise makes unreachable.  Production code must use
+    /// [`set_dtype`](Self::set_dtype).
+    #[doc(hidden)]
+    pub fn set_dtype_raw_for_test(&mut self, raw: u8) {
+        self.dtype_raw = raw;
+    }
+
     /// Sanitize a Tensor read from untrusted bytes (SHM, network, file).
     ///
-    /// Clamps `ndim` and `dtype` to valid ranges to prevent UB from invalid
-    /// enum discriminants or out-of-bounds array slicing.
+    /// Clamps `ndim` to the shape/strides array bound and normalises the raw
+    /// dtype byte to a valid discriminant.  [`dtype`](Self::dtype) already
+    /// launders the byte on every read — this only makes the *stored* byte
+    /// agree, so a descriptor forwarded on the wire carries the clamped value.
     #[inline]
     pub fn sanitize_from_shm(&mut self) {
         self.ndim = self.ndim.min(MAX_TENSOR_DIMS as u8);
-        // SAFETY: read the raw discriminant byte to avoid UB from matching an invalid enum
-        let dtype_raw = unsafe { *(&self.dtype as *const TensorDtype as *const u8) };
-        self.dtype = TensorDtype::from_raw(dtype_raw);
+        self.dtype_raw = self.dtype() as u8;
     }
 
     /// Create a new tensor descriptor
@@ -170,7 +208,7 @@ impl Tensor {
             generation_hi: (generation_full >> 32) as u32,
             offset,
             size,
-            dtype,
+            dtype_raw: dtype as u8,
             ndim,
             device_type: device.device_type,
             _pad1: 0,
@@ -220,7 +258,7 @@ impl Tensor {
     /// Returns `None` on overflow.
     #[inline]
     pub fn addressed_extent_bytes(&self) -> Option<u64> {
-        let elem = self.dtype.element_size() as u64;
+        let elem = self.dtype().element_size() as u64;
         let mut extent: u64 = elem;
         for (&dim, &stride) in self.shape().iter().zip(self.strides().iter()) {
             if dim == 0 {
@@ -241,7 +279,7 @@ impl Tensor {
     /// past the end of the pool slot.
     #[inline]
     pub fn element_count_fits(&self, count: u64) -> bool {
-        match count.checked_mul(self.dtype.element_size() as u64) {
+        match count.checked_mul(self.dtype().element_size() as u64) {
             Some(bytes) => bytes <= self.size,
             None => false, // overflow — reject
         }
@@ -276,7 +314,7 @@ impl Tensor {
             return true;
         }
 
-        let mut expected_stride = self.dtype.element_size() as u64;
+        let mut expected_stride = self.dtype().element_size() as u64;
         for i in (0..(self.ndim as usize).min(MAX_TENSOR_DIMS)).rev() {
             if self.strides[i] != expected_stride {
                 return false;
@@ -324,7 +362,7 @@ impl Tensor {
             self.generation_full(),
             self.offset,
             new_shape,
-            self.dtype,
+            self.dtype(),
             self.device(),
         ))
     }
@@ -341,7 +379,7 @@ impl Tensor {
         let new_numel: u64 = new_tensor.shape[..new_tensor.ndim as usize]
             .iter()
             .product();
-        new_tensor.size = new_numel * self.dtype.element_size() as u64;
+        new_tensor.size = new_numel * self.dtype().element_size() as u64;
 
         Some(new_tensor)
     }
@@ -361,7 +399,7 @@ impl Serialize for Tensor {
         state.serialize_field("generation_hi", &self.generation_hi)?;
         state.serialize_field("offset", &self.offset)?;
         state.serialize_field("size", &self.size)?;
-        state.serialize_field("dtype", &self.dtype)?;
+        state.serialize_field("dtype", &self.dtype())?;
         state.serialize_field("ndim", &self.ndim)?;
         state.serialize_field("device", &self.device())?;
         state.serialize_field("shape", &self.shape[..])?;
@@ -400,7 +438,10 @@ impl<'de> Deserialize<'de> for Tensor {
                         "generation_hi" => tensor.generation_hi = map.next_value()?,
                         "offset" => tensor.offset = map.next_value()?,
                         "size" => tensor.size = map.next_value()?,
-                        "dtype" => tensor.dtype = map.next_value()?,
+                        "dtype" => {
+                            let dtype: TensorDtype = map.next_value()?;
+                            tensor.dtype_raw = dtype as u8;
+                        }
                         "ndim" => {
                             let raw: u8 = map.next_value()?;
                             tensor.ndim = raw.min(MAX_TENSOR_DIMS as u8);
@@ -553,7 +594,7 @@ mod tests {
 
         // Roundtrip through bytes
         let recovered: &Tensor = bytemuck::from_bytes(bytes);
-        assert_eq!(recovered.dtype, TensorDtype::F32);
+        assert_eq!(recovered.dtype(), TensorDtype::F32);
         assert_eq!(recovered.ndim, 0);
         assert!(recovered.is_cpu());
     }
@@ -578,7 +619,7 @@ mod tests {
         assert_eq!(recovered.generation, tensor.generation);
         assert_eq!(recovered.offset, tensor.offset);
         assert_eq!(recovered.size, tensor.size);
-        assert_eq!(recovered.dtype, tensor.dtype);
+        assert_eq!(recovered.dtype(), tensor.dtype());
         assert_eq!(recovered.ndim, tensor.ndim);
         assert_eq!(recovered.device(), tensor.device());
         assert_eq!(recovered.shape(), tensor.shape());
@@ -595,7 +636,7 @@ mod tests {
         assert_eq!(tensor.generation_full(), 0);
         assert_eq!(tensor.offset, 0);
         assert_eq!(tensor.size, 0);
-        assert_eq!(tensor.dtype, TensorDtype::F32);
+        assert_eq!(tensor.dtype(), TensorDtype::F32);
         assert_eq!(tensor.ndim, 0);
         assert!(tensor.is_cpu());
         assert_eq!(tensor.device(), Device::cpu());
@@ -633,6 +674,39 @@ mod tests {
         _copy.shape[0] = 1;
         assert_eq!(t.pool_id, 1, "original must be unaffected by copy mutation");
         assert_eq!(t.shape[0], 480);
+    }
+
+    /// `Tensor` used to carry `pub dtype: TensorDtype` under `unsafe impl Pod`,
+    /// so a descriptor byte-copied out of peer-writable SHM could hold a
+    /// discriminant no variant names — undefined behaviour the moment anything
+    /// matched on it.  The byte is private and laundered now, so the same input
+    /// is merely wrong, not unsound; and it must still sit at the same offset,
+    /// because the wire layout is a cross-process contract.
+    #[test]
+    fn an_invalid_dtype_byte_is_laundered_and_stays_at_its_wire_offset() {
+        const DTYPE_BYTE_OFFSET: usize = 32; // 16 (ids) + 16 (offset/size)
+
+        let t = Tensor::new(1, 0, 0, 0, &[4, 4], TensorDtype::U8, Device::CPU);
+        assert_eq!(
+            bytemuck::bytes_of(&t)[DTYPE_BYTE_OFFSET],
+            TensorDtype::U8 as u8,
+            "the dtype discriminant must stay at wire offset 32"
+        );
+
+        let mut corrupt = t;
+        corrupt.set_dtype_raw_for_test(200);
+        assert_eq!(
+            corrupt.dtype(),
+            TensorDtype::F32,
+            "a discriminant no variant names must read back as the F32 fallback"
+        );
+        // The reader is what makes it safe, but sanitize_from_shm must also
+        // rewrite the stored byte so a forwarded descriptor carries the fallback.
+        corrupt.sanitize_from_shm();
+        assert_eq!(
+            bytemuck::bytes_of(&corrupt)[DTYPE_BYTE_OFFSET],
+            TensorDtype::F32 as u8
+        );
     }
 
     #[test]

--- a/horus_core/tests/cross_process_infrastructure.rs
+++ b/horus_core/tests/cross_process_infrastructure.rs
@@ -215,8 +215,16 @@ fn cross_process_registry_readable() {
 
     // Parent: create registry, register nodes
     let registry = SchedulerRegistry::open(&sched_name).expect("open registry");
-    let slot0 = registry.register_node("sensor_driver", 0, 100.0, 0);
-    let slot1 = registry.register_node("controller", 1, 1000.0, 0);
+    // `register_node` returns Option: the registry has MAX_REGISTRY_NODES slots
+    // and overflow now yields None rather than silently aliasing the last slot.
+    // Two nodes in a fresh registry always fit, so unwrapping here is the
+    // assertion that they did.
+    let slot0 = registry
+        .register_node("sensor_driver", 0, 100.0, 0)
+        .expect("registry not full");
+    let slot1 = registry
+        .register_node("controller", 1, 1000.0, 0)
+        .expect("registry not full");
 
     // Update some metrics (health, tick_count, error_count, budget_misses, deadline_misses, watchdog_severity, last_tick_ns, avg_tick_ns, max_tick_ns, p99_tick_ns)
     registry.update_node(slot0, 0, 50, 0, 0, 0, 0, 1000, 500, 800, 750);

--- a/horus_core/tests/memory_coverage.rs
+++ b/horus_core/tests/memory_coverage.rs
@@ -227,7 +227,11 @@ fn tensor_sanitize_preserves_valid_dtype() {
     // `t.dtype = ...` before the discriminant became a private byte.
     t.set_dtype(TensorDtype::U8);
     t.sanitize_from_shm();
-    assert_eq!(t.dtype(), TensorDtype::U8, "valid dtype should be preserved");
+    assert_eq!(
+        t.dtype(),
+        TensorDtype::U8,
+        "valid dtype should be preserved"
+    );
 }
 
 // ============================================================

--- a/horus_core/tests/memory_coverage.rs
+++ b/horus_core/tests/memory_coverage.rs
@@ -204,13 +204,16 @@ fn tensor_sanitize_clamps_invalid_dtype() {
     use horus_core::types::Tensor;
 
     let mut t = Tensor::default();
-    // Set dtype to an invalid raw value by writing directly to the byte
-    let dtype_ptr = &mut t.dtype as *mut TensorDtype as *mut u8;
-    unsafe { *dtype_ptr = 200 }; // Invalid discriminant
+    // This used to plant the byte through `&mut t.dtype as *mut TensorDtype`,
+    // which only compiled because the discriminant was a public field of enum
+    // type — the very hole that let peer-written SHM bytes become an invalid
+    // enum value. The field is a private `u8` now, so planting an invalid byte
+    // from outside the crate goes through the deliberate test-only hook.
+    t.set_dtype_raw_for_test(200); // Invalid discriminant
     t.sanitize_from_shm();
     // from_raw falls back to F32 for invalid discriminants
     assert_eq!(
-        t.dtype,
+        t.dtype(),
         TensorDtype::F32,
         "invalid dtype should fall back to F32"
     );
@@ -221,9 +224,10 @@ fn tensor_sanitize_preserves_valid_dtype() {
     use horus_core::types::Tensor;
 
     let mut t = Tensor::default();
-    t.dtype = TensorDtype::U8;
+    // `t.dtype = ...` before the discriminant became a private byte.
+    t.set_dtype(TensorDtype::U8);
     t.sanitize_from_shm();
-    assert_eq!(t.dtype, TensorDtype::U8, "valid dtype should be preserved");
+    assert_eq!(t.dtype(), TensorDtype::U8, "valid dtype should be preserved");
 }
 
 // ============================================================

--- a/horus_core/tests/production_fanout_battle.rs
+++ b/horus_core/tests/production_fanout_battle.rs
@@ -1598,9 +1598,20 @@ fn fault_child_publisher() {
     t.check_migration_now();
     std::thread::sleep(Duration::from_millis(100));
 
-    // Publish monotonically increasing values
-    for i in 0u64.. {
+    // Publish monotonically increasing values until the parent SIGKILLs us.
+    //
+    // Written as an explicit `loop` with its own counter rather than the more
+    // obvious `for i in 0u64..`: the unbounded-range form trips clippy's
+    // `for_unbounded_range`, which is new in 1.98 and denied by CI's
+    // `-D warnings`. An `#[allow]` is not an option — it would be an
+    // unknown-lint warning (so, also an error) on older toolchains that predate
+    // the lint. The semantics are identical; `RangeFrom`'s iterator does this
+    // same `+= 1`. Overflow is unreachable in either form: at ~2ms per message
+    // a u64 counter needs ~10^9 years to wrap, and this child lives ~1.5s.
+    let mut i: u64 = 0;
+    loop {
         t.send(i);
+        i += 1;
         // Pace at ~2ms to match cross-process pattern
         std::thread::sleep(Duration::from_millis(2));
     }

--- a/horus_core/tests/stress_tensorpool_fragmentation.rs
+++ b/horus_core/tests/stress_tensorpool_fragmentation.rs
@@ -24,10 +24,82 @@ use std::time::{Duration, Instant};
 mod common;
 use common::cleanup_stale_shm;
 
-/// Clean up tensor pool SHM files (cleanup_stale_shm only removes topics/nodes).
-fn cleanup_tensor_shm() {
-    let tensors_dir = shm_base_dir().join("tensors");
-    let _ = std::fs::remove_dir_all(&tensors_dir);
+// ============================================================================
+// Pool identity
+// ============================================================================
+//
+// Every test in this file gets its OWN base id and they all use the SAME
+// `PID_SPREAD` modulus, so no two tests in this binary can ever derive the same
+// pool id.
+//
+// They used to. `stress_tensorpool_alternating_free_pattern` used
+// `9900 + pid % 100` and `stress_tensorpool_rapid_slot_churn` used
+// `9950 + pid % 50`. For every pid where `pid % 100 >= 50` — half of all runs —
+// those are the *same number*: with `p = pid % 100 >= 50`, `p % 50 == p - 50`,
+// so `9950 + (p - 50) == 9900 + p`. libtest runs tests in name order, so
+// `alternating` went first, created the pool with a 32 MiB / 128-slot geometry,
+// and left the file behind — `cleanup_stale_shm()` only wipes topics/ and
+// nodes/, `TensorPool`'s `Drop` deliberately does not unlink, so nothing
+// removed it. `rapid_slot_churn` then asked for 64 MiB / 32 slots at that same
+// id and `TensorPool::new` correctly refused to resize a pool it did not
+// create:
+//
+//     Failed to create pool: Config(Other("Tensor pool 9989 exists but is only
+//     33561664 bytes, smaller than the 67110720 bytes this process needs"))
+//
+// The two byte counts are the two geometries exactly, which is what pins the
+// diagnosis to this collision rather than to a stale file from another run:
+//   33561664 = 64 (PoolHeader) + 128 * 56 (SlotHeader) + 32 MiB  <- alternating
+//   67110720 = 64 (PoolHeader) +  32 * 56 (SlotHeader) + 64 MiB  <- churn
+// and 9989 is reachable by both formulas only at `pid % 100 == 89`.
+//
+// Bases are 1000 apart and live in an id range no other test file uses
+// (tensor_pool_concurrent.rs holds 9700-9799, resource_exhaustion.rs and
+// regressions.rs hold 9800-9899, memory_coverage.rs holds 99990/99999).
+
+/// Width of the pid-derived spread. Keeps concurrently running *processes* off
+/// each other's pools; `clear_stale_pool` covers the leftovers of dead ones.
+const PID_SPREAD: u32 = 1000;
+
+const POOL_BASE_MULTITHREAD: u32 = 30_000;
+const POOL_BASE_ALTERNATING: u32 = 31_000;
+const POOL_BASE_CHURN: u32 = 32_000;
+/// Reserved 33_000..35_000: this test adds a per-cycle offset on top of the
+/// spread, so its band is two wide.
+const POOL_BASE_LIFECYCLE: u32 = 33_000;
+
+/// Pool id for one test: its own base plus this process's spread.
+fn test_pool_id(base: u32) -> u32 {
+    base + (std::process::id() % PID_SPREAD)
+}
+
+/// Path of a pool's backing SHM file.
+fn pool_shm_path(pool_id: u32) -> std::path::PathBuf {
+    shm_base_dir()
+        .join("tensors")
+        .join(format!("tensor_pool_{}", pool_id))
+}
+
+/// Remove a leftover pool file *before* creating, so this test creates rather
+/// than attaches.
+///
+/// A run that panicked or was killed leaves its SHM file behind (`Drop` does not
+/// unlink, and `cleanup_stale_shm()` only clears topics/ and nodes/). If a later
+/// run's pid lands on the same spread slot, `TensorPool::new` attaches to that
+/// stale file instead — and then either adopts a geometry the test did not ask
+/// for, or fails outright when the leftover is smaller than the mapping this
+/// config needs. Same idiom as `clear_stale_pool` in tensor_pool.rs's own tests.
+fn clear_stale_pool(pool_id: u32) {
+    let _ = std::fs::remove_file(pool_shm_path(pool_id));
+}
+
+/// Drop a pool's backing file once the test is done with it.
+///
+/// Targeted on purpose: the previous helper here did `remove_dir_all` on the
+/// whole `tensors/` directory, which also destroys pools belonging to any other
+/// test binary running at the same time.
+fn remove_pool_file(pool_id: u32) {
+    let _ = std::fs::remove_file(pool_shm_path(pool_id));
 }
 
 // ============================================================================
@@ -104,12 +176,13 @@ fn stress_tensorpool_repeated_lifecycle_60s() {
     let mut cycle = 0;
     let mut all_stats: Vec<CycleStats> = Vec::new();
 
-    // Use PID + monotonic counter for unique pool IDs across runs
-    let pid_base = std::process::id() % 10000;
-
     while start.elapsed() < test_duration {
         // Unique pool ID per cycle — avoids stale SHM file collisions
-        let pool_id = 10000 + pid_base + cycle as u32;
+        // `% PID_SPREAD` keeps the id inside the reserved 33_000..35_000 band
+        // even if a create-failure loop spins `cycle` far past the ~12 a 60s
+        // run normally reaches.
+        let pool_id = test_pool_id(POOL_BASE_LIFECYCLE) + (cycle as u32 % PID_SPREAD);
+        clear_stale_pool(pool_id);
         let config = TensorPoolConfig {
             pool_size: 32 * 1024 * 1024, // 32MB
             max_slots: 128,
@@ -209,7 +282,7 @@ fn stress_tensorpool_repeated_lifecycle_60s() {
         // Clean up ALL SHM files (including tensor pool) before next cycle
         drop(pool); // ensure mmap is unmapped before deleting backing file
         let _shm_guard = cleanup_stale_shm();
-        cleanup_tensor_shm();
+        remove_pool_file(pool_id);
 
         all_stats.push(stats);
         cycle += 1;
@@ -264,7 +337,8 @@ fn stress_tensorpool_repeated_lifecycle_60s() {
 fn stress_tensorpool_multithread_exhaust() {
     let _shm_guard = cleanup_stale_shm();
 
-    let pool_id = 9860 + (std::process::id() % 100);
+    let pool_id = test_pool_id(POOL_BASE_MULTITHREAD);
+    clear_stale_pool(pool_id);
     let config = TensorPoolConfig {
         pool_size: 16 * 1024 * 1024, // 16MB
         max_slots: 64,
@@ -357,6 +431,8 @@ fn stress_tensorpool_multithread_exhaust() {
     let releases = total_releases.load(Ordering::SeqCst);
     let corruptions = data_corruptions.load(Ordering::SeqCst);
 
+    remove_pool_file(pool_id);
+
     eprintln!(
         "[multithread] allocs: {}, failures: {}, releases: {}, corruptions: {}",
         allocs, failures, releases, corruptions
@@ -386,7 +462,8 @@ fn stress_tensorpool_multithread_exhaust() {
 fn stress_tensorpool_alternating_free_pattern() {
     let _shm_guard = cleanup_stale_shm();
 
-    let pool_id = 9900 + (std::process::id() % 100);
+    let pool_id = test_pool_id(POOL_BASE_ALTERNATING);
+    clear_stale_pool(pool_id);
     let config = TensorPoolConfig {
         pool_size: 32 * 1024 * 1024, // 32MB
         max_slots: 128,
@@ -461,6 +538,9 @@ fn stress_tensorpool_alternating_free_pattern() {
         stats.used_bytes as f64 / 1024.0
     );
 
+    drop(pool);
+    remove_pool_file(pool_id);
+
     // All freed slots should be reclaimable (if data space allows)
     assert!(
         reallocated >= freed / 2,
@@ -476,7 +556,8 @@ fn stress_tensorpool_alternating_free_pattern() {
 fn stress_tensorpool_rapid_slot_churn() {
     let _shm_guard = cleanup_stale_shm();
 
-    let pool_id = 9950 + (std::process::id() % 50);
+    let pool_id = test_pool_id(POOL_BASE_CHURN);
+    clear_stale_pool(pool_id);
     let config = TensorPoolConfig {
         pool_size: 64 * 1024 * 1024, // 64MB — generous for many small allocs
         max_slots: 32,               // few slots, high reuse
@@ -503,6 +584,10 @@ fn stress_tensorpool_rapid_slot_churn() {
     }
 
     let completed = alloc_times_ns.len();
+
+    drop(pool);
+    remove_pool_file(pool_id);
+
     eprintln!(
         "[churn] Completed {}/{} alloc+release cycles",
         completed, churn_count

--- a/horus_core/tests/topic_stress.rs
+++ b/horus_core/tests/topic_stress.rs
@@ -253,14 +253,27 @@ fn test_topic_stress_alternating_send_recv() {
 // Test 5: Overwrite ring buffer — send more than capacity
 // ============================================================================
 
-/// INTENT: When a producer sends more messages than the ring buffer can hold
-/// without the consumer draining, excess messages are dropped (fire-and-forget).
-/// The ring buffer saturates at capacity and the consumer sees at most
-/// `capacity` messages.
+/// INTENT: When a producer sends more messages than the ring can hold and
+/// nothing is draining it, `send` — the lossy publish — retires the OLDEST
+/// slot and takes it. A consumer that attaches afterwards is handed the
+/// newest `capacity` messages, not the first `capacity` ever sent.
 ///
-/// This is the correct behavior for robotics: dropping stale sensor data is
-/// preferable to blocking the producer or corrupting the ring. The consumer
-/// gets the oldest unread data up to ring capacity.
+/// This is the correct behavior for robotics: a subscriber attaching to a
+/// sensor topic wants the most recent sample, and a ring nobody is reading
+/// must not hold the newest data hostage. `Topic::send`'s contract spells
+/// this out — see the keep-last-N reclaim in `send_lossy_retry`, and
+/// `Topic::missed_count` ("drop-oldest under overload is by design").
+/// `try_send` and `send_blocking` are the calls that refuse instead of
+/// dropping; `send` never fails and never blocks, so it drops.
+///
+/// NOTE — THIS TEST'S OLD EXPECTATION WAS WRONG. It used to assert
+/// `drained[0] == 0`, "FIFO — earliest messages kept", which pins the
+/// pre-keep-last-N behaviour: an unattended full ring froze holding the FIRST
+/// `capacity` messages for the life of the segment while the publisher kept
+/// counting sends, so `topic list` showed a live rate while `topic echo`
+/// replayed minutes-old payloads. The assertions below pin what the topic
+/// actually guarantees, including the part that matters most — the newest
+/// message IS present.
 #[test]
 fn test_topic_stress_overwrite_ring_buffer() {
     let _shm_guard = cleanup_stale_shm();
@@ -270,6 +283,7 @@ fn test_topic_stress_overwrite_ring_buffer() {
     let topic = Topic::<u64>::new(&name).expect("create topic");
 
     let send_count = 1_000u64;
+    const RING_CAPACITY: u64 = 512;
 
     for i in 0..send_count {
         topic.send(i);
@@ -281,17 +295,17 @@ fn test_topic_stress_overwrite_ring_buffer() {
         drained.push(val);
     }
 
-    // We sent 1000 messages to a 512-slot ring. Only 512 should have been
-    // accepted (the ring is bounded, excess sends are dropped).
+    // The ring is bounded: it cannot have kept all 1000.
     assert!(
         !drained.is_empty(),
         "Should have received at least some messages after sending {}",
         send_count
     );
     assert!(
-        drained.len() <= 512,
-        "Drained {} messages but ring capacity should be at most 512",
-        drained.len()
+        drained.len() as u64 <= RING_CAPACITY,
+        "Drained {} messages but ring capacity should be at most {}",
+        drained.len(),
+        RING_CAPACITY
     );
     assert!(
         (drained.len() as u64) < send_count,
@@ -301,17 +315,7 @@ fn test_topic_stress_overwrite_ring_buffer() {
         send_count
     );
 
-    // Verify FIFO ordering — messages within the ring must be in order
-    for window in drained.windows(2) {
-        assert!(
-            window[1] > window[0],
-            "Drained values must be monotonically increasing, got {} after {}",
-            window[1],
-            window[0]
-        );
-    }
-
-    // All values must be valid (within the range we sent)
+    // Every value must be one we actually sent.
     for &val in &drained {
         assert!(
             val < send_count,
@@ -321,9 +325,41 @@ fn test_topic_stress_overwrite_ring_buffer() {
         );
     }
 
-    // The first value should be 0 (oldest messages accepted first)
+    // What survived is a CONTIGUOUS ascending run of the sent sequence. The
+    // ring retires whole messages off one end; it never reorders them, never
+    // duplicates one, and never leaves a hole in the middle of what it kept.
+    for window in drained.windows(2) {
+        assert_eq!(
+            window[1],
+            window[0] + 1,
+            "Drained values must be a contiguous ascending run, got {} after {}",
+            window[1],
+            window[0]
+        );
+    }
+
+    // ...and the end it retires from is the OLD end. The newest message must
+    // be in the ring: that is the entire point of retiring the oldest slot
+    // instead of refusing the send. If this regresses, an unread topic
+    // silently freezes on stale data while the publisher keeps counting sends
+    // — the failure keep-last-N exists to prevent.
     assert_eq!(
-        drained[0], 0,
-        "First drained value should be 0 (FIFO — earliest messages kept)"
+        *drained.last().unwrap(),
+        send_count - 1,
+        "Newest message must survive on an undrained ring (keep-last-N); \
+         drained {} messages, {}..={}",
+        drained.len(),
+        drained[0],
+        drained.last().unwrap()
+    );
+
+    // The inverse of the old, wrong assertion, stated explicitly so a
+    // regression back to "keep the first N forever" cannot pass silently.
+    assert!(
+        drained[0] > 0,
+        "Oldest messages must have been retired, not kept — \
+         first drained value was {} after sending {}",
+        drained[0],
+        send_count
     );
 }

--- a/horus_cpp/include/horus/horus_c.h
+++ b/horus_cpp/include/horus/horus_c.h
@@ -33,7 +33,9 @@ typedef struct HorusSubscriber HorusSubscriber;
 
 HorusScheduler* horus_scheduler_new(void);
 void            horus_scheduler_destroy(HorusScheduler* sched);
-void            horus_scheduler_tick_rate(HorusScheduler* sched, double hz);
+/* Returns 0 on success, -1 if sched is NULL or hz is not finite and positive.
+ * Fractional rates (e.g. 0.5) are honored exactly. */
+int             horus_scheduler_tick_rate(HorusScheduler* sched, double hz);
 void            horus_scheduler_name(HorusScheduler* sched, const char* name);
 void            horus_scheduler_prefer_rt(HorusScheduler* sched);
 void            horus_scheduler_require_rt(HorusScheduler* sched);

--- a/horus_cpp/include/horus/impl/scheduler_impl.hpp
+++ b/horus_cpp/include/horus/impl/scheduler_impl.hpp
@@ -8,7 +8,9 @@
 #include "../duration.hpp"
 #include "../error.hpp"
 
+#include <atomic>
 #include <chrono>
+#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -253,12 +255,21 @@ inline NodeBuilder& NodeBuilder::shutdown(std::function<void()> callback) {
 // The extern "C" trampoline indexes into this array.
 // Per-node callback registry with trampolines for tick, init, and safe_state.
 namespace detail {
-    static constexpr size_t MAX_NODES = 256;
-    static std::function<void()> g_tick_callbacks[MAX_NODES];
-    static std::function<void()> g_init_callbacks[MAX_NODES];
-    static std::function<void()> g_safe_callbacks[MAX_NODES];
-    static std::function<void()> g_shutdown_callbacks[MAX_NODES];
-    static size_t g_next_slot = 0;
+    // These MUST be `inline` (C++17 inline variables), not `static`. `static` at
+    // namespace scope in a header gives every translation unit its own copy, so
+    // two .cpp files each registering a node both took slot 0 of their private
+    // counter and both handed Rust the same `tick_trampoline_0` — while the
+    // linker kept exactly one body of that inline trampoline, bound to one TU's
+    // array. One node then ran the other's tick body, or never ticked at all.
+    // `inline` collapses the copies into a single definition program-wide and
+    // removes the ODR violation. The counter is atomic because build() may be
+    // called from more than one thread.
+    inline constexpr size_t MAX_NODES = 32;  // must equal the trampoline count below
+    inline std::function<void()> g_tick_callbacks[MAX_NODES];
+    inline std::function<void()> g_init_callbacks[MAX_NODES];
+    inline std::function<void()> g_safe_callbacks[MAX_NODES];
+    inline std::function<void()> g_shutdown_callbacks[MAX_NODES];
+    inline std::atomic<size_t> g_next_slot{0};
 
     // Generate trampolines for tick, init, safe_state, and shutdown
     #define HORUS_TRAMPOLINE_TICK(N) inline void tick_trampoline_##N() { if (g_tick_callbacks[N]) g_tick_callbacks[N](); }
@@ -291,7 +302,7 @@ namespace detail {
             HORUS_TABLE_ENTRY(24), HORUS_TABLE_ENTRY(25), HORUS_TABLE_ENTRY(26), HORUS_TABLE_ENTRY(27),
             HORUS_TABLE_ENTRY(28), HORUS_TABLE_ENTRY(29), HORUS_TABLE_ENTRY(30), HORUS_TABLE_ENTRY(31),
         };
-        return slot < 32 ? table[slot] : nullptr;
+        return slot < MAX_NODES ? table[slot] : nullptr;
     }
     #undef HORUS_TABLE_ENTRY
 
@@ -307,7 +318,7 @@ namespace detail {
             HORUS_TABLE_ENTRY(24), HORUS_TABLE_ENTRY(25), HORUS_TABLE_ENTRY(26), HORUS_TABLE_ENTRY(27),
             HORUS_TABLE_ENTRY(28), HORUS_TABLE_ENTRY(29), HORUS_TABLE_ENTRY(30), HORUS_TABLE_ENTRY(31),
         };
-        return slot < 32 ? table[slot] : nullptr;
+        return slot < MAX_NODES ? table[slot] : nullptr;
     }
     #undef HORUS_TABLE_ENTRY
 
@@ -323,7 +334,7 @@ namespace detail {
             HORUS_TABLE_ENTRY(24), HORUS_TABLE_ENTRY(25), HORUS_TABLE_ENTRY(26), HORUS_TABLE_ENTRY(27),
             HORUS_TABLE_ENTRY(28), HORUS_TABLE_ENTRY(29), HORUS_TABLE_ENTRY(30), HORUS_TABLE_ENTRY(31),
         };
-        return slot < 32 ? table[slot] : nullptr;
+        return slot < MAX_NODES ? table[slot] : nullptr;
     }
     #undef HORUS_TABLE_ENTRY
 
@@ -339,7 +350,7 @@ namespace detail {
             HORUS_TABLE_ENTRY(24), HORUS_TABLE_ENTRY(25), HORUS_TABLE_ENTRY(26), HORUS_TABLE_ENTRY(27),
             HORUS_TABLE_ENTRY(28), HORUS_TABLE_ENTRY(29), HORUS_TABLE_ENTRY(30), HORUS_TABLE_ENTRY(31),
         };
-        return slot < 32 ? table[slot] : nullptr;
+        return slot < MAX_NODES ? table[slot] : nullptr;
     }
     #undef HORUS_TABLE_ENTRY
 
@@ -352,8 +363,11 @@ namespace detail {
 
 inline void NodeBuilder::build() {
     if (tick_fn_ || init_fn_ || safe_state_fn_ || shutdown_fn_) {
-        size_t slot = detail::g_next_slot++;
-        if (slot >= 32) {
+        // fetch_add so two threads cannot take the same slot; give the slot
+        // back on overflow so a failed build does not burn one.
+        size_t slot = detail::g_next_slot.fetch_add(1, std::memory_order_relaxed);
+        if (slot >= detail::MAX_NODES) {
+            detail::g_next_slot.fetch_sub(1, std::memory_order_relaxed);
             throw Error("Too many nodes (max 32 with callbacks)");
         }
 

--- a/horus_cpp/include/horus/impl/scheduler_impl.hpp
+++ b/horus_cpp/include/horus/impl/scheduler_impl.hpp
@@ -40,7 +40,12 @@ inline Scheduler& Scheduler::operator=(Scheduler&& other) noexcept {
 }
 
 inline Scheduler& Scheduler::tick_rate(Frequency freq) {
-    horus_scheduler_tick_rate(inner_, freq.value());
+    // A non-positive or non-finite rate used to reach an assert! on the Rust
+    // side and abort the process from inside an extern "C" frame. It is now
+    // rejected at the boundary and surfaces here as an ordinary exception.
+    if (horus_scheduler_tick_rate(inner_, freq.value()) != 0) {
+        throw Error("Invalid tick rate (must be finite and > 0 Hz)");
+    }
     return *this;
 }
 

--- a/horus_cpp/include/horus/pool.hpp
+++ b/horus_cpp/include/horus/pool.hpp
@@ -79,12 +79,19 @@ public:
         : handle_(horus_tensor_alloc(pool.raw(), shape, ndim, static_cast<uint8_t>(dtype)))
         , pool_raw_(pool.raw()) {}
 
-    ~Tensor() { if (handle_) horus_tensor_destroy(handle_); }
+    // horus_tensor_destroy only frees the FFI handle box; it does NOT touch the
+    // pool refcount, and FfiTensor has no Drop impl. Destroying without first
+    // calling horus_tensor_release therefore leaked the pool slot forever, so a
+    // node allocating one Tensor per tick exhausted the pool after max_slots
+    // ticks and then got null data() pointers. Every path that gives up
+    // ownership of the handle now goes through reset(), which releases the slot
+    // before destroying the handle.
+    ~Tensor() { reset(); }
 
     // Move only
-    Tensor(Tensor&& o) noexcept : handle_(o.handle_), pool_raw_(o.pool_raw_) { o.handle_ = nullptr; }
+    Tensor(Tensor&& o) noexcept : handle_(o.handle_), pool_raw_(o.pool_raw_) { o.handle_ = nullptr; o.pool_raw_ = nullptr; }
     Tensor& operator=(Tensor&& o) noexcept {
-        if (this != &o) { if (handle_) horus_tensor_destroy(handle_); handle_ = o.handle_; pool_raw_ = o.pool_raw_; o.handle_ = nullptr; }
+        if (this != &o) { reset(); handle_ = o.handle_; pool_raw_ = o.pool_raw_; o.handle_ = nullptr; o.pool_raw_ = nullptr; }
         return *this;
     }
     Tensor(const Tensor&) = delete;
@@ -95,11 +102,23 @@ public:
     uint8_t* data() const { return horus_tensor_data_ptr(pool_raw_, handle_); }
     uint64_t nbytes() const { return handle_ ? horus_tensor_nbytes(handle_) : 0; }
 
-    void release() {
-        if (handle_ && pool_raw_) horus_tensor_release(pool_raw_, handle_);
-    }
+    /// Return the slot to the pool early. The Tensor becomes empty; data()
+    /// then returns nullptr instead of a pointer into a recycled slot, and the
+    /// destructor will not release the same slot a second time.
+    void release() { reset(); }
 
 private:
+    // Order matters: horus_tensor_destroy frees the FfiTensor box that
+    // horus_tensor_release reads the slot descriptor from, so release first.
+    void reset() {
+        if (handle_) {
+            if (pool_raw_) horus_tensor_release(pool_raw_, handle_);
+            horus_tensor_destroy(handle_);
+            handle_ = nullptr;
+            pool_raw_ = nullptr;
+        }
+    }
+
     HorusTensor* handle_;
     HorusTensorPool* pool_raw_;
 };

--- a/horus_cpp/src/c_api.rs
+++ b/horus_cpp/src/c_api.rs
@@ -28,11 +28,18 @@ pub unsafe extern "C" fn horus_scheduler_destroy(sched: *mut FfiScheduler) {
     }
 }
 
-/// Set tick rate in Hz.
+/// Set tick rate in Hz. Returns 0 on success, -1 if `sched` is null or `hz` is
+/// not a finite positive number.
+///
+/// This used to return void and truncate `hz` to a `u64`, so any rate below
+/// 1 Hz became 0 and tripped an `assert!` deep in `u64::hz()` — a panic inside
+/// an `extern "C"` frame, which aborts the process rather than telling C++
+/// anything. Invalid rates are now reported through the return value.
 #[no_mangle]
-pub unsafe extern "C" fn horus_scheduler_tick_rate(sched: *mut FfiScheduler, hz: f64) {
-    if let Some(s) = sched.as_mut() {
-        scheduler_ffi::scheduler_tick_rate(s, hz);
+pub unsafe extern "C" fn horus_scheduler_tick_rate(sched: *mut FfiScheduler, hz: f64) -> i32 {
+    match sched.as_mut() {
+        Some(s) if scheduler_ffi::scheduler_tick_rate(s, hz) => 0,
+        _ => -1,
     }
 }
 
@@ -202,9 +209,16 @@ pub unsafe extern "C" fn horus_node_builder_build(
     }
     let builder = Box::from_raw(builder);
     let sched = &mut *sched;
-    match node_ffi::node_builder_build(builder, sched) {
-        Ok(()) => 0,
-        Err(_) => -1,
+    // A panic that escapes an `extern "C"` frame is undefined behaviour and in
+    // practice aborts the process, giving the C++ caller no way to react. Build
+    // runs a lot of horus_core code, so catch any unwind here and report it as
+    // the ordinary -1 failure the C API already documents.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        node_ffi::node_builder_build(builder, sched)
+    }));
+    match result {
+        Ok(Ok(())) => 0,
+        Ok(Err(_)) | Err(_) => -1,
     }
 }
 
@@ -2059,7 +2073,13 @@ mod tests {
             assert!(!sched.is_null());
             assert!(horus_scheduler_is_running(sched));
 
-            horus_scheduler_tick_rate(sched, 100.0);
+            assert_eq!(horus_scheduler_tick_rate(sched, 100.0), 0);
+            // Sub-1 Hz rates used to truncate to 0 and abort the process from
+            // inside this extern "C" frame; invalid ones now return -1.
+            assert_eq!(horus_scheduler_tick_rate(sched, 0.5), 0);
+            assert_eq!(horus_scheduler_tick_rate(sched, 0.0), -1);
+            assert_eq!(horus_scheduler_tick_rate(sched, f64::NAN), -1);
+            assert_eq!(horus_scheduler_tick_rate(sched, 100.0), 0);
             horus_scheduler_prefer_rt(sched);
 
             assert_eq!(horus_scheduler_tick_once(sched), 0);
@@ -2106,7 +2126,7 @@ mod tests {
         unsafe {
             // All functions should handle null gracefully
             horus_scheduler_destroy(std::ptr::null_mut());
-            horus_scheduler_tick_rate(std::ptr::null_mut(), 100.0);
+            assert_eq!(horus_scheduler_tick_rate(std::ptr::null_mut(), 100.0), -1);
             horus_scheduler_stop(std::ptr::null());
             assert!(!horus_scheduler_is_running(std::ptr::null()));
             assert_eq!(horus_scheduler_tick_once(std::ptr::null_mut()), -1);

--- a/horus_cpp/src/c_api.rs
+++ b/horus_cpp/src/c_api.rs
@@ -38,8 +38,14 @@ pub unsafe extern "C" fn horus_scheduler_destroy(sched: *mut FfiScheduler) {
 #[no_mangle]
 pub unsafe extern "C" fn horus_scheduler_tick_rate(sched: *mut FfiScheduler, hz: f64) -> i32 {
     match sched.as_mut() {
-        Some(s) if scheduler_ffi::scheduler_tick_rate(s, hz) => 0,
-        _ => -1,
+        Some(s) => {
+            if scheduler_ffi::scheduler_tick_rate(s, hz) {
+                0
+            } else {
+                -1
+            }
+        }
+        None => -1,
     }
 }
 

--- a/horus_cpp/src/node_ffi.rs
+++ b/horus_cpp/src/node_ffi.rs
@@ -378,7 +378,7 @@ mod tests {
         let mut sched = scheduler_new();
         let mut slow = node_builder_new("telemetry");
         node_builder_rate(&mut slow, 0.5);
-        assert!(node_builder_build(slow, &mut sched).is_ok());
+        node_builder_build(slow, &mut sched).unwrap();
         assert!(scheduler_node_list(&sched).contains(&"telemetry".to_string()));
 
         for bad in [0.0_f64, -1.0, f64::NAN, f64::INFINITY] {

--- a/horus_cpp/src/node_ffi.rs
+++ b/horus_cpp/src/node_ffi.rs
@@ -247,6 +247,22 @@ pub fn node_builder_build(
     let config = builder.config;
     let node_name = config.name.clone();
 
+    // Validate the rate before touching the scheduler. The rate arrives as an
+    // f64 (the C++ `Frequency` carries a double) and used to be applied as
+    // `(hz as u64).hz()`: that truncated 2.5 Hz to 2 Hz and truncated anything
+    // below 1 Hz to 0, where `u64::hz()` asserts — a panic inside an
+    // `extern "C"` frame, which aborts the whole process instead of returning
+    // an error C++ can see. Reject only genuinely invalid rates, and keep the
+    // f64 so fractional rates survive.
+    let rate_hz = match config.rate_hz {
+        Some(hz) if !hz.is_finite() || hz <= 0.0 => {
+            return Err(format!(
+                "node '{node_name}': tick rate must be finite and positive (got {hz})"
+            ));
+        }
+        other => other,
+    };
+
     // Create node with the C++ tick callback (or no-op if none set).
     // The callback is an extern "C" fn() — panics across extern "C" abort
     // the process (Rust 2024 behavior). Our catch_unwind in CppNode::tick()
@@ -271,8 +287,8 @@ pub fn node_builder_build(
     let mut nb = sched.inner.add(node);
 
     // Apply configuration
-    if let Some(hz) = config.rate_hz {
-        nb = nb.rate((hz as u64).hz());
+    if let Some(hz) = rate_hz {
+        nb = nb.rate(hz.hz());
     }
     if let Some(us) = config.budget_us {
         nb = nb.budget(Duration::from_micros(us));
@@ -351,6 +367,29 @@ mod tests {
         let result = node_builder_build(builder, &mut sched);
         assert!(result.is_ok(), "build failed: {:?}", result);
         assert!(scheduler_node_list(&sched).contains(&"motor_ctrl".to_string()));
+    }
+
+    // Regression: a sub-1 Hz rate used to truncate to 0 and hit the `assert!`
+    // in `u64::hz()` — a panic raised inside an `extern "C"` frame, i.e. an
+    // abort of the whole process. Fractional rates must build, and invalid
+    // ones must come back as an ordinary error.
+    #[test]
+    fn fractional_rate_builds_and_invalid_rate_is_an_error() {
+        let mut sched = scheduler_new();
+        let mut slow = node_builder_new("telemetry");
+        node_builder_rate(&mut slow, 0.5);
+        assert!(node_builder_build(slow, &mut sched).is_ok());
+        assert!(scheduler_node_list(&sched).contains(&"telemetry".to_string()));
+
+        for bad in [0.0_f64, -1.0, f64::NAN, f64::INFINITY] {
+            let mut b = node_builder_new("bad_rate");
+            node_builder_rate(&mut b, bad);
+            assert!(
+                node_builder_build(b, &mut sched).is_err(),
+                "rate {bad} should be rejected, not applied"
+            );
+        }
+        assert!(!scheduler_node_list(&sched).contains(&"bad_rate".to_string()));
     }
 
     #[test]

--- a/horus_cpp/src/scheduler_ffi.rs
+++ b/horus_cpp/src/scheduler_ffi.rs
@@ -50,12 +50,24 @@ pub fn scheduler_new_checked(compiled_abi_version: u32) -> Result<Box<FfiSchedul
 // out of a Box, so we use std::mem::replace to swap the inner scheduler
 // with the builder-modified version.
 
-/// Set the scheduler tick rate in Hz.
+/// Set the scheduler tick rate in Hz. Returns false if `hz` is rejected.
+///
+/// The rate arrives as an f64 because the C++ `Frequency` type carries a
+/// double. It used to be truncated with `(hz as u64).hz()`, which silently
+/// turned 2.5 Hz into 2 Hz and, worse, turned any rate below 1 Hz into 0 —
+/// and `u64::hz()` asserts on 0. That panic was raised inside an `extern "C"`
+/// frame, which aborts the process instead of surfacing an error to C++. So
+/// validate here and keep full f64 precision; the caller reports the
+/// rejection through the ABI.
 ///
 /// C++ usage: `scheduler_tick_rate(sched, 100.0);`
-pub fn scheduler_tick_rate(sched: &mut FfiScheduler, hz: f64) {
+pub fn scheduler_tick_rate(sched: &mut FfiScheduler, hz: f64) -> bool {
+    if !hz.is_finite() || hz <= 0.0 {
+        return false;
+    }
     let inner = std::mem::replace(&mut sched.inner, Scheduler::new());
-    sched.inner = inner.tick_rate((hz as u64).hz());
+    sched.inner = inner.tick_rate(hz.hz());
+    true
 }
 
 /// Set the scheduler name.
@@ -188,8 +200,16 @@ mod tests {
     #[test]
     fn tick_rate_sets_rate() {
         let mut sched = scheduler_new();
-        scheduler_tick_rate(&mut sched, 100.0);
-        // Scheduler stores config internally — verify no panic
+        assert!(scheduler_tick_rate(&mut sched, 100.0));
+        // Fractional rates used to be truncated to u64; sub-1 Hz truncated to
+        // 0 and asserted (an abort across the C boundary). Both are accepted
+        // now, and only genuinely invalid rates are rejected — without panic.
+        assert!(scheduler_tick_rate(&mut sched, 0.5));
+        assert!(scheduler_tick_rate(&mut sched, 2.5));
+        assert!(!scheduler_tick_rate(&mut sched, 0.0));
+        assert!(!scheduler_tick_rate(&mut sched, -1.0));
+        assert!(!scheduler_tick_rate(&mut sched, f64::NAN));
+        assert!(!scheduler_tick_rate(&mut sched, f64::INFINITY));
     }
 
     #[test]
@@ -202,7 +222,7 @@ mod tests {
     #[test]
     fn builder_chain_works() {
         let mut sched = scheduler_new();
-        scheduler_tick_rate(&mut sched, 100.0);
+        assert!(scheduler_tick_rate(&mut sched, 100.0));
         scheduler_prefer_rt(&mut sched);
         scheduler_deterministic(&mut sched, true);
         scheduler_verbose(&mut sched, false);

--- a/horus_cpp/tests/CMakeLists.txt
+++ b/horus_cpp/tests/CMakeLists.txt
@@ -46,6 +46,16 @@ horus_add_gtest(cpp_stress_test     cpp_stress_test.cpp)
 horus_add_gtest(cpp_all_types_test  cpp_all_types_test.cpp)
 horus_add_gtest(cpp_fault_injection cpp_fault_injection.cpp)
 
+# Two translation units in one binary — pins that the header's node callback
+# registry has a single, external-linkage instance program-wide. Built at -O2
+# so the inline trampolines are actually collapsed by the linker.
+add_executable(cpp_multi_tu_test cpp_multi_tu_test.cpp cpp_multi_tu_node.cpp)
+target_compile_options(cpp_multi_tu_test PRIVATE -O2 -fext-numeric-literals)
+target_include_directories(cpp_multi_tu_test PRIVATE ${CMAKE_SOURCE_DIR}/../include)
+target_link_directories(cpp_multi_tu_test PRIVATE ${HORUS_RUST_TARGET_DIR})
+target_link_libraries(cpp_multi_tu_test PRIVATE GTest::gtest_main horus_cpp pthread dl m)
+gtest_discover_tests(cpp_multi_tu_test DISCOVERY_TIMEOUT 60)
+
 # Nightly-only: 2-hour soak. Default ctest excludes via label filter.
 horus_add_nightly_gtest(cpp_soak_test cpp_soak_test.cpp)
 

--- a/horus_cpp/tests/cpp_benchmark.cpp
+++ b/horus_cpp/tests/cpp_benchmark.cpp
@@ -17,7 +17,7 @@
 extern "C" {
     void*    horus_scheduler_new();
     void     horus_scheduler_destroy(void* sched);
-    void     horus_scheduler_tick_rate(void* sched, double hz);
+    int      horus_scheduler_tick_rate(void* sched, double hz);
     void     horus_scheduler_stop(const void* sched);
     bool     horus_scheduler_is_running(const void* sched);
     int      horus_scheduler_tick_once(void* sched);

--- a/horus_cpp/tests/cpp_e2e_test.cpp
+++ b/horus_cpp/tests/cpp_e2e_test.cpp
@@ -12,7 +12,7 @@ extern "C" {
     // Scheduler
     void* horus_scheduler_new();
     void  horus_scheduler_destroy(void* sched);
-    void  horus_scheduler_tick_rate(void* sched, double hz);
+    int   horus_scheduler_tick_rate(void* sched, double hz);
     void  horus_scheduler_prefer_rt(void* sched);
     void  horus_scheduler_stop(const void* sched);
     bool  horus_scheduler_is_running(const void* sched);
@@ -80,7 +80,9 @@ TEST(Cabi, NodeTickCallbackInvoked) {
 TEST(Cabi, NullSafety) {
     // None of these must crash
     horus_scheduler_destroy(nullptr);
-    horus_scheduler_tick_rate(nullptr, 100.0);
+    // tick_rate reports invalid input through its return value now, rather
+    // than returning void: -1 for a null scheduler.
+    EXPECT_EQ(horus_scheduler_tick_rate(nullptr, 100.0), -1);
     horus_scheduler_stop(nullptr);
     EXPECT_FALSE(horus_scheduler_is_running(nullptr)) << "null is_running returns false";
 }

--- a/horus_cpp/tests/cpp_multi_tu_node.cpp
+++ b/horus_cpp/tests/cpp_multi_tu_node.cpp
@@ -1,0 +1,22 @@
+// Second translation unit for the multi-TU callback-registry regression test.
+//
+// Registering a node from a *different* .cpp file than the test body is the
+// whole point of this test: the per-node callback registry in
+// <horus/impl/scheduler_impl.hpp> used to be declared `static` at namespace
+// scope in a header, so every TU got a private copy of the array and of the
+// slot counter. Both TUs then claimed slot 0 and handed Rust the same
+// `tick_trampoline_0`, of which the linker keeps exactly one body — so one
+// node ran the other's tick body, or silently never ticked at all.
+
+#include <horus/horus.hpp>
+
+#include <atomic>
+
+// Defined here, observed by the test TU.
+std::atomic<int> g_tu2_ticks{0};
+
+void register_second_tu_node(horus::Scheduler& sched) {
+    sched.add("tu2_node")
+        .tick([] { g_tu2_ticks.fetch_add(1, std::memory_order_relaxed); })
+        .build();
+}

--- a/horus_cpp/tests/cpp_multi_tu_test.cpp
+++ b/horus_cpp/tests/cpp_multi_tu_test.cpp
@@ -1,0 +1,40 @@
+// Regression test: nodes registered from two different translation units must
+// each get their own callback slot. See cpp_multi_tu_node.cpp for the second TU
+// and the history — every other C++ test in this suite is single-TU, which is
+// why nothing here pinned the header's internal-linkage callback registry.
+
+#include <horus/horus.hpp>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+using namespace horus::literals;
+
+// Defined in cpp_multi_tu_node.cpp.
+extern std::atomic<int> g_tu2_ticks;
+void register_second_tu_node(horus::Scheduler& sched);
+
+static std::atomic<int> g_tu1_ticks{0};
+
+TEST(MultiTranslationUnit, BothNodesRunTheirOwnTickBody) {
+    horus::Scheduler sched;
+    sched.tick_rate(100_hz).name("multi_tu");
+
+    sched.add("tu1_node")
+        .tick([] { g_tu1_ticks.fetch_add(1, std::memory_order_relaxed); })
+        .build();
+
+    register_second_tu_node(sched);
+
+    for (int i = 0; i < 10; ++i) sched.tick_once();
+
+    // With per-TU slot counters both nodes registered trampoline 0, so one of
+    // these two counters stayed at zero while the other counted double.
+    EXPECT_GT(g_tu1_ticks.load(std::memory_order_relaxed), 0)
+        << "node from TU 1 never ticked";
+    EXPECT_GT(g_tu2_ticks.load(std::memory_order_relaxed), 0)
+        << "node from TU 2 never ticked";
+    EXPECT_EQ(g_tu1_ticks.load(std::memory_order_relaxed),
+              g_tu2_ticks.load(std::memory_order_relaxed))
+        << "one tick body ran in place of the other";
+}

--- a/horus_cpp/tests/cpp_stress_test.cpp
+++ b/horus_cpp/tests/cpp_stress_test.cpp
@@ -9,7 +9,7 @@
 extern "C" {
     void*    horus_scheduler_new();
     void     horus_scheduler_destroy(void* sched);
-    void     horus_scheduler_tick_rate(void* sched, double hz);
+    int      horus_scheduler_tick_rate(void* sched, double hz);
     void     horus_scheduler_stop(const void* sched);
     bool     horus_scheduler_is_running(const void* sched);
     int      horus_scheduler_tick_once(void* sched);

--- a/horus_cpp/tests/cpp_user_api_test.cpp
+++ b/horus_cpp/tests/cpp_user_api_test.cpp
@@ -127,6 +127,36 @@ TEST(UserApi, PerceptionPoolImagePointcloudTensor) {
     EXPECT_GT(pool.stats().allocated, 0u);
 }
 
+// Regression: horus::Tensor's destructor used to call horus_tensor_destroy only.
+// That frees the FFI handle but never returns the pool slot (FfiTensor has no
+// Drop impl), so a node allocating one tensor per tick exhausted the pool after
+// max_slots ticks and then wrote through a null data() pointer. The test above
+// only checks `allocated > 0` while a tensor is alive, so it could not catch it.
+TEST(UserApi, TensorReturnsPoolSlotOnDestruction) {
+    const size_t kMaxSlots = 8;
+    horus::TensorPool pool(9961, 4 * 1024 * 1024, kMaxSlots);
+    ASSERT_TRUE(bool(pool));
+
+    uint64_t shape[] = {1, 3, 32, 32};
+    for (size_t i = 0; i < kMaxSlots * 4; ++i) {
+        horus::Tensor t(pool, shape, 4, horus::Dtype::F32);
+        ASSERT_TRUE(bool(t)) << "pool exhausted at iteration " << i;
+        ASSERT_NE(t.data(), nullptr);
+    }
+    EXPECT_EQ(pool.stats().allocated, 0u);
+
+    // An explicit release() empties the handle, so scope exit must not release
+    // (and must not hand out a pointer into) a slot that has been recycled.
+    {
+        horus::Tensor t(pool, shape, 4, horus::Dtype::F32);
+        ASSERT_TRUE(bool(t));
+        t.release();
+        EXPECT_FALSE(bool(t));
+        EXPECT_EQ(t.data(), nullptr);
+    }
+    EXPECT_EQ(pool.stats().allocated, 0u);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 4. Runtime Parameters
 // ═══════════════════════════════════════════════════════════════════════════

--- a/horus_manager/Cargo.toml
+++ b/horus_manager/Cargo.toml
@@ -67,7 +67,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "blocking",
     "rustls-tls",
 ] }
-tempfile = "3.8"
+tempfile = "3.10"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 walkdir = "2.3"
 sha2 = "0.11"

--- a/horus_manager/src/cargo_gen.rs
+++ b/horus_manager/src/cargo_gen.rs
@@ -460,7 +460,7 @@ fn report_lost_edits(path: &Path, lost: &[String], in_workspace_member: bool) {
 #[cfg(test)]
 thread_local! {
     static REPORTED_LOST_EDITS: std::cell::RefCell<Vec<String>> =
-        std::cell::RefCell::new(Vec::new());
+        const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// Take (and clear) the warnings emitted on this thread.

--- a/horus_manager/src/commands/node.rs
+++ b/horus_manager/src/commands/node.rs
@@ -688,12 +688,12 @@ mod tests {
     #[test]
     fn a_rate_far_below_target_is_painted_red() {
         assert_eq!(
-            paint_rate_shortfall("15.9 Hz".to_string(), 100.0, 15.9).fgcolor(),
+            paint_rate_shortfall("15.9 Hz".to_string(), 100.0, 15.9).fgcolor,
             Some(Color::Red),
             "16% of the configured rate is the case the column exists for"
         );
         assert_eq!(
-            paint_rate_shortfall("0.0 Hz".to_string(), 100.0, 0.0).fgcolor(),
+            paint_rate_shortfall("0.0 Hz".to_string(), 100.0, 0.0).fgcolor,
             Some(Color::Red)
         );
     }
@@ -701,13 +701,13 @@ mod tests {
     #[test]
     fn a_rate_that_is_keeping_up_is_painted_green() {
         assert_eq!(
-            paint_rate_shortfall("99.8 Hz".to_string(), 100.0, 99.8).fgcolor(),
+            paint_rate_shortfall("99.8 Hz".to_string(), 100.0, 99.8).fgcolor,
             Some(Color::Green),
             "the sampling window is about a second, so a couple of percent of \
              wander is not a finding"
         );
         assert_eq!(
-            paint_rate_shortfall("30.0 Hz".to_string(), 30.0, 30.0).fgcolor(),
+            paint_rate_shortfall("30.0 Hz".to_string(), 30.0, 30.0).fgcolor,
             Some(Color::Green)
         );
     }
@@ -715,7 +715,7 @@ mod tests {
     #[test]
     fn a_partial_shortfall_is_painted_amber() {
         assert_eq!(
-            paint_rate_shortfall("75.0 Hz".to_string(), 100.0, 75.0).fgcolor(),
+            paint_rate_shortfall("75.0 Hz".to_string(), 100.0, 75.0).fgcolor,
             Some(Color::Yellow)
         );
     }
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn a_node_with_no_configured_rate_gets_no_verdict() {
         assert_eq!(
-            paint_rate_shortfall("12.0 Hz".to_string(), 0.0, 12.0).fgcolor(),
+            paint_rate_shortfall("12.0 Hz".to_string(), 0.0, 12.0).fgcolor,
             None
         );
     }

--- a/horus_manager/src/commands/pod_decode.rs
+++ b/horus_manager/src/commands/pod_decode.rs
@@ -357,9 +357,9 @@ mod tests {
         // A payload from a different version of the type, or a layout this code
         // computed wrongly. Either way the caller falls back to hex.
         let reg = registry();
-        assert!(decode("Twist", &vec![0u8; 55], &reg).is_none());
-        assert!(decode("Twist", &vec![0u8; 57], &reg).is_none());
-        assert!(decode("NotAMessage", &vec![0u8; 8], &reg).is_none());
+        assert!(decode("Twist", &[0u8; 55], &reg).is_none());
+        assert!(decode("Twist", &[0u8; 57], &reg).is_none());
+        assert!(decode("NotAMessage", &[0u8; 8], &reg).is_none());
     }
 
     #[test]

--- a/horus_manager/src/commands/run/deps.rs
+++ b/horus_manager/src/commands/run/deps.rs
@@ -260,7 +260,7 @@ fn parse_all_python_imports(line: &str) -> Vec<String> {
             .split(',')
             .filter_map(|item| {
                 // `numpy as np` -> `numpy`; `os.path` -> `os`
-                let name = item.trim().split_whitespace().next()?.split('.').next()?;
+                let name = item.split_whitespace().next()?.split('.').next()?;
                 keep_package(name)
             })
             .collect();

--- a/horus_manager/src/commands/run/install.rs
+++ b/horus_manager/src/commands/run/install.rs
@@ -1711,6 +1711,261 @@ pub(crate) fn create_system_reference_python_run(
     Ok(())
 }
 
+/// Whether a crates.io cache directory actually holds an installed binary.
+///
+/// `cargo install --root DIR` puts executables in `DIR/bin/`, so that is what
+/// "installed" means here — unlike the pypi cache, where it means an importable
+/// module.
+fn cargo_cache_is_usable(dir: &Path) -> bool {
+    if !dir.join("metadata.json").is_file() {
+        return false;
+    }
+    fs::read_dir(dir.join("bin"))
+        .map(|mut e| e.next().is_some())
+        .unwrap_or(false)
+}
+
+/// Whether a cache directory actually holds an installed package.
+///
+/// `metadata.json` is written only after pip reports success, so its absence
+/// means the install did not finish. Its presence is necessary and not
+/// sufficient: a metadata file next to nothing is not a package, and an
+/// interrupted run can leave exactly that.
+fn cache_is_usable(dir: &Path) -> bool {
+    if !dir.join("metadata.json").is_file() {
+        return false;
+    }
+    !top_level_modules(dir).is_empty()
+}
+
+/// The importable names a pip `--target` directory provides.
+///
+/// Package name and module name are routinely different — `horus-robotics`
+/// installs `horus` — so this reports what is actually there rather than
+/// guessing an import to try. Directories with an `__init__.py`, bare `.py`
+/// modules, and compiled extensions all count; pip's own bookkeeping
+/// (`*.dist-info`, `*.egg-info`, `__pycache__`, `bin`) does not.
+///
+/// `run_python::push_importable_dirs` asks the same question of the same
+/// directories when it builds PYTHONPATH, which is why this is `pub(super)`:
+/// the set of directories HORUS calls importable and the set it puts on
+/// sys.path have to be the same set, or the install reports a module the
+/// interpreter cannot then find.
+pub(super) fn top_level_modules(dir: &Path) -> Vec<String> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.ends_with(".dist-info")
+            || name.ends_with(".egg-info")
+            || name == "__pycache__"
+            || name == "bin"
+            || name == "metadata.json"
+        {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() && path.join("__init__.py").is_file() {
+            out.push(name);
+        } else if name.ends_with(".py") {
+            out.push(name.trim_end_matches(".py").to_string());
+        } else if name.ends_with(".so") || name.ends_with(".pyd") {
+            // e.g. `_horus.cpython-314-x86_64-linux-gnu.so`
+            out.push(name.split('.').next().unwrap_or(&name).to_string());
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+// ── Link and materialization checks (PATH-3) ───────────────────────────────
+//
+// Three gates in this file used to ask `link.exists() || link.read_link().is_ok()`.
+// The second half of that disjunction is true for a *dangling* symlink for as
+// long as the link file exists, so once a cache directory went away — deleted
+// by the user, by a cleanup script, or on the advice this module itself prints
+// — every later run reported "(already linked)" with a green tick and skipped
+// the install that would have repaired it.
+
+/// Remove a link/entry that is present but no longer usable.
+///
+/// Returns whether anything was removed, so callers can say so. Without this
+/// the reinstall would fail on "File exists" when it tried to re-create the
+/// symlink.
+///
+/// Only ever removes a symlink (never its target) or an empty directory. A
+/// non-empty real directory at this path was put there by something other than
+/// this code, and deleting it to "repair" a link would be a far worse bug than
+/// the one being repaired.
+fn clear_broken_link(path: &Path) -> bool {
+    let Ok(meta) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    if meta.file_type().is_symlink() {
+        // remove_file on a symlink unlinks the link itself, not the target.
+        return fs::remove_file(path).is_ok();
+    }
+    if meta.is_dir() {
+        let empty = fs::read_dir(path)
+            .map(|mut e| e.next().is_none())
+            .unwrap_or(false);
+        if empty {
+            return fs::remove_dir(path).is_ok();
+        }
+        log::warn!(
+            "{} is a directory, not a HORUS link — leaving it alone",
+            path.display()
+        );
+        return false;
+    }
+    fs::remove_file(path).is_ok()
+}
+
+/// Whether `.horus/packages/<name>` still resolves to an importable package.
+///
+/// The same predicate the install path uses to decide whether the cache is a
+/// hit, applied through the link: a link into an emptied cache directory is no
+/// more useful than a link into a deleted one.
+fn python_link_is_usable(link: &Path) -> bool {
+    if !link.exists() {
+        return false;
+    }
+    match fs::symlink_metadata(link) {
+        Ok(m) if m.file_type().is_symlink() => cache_is_usable(link),
+        // Not a link into the cache: something else owns this path — an older
+        // HORUS, a copy, a vendored package. It is not this code's to replace,
+        // and it works if it provides a module.
+        _ => !top_level_modules(link).is_empty(),
+    }
+}
+
+/// Whether `.horus/packages/<name>` still resolves to an install HORUS finished.
+///
+/// Deliberately weaker than `python_link_is_usable`, and used only to decide
+/// whether the lockfile may skip resolution. `metadata.json` is written after
+/// pip reports success and is therefore the record that an install completed;
+/// requiring an importable module here as well would send the handful of
+/// distributions that ship only scripts back through pip on every single run,
+/// which is a worse bargain than the case it would catch (a cache directory
+/// emptied by hand but with the marker left in place — `rm -rf` takes the
+/// marker with it, and so does a partial install, because the marker is
+/// written last).
+fn python_link_records_a_finished_install(link: &Path) -> bool {
+    if !link.exists() {
+        return false;
+    }
+    // Either HORUS's own record of a finished install, or a path something
+    // else manages that provides a module anyway.
+    link.join("metadata.json").is_file() || python_link_is_usable(link)
+}
+
+/// Whether `.horus/bin/<name>` still resolves to a binary.
+fn cargo_link_is_usable(link: &Path) -> bool {
+    link.exists()
+}
+
+/// Whether a HORUS registry cache directory holds anything at all.
+///
+/// Registry packages have no metadata.json of our making, so "usable" here can
+/// only mean non-empty — but non-empty is precisely what a failed install is
+/// not.
+fn horus_cache_is_usable(dir: &Path) -> bool {
+    fs::read_dir(dir)
+        .map(|mut e| e.next().is_some())
+        .unwrap_or(false)
+}
+
+/// Whether a link created by `resolve_horus_packages` still resolves.
+fn horus_link_is_usable(link: &Path) -> bool {
+    link.exists() && (link.is_file() || horus_cache_is_usable(link))
+}
+
+/// The dependencies horus.lock stands for that are not actually installed.
+///
+/// horus.lock records a config hash and nothing else — no package set, no
+/// versions, no paths. "The hash still matches" therefore says only that the
+/// *inputs* are unchanged; it is not evidence that the outputs survived. This
+/// asks the disk instead, so the lockfile fast path can be taken when it is
+/// true and skipped when it is not.
+///
+/// `root` is the project directory (`.` in normal operation, a tempdir under
+/// test).
+///
+/// `system_reference_usable` answers, for a package that resolved to the
+/// interpreter's own copy, whether that copy is still there. It is a parameter
+/// rather than a call because answering it costs a child interpreter, and
+/// because a filesystem fixture cannot express "installed in Python" — see
+/// `system_reference_is_usable` for the production answer.
+fn unmaterialized_dependencies(
+    root: &Path,
+    horus_packages: &[String],
+    pip_packages: &[PipPackage],
+    cargo_packages: &[CargoPackage],
+    context_language: Option<&str>,
+    system_reference_usable: &dyn Fn(&str) -> bool,
+) -> Vec<String> {
+    let packages_dir = root.join(".horus/packages");
+    let bin_dir = root.join(".horus/bin");
+
+    // A package resolved to the system copy leaves a marker instead of a link.
+    let has_system_reference =
+        |name: &str| packages_dir.join(format!("{}.system.json", name)).is_file();
+
+    // For a *Python* package the marker's existence was the whole of this
+    // check, and a marker is a claim about somewhere else. `pip uninstall`
+    // interrupted halfway, a hand `rm -rf site-packages/<pkg>`, or a Python
+    // minor-version bump leaves the claim behind and the package gone, and this
+    // reported the dependency as installed — so the lockfile fast path printed
+    // "* Dependencies locked (horus.lock is up-to-date)" and the node then
+    // died on `import`, with the code that would have repaired it never
+    // reached. Asking whether the reference still resolves is what makes the
+    // green line true.
+    //
+    // Only the pip loop asks. `create_system_reference_cargo_run` writes into
+    // the same `<name>.system.json` namespace for a crates.io *binary*, and a
+    // binary on PATH is not a Python distribution: putting the import question
+    // to it would answer "missing" every time and re-resolve it on every run.
+    let has_importable_system_reference =
+        |name: &str| has_system_reference(name) && system_reference_usable(name);
+
+    let mut missing = Vec::new();
+
+    for package in horus_packages {
+        // horus_py is linked under the name it is imported by.
+        let link = if package == "horus_py" || package.starts_with("horus_py@") {
+            packages_dir.join("horus")
+        } else {
+            packages_dir.join(package)
+        };
+        if !horus_link_is_usable(&link) && !has_system_reference(package) {
+            missing.push(package.clone());
+        }
+    }
+
+    for pkg in pip_packages {
+        if !python_link_records_a_finished_install(&packages_dir.join(&pkg.name))
+            && !has_importable_system_reference(&pkg.name)
+        {
+            missing.push(pkg.name.clone());
+        }
+    }
+
+    // Mirror the resolver: cargo packages are not installed at all in a Python
+    // project, so their absence is not a missing dependency there.
+    if context_language != Some("python") {
+        for pkg in cargo_packages {
+            if !cargo_link_is_usable(&bin_dir.join(&pkg.name)) && !has_system_reference(&pkg.name) {
+                missing.push(pkg.name.clone());
+            }
+        }
+    }
+
+    missing
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -2865,259 +3120,4 @@ mod tests {
         assert!(written.contains("6.1"), "{written}");
         assert!(written.contains("pypi"), "{written}");
     }
-}
-
-/// Whether a crates.io cache directory actually holds an installed binary.
-///
-/// `cargo install --root DIR` puts executables in `DIR/bin/`, so that is what
-/// "installed" means here — unlike the pypi cache, where it means an importable
-/// module.
-fn cargo_cache_is_usable(dir: &Path) -> bool {
-    if !dir.join("metadata.json").is_file() {
-        return false;
-    }
-    fs::read_dir(dir.join("bin"))
-        .map(|mut e| e.next().is_some())
-        .unwrap_or(false)
-}
-
-/// Whether a cache directory actually holds an installed package.
-///
-/// `metadata.json` is written only after pip reports success, so its absence
-/// means the install did not finish. Its presence is necessary and not
-/// sufficient: a metadata file next to nothing is not a package, and an
-/// interrupted run can leave exactly that.
-fn cache_is_usable(dir: &Path) -> bool {
-    if !dir.join("metadata.json").is_file() {
-        return false;
-    }
-    !top_level_modules(dir).is_empty()
-}
-
-/// The importable names a pip `--target` directory provides.
-///
-/// Package name and module name are routinely different — `horus-robotics`
-/// installs `horus` — so this reports what is actually there rather than
-/// guessing an import to try. Directories with an `__init__.py`, bare `.py`
-/// modules, and compiled extensions all count; pip's own bookkeeping
-/// (`*.dist-info`, `*.egg-info`, `__pycache__`, `bin`) does not.
-///
-/// `run_python::push_importable_dirs` asks the same question of the same
-/// directories when it builds PYTHONPATH, which is why this is `pub(super)`:
-/// the set of directories HORUS calls importable and the set it puts on
-/// sys.path have to be the same set, or the install reports a module the
-/// interpreter cannot then find.
-pub(super) fn top_level_modules(dir: &Path) -> Vec<String> {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    let mut out = Vec::new();
-    for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if name.ends_with(".dist-info")
-            || name.ends_with(".egg-info")
-            || name == "__pycache__"
-            || name == "bin"
-            || name == "metadata.json"
-        {
-            continue;
-        }
-        let path = entry.path();
-        if path.is_dir() && path.join("__init__.py").is_file() {
-            out.push(name);
-        } else if name.ends_with(".py") {
-            out.push(name.trim_end_matches(".py").to_string());
-        } else if name.ends_with(".so") || name.ends_with(".pyd") {
-            // e.g. `_horus.cpython-314-x86_64-linux-gnu.so`
-            out.push(name.split('.').next().unwrap_or(&name).to_string());
-        }
-    }
-    out.sort();
-    out.dedup();
-    out
-}
-
-// ── Link and materialization checks (PATH-3) ───────────────────────────────
-//
-// Three gates in this file used to ask `link.exists() || link.read_link().is_ok()`.
-// The second half of that disjunction is true for a *dangling* symlink for as
-// long as the link file exists, so once a cache directory went away — deleted
-// by the user, by a cleanup script, or on the advice this module itself prints
-// — every later run reported "(already linked)" with a green tick and skipped
-// the install that would have repaired it.
-
-/// Remove a link/entry that is present but no longer usable.
-///
-/// Returns whether anything was removed, so callers can say so. Without this
-/// the reinstall would fail on "File exists" when it tried to re-create the
-/// symlink.
-///
-/// Only ever removes a symlink (never its target) or an empty directory. A
-/// non-empty real directory at this path was put there by something other than
-/// this code, and deleting it to "repair" a link would be a far worse bug than
-/// the one being repaired.
-fn clear_broken_link(path: &Path) -> bool {
-    let Ok(meta) = fs::symlink_metadata(path) else {
-        return false;
-    };
-    if meta.file_type().is_symlink() {
-        // remove_file on a symlink unlinks the link itself, not the target.
-        return fs::remove_file(path).is_ok();
-    }
-    if meta.is_dir() {
-        let empty = fs::read_dir(path)
-            .map(|mut e| e.next().is_none())
-            .unwrap_or(false);
-        if empty {
-            return fs::remove_dir(path).is_ok();
-        }
-        log::warn!(
-            "{} is a directory, not a HORUS link — leaving it alone",
-            path.display()
-        );
-        return false;
-    }
-    fs::remove_file(path).is_ok()
-}
-
-/// Whether `.horus/packages/<name>` still resolves to an importable package.
-///
-/// The same predicate the install path uses to decide whether the cache is a
-/// hit, applied through the link: a link into an emptied cache directory is no
-/// more useful than a link into a deleted one.
-fn python_link_is_usable(link: &Path) -> bool {
-    if !link.exists() {
-        return false;
-    }
-    match fs::symlink_metadata(link) {
-        Ok(m) if m.file_type().is_symlink() => cache_is_usable(link),
-        // Not a link into the cache: something else owns this path — an older
-        // HORUS, a copy, a vendored package. It is not this code's to replace,
-        // and it works if it provides a module.
-        _ => !top_level_modules(link).is_empty(),
-    }
-}
-
-/// Whether `.horus/packages/<name>` still resolves to an install HORUS finished.
-///
-/// Deliberately weaker than `python_link_is_usable`, and used only to decide
-/// whether the lockfile may skip resolution. `metadata.json` is written after
-/// pip reports success and is therefore the record that an install completed;
-/// requiring an importable module here as well would send the handful of
-/// distributions that ship only scripts back through pip on every single run,
-/// which is a worse bargain than the case it would catch (a cache directory
-/// emptied by hand but with the marker left in place — `rm -rf` takes the
-/// marker with it, and so does a partial install, because the marker is
-/// written last).
-fn python_link_records_a_finished_install(link: &Path) -> bool {
-    if !link.exists() {
-        return false;
-    }
-    // Either HORUS's own record of a finished install, or a path something
-    // else manages that provides a module anyway.
-    link.join("metadata.json").is_file() || python_link_is_usable(link)
-}
-
-/// Whether `.horus/bin/<name>` still resolves to a binary.
-fn cargo_link_is_usable(link: &Path) -> bool {
-    link.exists()
-}
-
-/// Whether a HORUS registry cache directory holds anything at all.
-///
-/// Registry packages have no metadata.json of our making, so "usable" here can
-/// only mean non-empty — but non-empty is precisely what a failed install is
-/// not.
-fn horus_cache_is_usable(dir: &Path) -> bool {
-    fs::read_dir(dir)
-        .map(|mut e| e.next().is_some())
-        .unwrap_or(false)
-}
-
-/// Whether a link created by `resolve_horus_packages` still resolves.
-fn horus_link_is_usable(link: &Path) -> bool {
-    link.exists() && (link.is_file() || horus_cache_is_usable(link))
-}
-
-/// The dependencies horus.lock stands for that are not actually installed.
-///
-/// horus.lock records a config hash and nothing else — no package set, no
-/// versions, no paths. "The hash still matches" therefore says only that the
-/// *inputs* are unchanged; it is not evidence that the outputs survived. This
-/// asks the disk instead, so the lockfile fast path can be taken when it is
-/// true and skipped when it is not.
-///
-/// `root` is the project directory (`.` in normal operation, a tempdir under
-/// test).
-///
-/// `system_reference_usable` answers, for a package that resolved to the
-/// interpreter's own copy, whether that copy is still there. It is a parameter
-/// rather than a call because answering it costs a child interpreter, and
-/// because a filesystem fixture cannot express "installed in Python" — see
-/// `system_reference_is_usable` for the production answer.
-fn unmaterialized_dependencies(
-    root: &Path,
-    horus_packages: &[String],
-    pip_packages: &[PipPackage],
-    cargo_packages: &[CargoPackage],
-    context_language: Option<&str>,
-    system_reference_usable: &dyn Fn(&str) -> bool,
-) -> Vec<String> {
-    let packages_dir = root.join(".horus/packages");
-    let bin_dir = root.join(".horus/bin");
-
-    // A package resolved to the system copy leaves a marker instead of a link.
-    let has_system_reference =
-        |name: &str| packages_dir.join(format!("{}.system.json", name)).is_file();
-
-    // For a *Python* package the marker's existence was the whole of this
-    // check, and a marker is a claim about somewhere else. `pip uninstall`
-    // interrupted halfway, a hand `rm -rf site-packages/<pkg>`, or a Python
-    // minor-version bump leaves the claim behind and the package gone, and this
-    // reported the dependency as installed — so the lockfile fast path printed
-    // "* Dependencies locked (horus.lock is up-to-date)" and the node then
-    // died on `import`, with the code that would have repaired it never
-    // reached. Asking whether the reference still resolves is what makes the
-    // green line true.
-    //
-    // Only the pip loop asks. `create_system_reference_cargo_run` writes into
-    // the same `<name>.system.json` namespace for a crates.io *binary*, and a
-    // binary on PATH is not a Python distribution: putting the import question
-    // to it would answer "missing" every time and re-resolve it on every run.
-    let has_importable_system_reference =
-        |name: &str| has_system_reference(name) && system_reference_usable(name);
-
-    let mut missing = Vec::new();
-
-    for package in horus_packages {
-        // horus_py is linked under the name it is imported by.
-        let link = if package == "horus_py" || package.starts_with("horus_py@") {
-            packages_dir.join("horus")
-        } else {
-            packages_dir.join(package)
-        };
-        if !horus_link_is_usable(&link) && !has_system_reference(package) {
-            missing.push(package.clone());
-        }
-    }
-
-    for pkg in pip_packages {
-        if !python_link_records_a_finished_install(&packages_dir.join(&pkg.name))
-            && !has_importable_system_reference(&pkg.name)
-        {
-            missing.push(pkg.name.clone());
-        }
-    }
-
-    // Mirror the resolver: cargo packages are not installed at all in a Python
-    // project, so their absence is not a missing dependency there.
-    if context_language != Some("python") {
-        for pkg in cargo_packages {
-            if !cargo_link_is_usable(&bin_dir.join(&pkg.name)) && !has_system_reference(&pkg.name) {
-                missing.push(pkg.name.clone());
-            }
-        }
-    }
-
-    missing
 }

--- a/horus_manager/src/commands/run/run_python.rs
+++ b/horus_manager/src/commands/run/run_python.rs
@@ -339,10 +339,25 @@ fn create_python_wrapper() -> Result<(tempfile::TempDir, PathBuf)> {
     // O_NOFOLLOW: in a shared /tmp another local user could pre-create the
     // path as a symlink, or simply rewrite the file in the window before the
     // interpreter opens it — and this file is then executed. A private
-    // per-invocation directory (mode 0700, random name, created exclusively)
+    // per-invocation directory (random name, mode 0700, created exclusively)
     // puts the script out of other users' reach entirely.
-    let dir = tempfile::Builder::new()
-        .prefix("horus_wrapper_")
+    //
+    // The 0700 has to be asked for explicitly: `tempdir()` on its own creates
+    // the directory with a plain `mkdir` at 0o777 & !umask, i.e. 0755 under
+    // the usual umask 022 — owned by us, but *enterable and readable* by every
+    // local user, which defeats the whole point of moving the script here.
+    // `Builder::permissions` passes the mode down to `mkdir(2)` itself, so the
+    // directory is never visible to anyone else even momentarily; chmod-ing
+    // after the fact would leave a window with the loose mode. umask can only
+    // clear further bits, never add them, so the result is at most 0700.
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("horus_wrapper_");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(fs::Permissions::from_mode(0o700));
+    }
+    let dir = builder
         .tempdir()
         .context("creating a private temporary directory for the Python wrapper")?;
     let wrapper_path = dir.path().join("wrapper.py");
@@ -392,7 +407,28 @@ if __name__ == "__main__":
     scheduler.run_node()
 "#;
 
-    fs::write(&wrapper_path, wrapper_content)?;
+    // Defence in depth for the script itself. The 0700 directory above is what
+    // actually keeps other users out, but the file inherits nothing from it:
+    // `fs::write` would create it 0o666 & !umask, so a wrapper.py that ever
+    // ended up somewhere less protected (a differently-configured TMPDIR, a
+    // future caller passing in its own directory) would be world-readable.
+    // `create_new` adds O_EXCL, so this never opens a path that already exists
+    // — no pre-planted symlink or file can be written through.
+    use std::io::Write;
+    let mut opts = fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut wrapper_file = opts
+        .open(&wrapper_path)
+        .with_context(|| format!("creating the Python wrapper {}", wrapper_path.display()))?;
+    wrapper_file
+        .write_all(wrapper_content.as_bytes())
+        .with_context(|| format!("writing the Python wrapper {}", wrapper_path.display()))?;
+
     Ok((dir, wrapper_path))
 }
 
@@ -817,7 +853,11 @@ mod tests {
         // Regression: the wrapper was written to a predictable
         // `/tmp/horus_wrapper_<nanos>.py` and then executed, so any local user
         // could pre-create or rewrite it. It must now sit inside its own
-        // directory, which tempfile creates with mode 0700.
+        // directory — and that directory has to be created 0700 *explicitly*:
+        // tempfile's default is a plain `mkdir` at 0o777 & !umask, which is
+        // 0755 under the usual umask 022 and leaves the script readable by
+        // every local user. This assertion is what catches a regression back
+        // to the default, so it checks the mode rather than trusting tempfile.
         let (dir, wrapper) = create_python_wrapper().unwrap();
         assert_eq!(
             wrapper.parent().unwrap(),
@@ -834,6 +874,16 @@ mod tests {
                 0,
                 "wrapper directory must not be group/world accessible: {:o}",
                 mode
+            );
+
+            // The script is what actually gets executed, so it carries its own
+            // restriction rather than relying on the directory's mode alone.
+            let file_mode = fs::metadata(&wrapper).unwrap().permissions().mode();
+            assert_eq!(
+                file_mode & 0o077,
+                0,
+                "wrapper script must not be group/world accessible: {:o}",
+                file_mode
             );
         }
     }

--- a/horus_manager/src/commands/run/run_python.rs
+++ b/horus_manager/src/commands/run/run_python.rs
@@ -1,5 +1,5 @@
 use crate::cli_output;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use colored::*;
 use std::collections::HashSet;
 use std::env;
@@ -36,7 +36,9 @@ pub(super) fn execute_python_node(file: PathBuf, args: Vec<String>, _release: bo
             cli_output::ICON_INFO.cyan()
         );
 
-        let wrapper_script = create_python_wrapper()?;
+        // `_wrapper_dir` must outlive the child: dropping it deletes the
+        // directory holding the script.
+        let (_wrapper_dir, wrapper_script) = create_python_wrapper()?;
 
         let mut cmd = Command::new(python_cmd);
         cmd.arg(&wrapper_script);
@@ -48,9 +50,6 @@ pub(super) fn execute_python_node(file: PathBuf, args: Vec<String>, _release: bo
         // Spawn child process with Ctrl+C forwarding
         let child = cmd.spawn()?;
         let status = super::spawn_with_ctrlc(child, "Python")?;
-
-        // Cleanup wrapper script
-        fs::remove_file(wrapper_script).ok();
 
         // Propagate the child's exit code as an error
         if !status.success() {
@@ -325,18 +324,28 @@ fn validate_node_path(file: &Path) -> Result<PathBuf> {
 /// Create a temporary Python wrapper script that loads the real node file from
 /// the `HORUS_NODE_FILE` environment variable at runtime.
 ///
+/// Returns the owning [`TempDir`] alongside the script path: the directory must
+/// stay alive until the interpreter has finished with the script, and dropping
+/// it removes both.
+///
 /// **Security**: the user-supplied file path is intentionally NOT interpolated
 /// into the Python source here.  It is passed out-of-band via the environment
 /// variable so that a crafted filename like `'); os.system('rm -rf /')` cannot
 /// execute arbitrary code.
-fn create_python_wrapper() -> Result<PathBuf> {
-    // Use a timestamp-based name so the wrapper cannot be guessed or hijacked,
-    // and no user-controlled string is included in the filename.
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let wrapper_path = env::temp_dir().join(format!("horus_wrapper_{ts}.py"));
+fn create_python_wrapper() -> Result<(tempfile::TempDir, PathBuf)> {
+    // The wrapper used to be written to `/tmp/horus_wrapper_<nanos>.py` under
+    // the claim that a timestamp "cannot be guessed or hijacked". A timestamp
+    // is not a secret, and `fs::write` is O_CREAT|O_TRUNC without O_EXCL or
+    // O_NOFOLLOW: in a shared /tmp another local user could pre-create the
+    // path as a symlink, or simply rewrite the file in the window before the
+    // interpreter opens it — and this file is then executed. A private
+    // per-invocation directory (mode 0700, random name, created exclusively)
+    // puts the script out of other users' reach entirely.
+    let dir = tempfile::Builder::new()
+        .prefix("horus_wrapper_")
+        .tempdir()
+        .context("creating a private temporary directory for the Python wrapper")?;
+    let wrapper_path = dir.path().join("wrapper.py");
 
     // Fixed template — no user input anywhere inside this string.
     let wrapper_content = r#"#!/usr/bin/env python3
@@ -384,7 +393,7 @@ if __name__ == "__main__":
 "#;
 
     fs::write(&wrapper_path, wrapper_content)?;
-    Ok(wrapper_path)
+    Ok((dir, wrapper_path))
 }
 
 /// Generate `.horus/pyproject.toml` from `horus.toml` if the manifest exists.
@@ -452,9 +461,8 @@ mod tests {
         // create_python_wrapper writes a fixed string — verify it doesn't
         // contain `{}` or `r'{}'` patterns that would indicate leftover
         // format!() interpolation.
-        let wrapper_path = create_python_wrapper().expect("wrapper creation failed");
+        let (_dir, wrapper_path) = create_python_wrapper().expect("wrapper creation failed");
         let content = fs::read_to_string(&wrapper_path).expect("read wrapper");
-        fs::remove_file(&wrapper_path).ok();
 
         assert!(
             !content.contains("r'{}'") && !content.contains("open(r'"),
@@ -778,9 +786,8 @@ mod tests {
 
     #[test]
     fn battle_wrapper_is_valid_python() {
-        let wrapper = create_python_wrapper().unwrap();
+        let (_dir, wrapper) = create_python_wrapper().unwrap();
         let content = fs::read_to_string(&wrapper).unwrap();
-        fs::remove_file(&wrapper).ok();
 
         // Verify it's valid Python by checking structure
         assert!(content.contains("#!/usr/bin/env python3"));
@@ -791,13 +798,44 @@ mod tests {
 
     #[test]
     fn battle_wrapper_unique_filenames() {
-        let w1 = create_python_wrapper().unwrap();
-        let w2 = create_python_wrapper().unwrap();
-        // Two wrappers created at different times should have different names
-        // (or at least not collide)
-        fs::remove_file(&w1).ok();
-        fs::remove_file(&w2).ok();
-        // Both created successfully — that's the test
+        // This used to assert nothing at all — two timestamped names in a
+        // shared /tmp. Each wrapper now lives in its own private directory, so
+        // assert the real property: the two paths differ and both exist at
+        // once, i.e. concurrent runs cannot land on the same file.
+        let (d1, w1) = create_python_wrapper().unwrap();
+        let (d2, w2) = create_python_wrapper().unwrap();
+        assert_ne!(w1, w2, "two wrappers must not share a path");
+        assert!(w1.exists() && w2.exists());
+        drop(d1);
+        drop(d2);
+        assert!(!w1.exists(), "TempDir drop must remove the wrapper");
+        assert!(!w2.exists(), "TempDir drop must remove the wrapper");
+    }
+
+    #[test]
+    fn wrapper_lives_in_a_private_directory_not_shared_tmp() {
+        // Regression: the wrapper was written to a predictable
+        // `/tmp/horus_wrapper_<nanos>.py` and then executed, so any local user
+        // could pre-create or rewrite it. It must now sit inside its own
+        // directory, which tempfile creates with mode 0700.
+        let (dir, wrapper) = create_python_wrapper().unwrap();
+        assert_eq!(
+            wrapper.parent().unwrap(),
+            dir.path(),
+            "wrapper must live inside its own temp directory"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(dir.path()).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o077,
+                0,
+                "wrapper directory must not be group/world accessible: {:o}",
+                mode
+            );
+        }
     }
 
     // ── Battle-testing: pyproject generation ─────────────────────────────

--- a/horus_manager/src/commands/run/run_python.rs
+++ b/horus_manager/src/commands/run/run_python.rs
@@ -520,7 +520,7 @@ mod tests {
         fs::create_dir_all(project.join(".horus/packages")).unwrap();
         horus_sys::fs::symlink(&pkg_dir, &project.join(".horus/packages/horus-fixture")).unwrap();
 
-        let entries = collect_python_path_entries(&project, &[cache.clone()]);
+        let entries = collect_python_path_entries(&project, std::slice::from_ref(&cache));
         let python_path = entries.join(PYTHON_PATH_SEP);
 
         let output = Command::new("python3")

--- a/horus_manager/src/commands/upgrade.rs
+++ b/horus_manager/src/commands/upgrade.rs
@@ -82,29 +82,118 @@ pub fn check_latest_version() -> Result<Option<String>> {
     }
 }
 
-/// Upgrade horus by rebuilding from source.
+/// Upgrade horus by rebuilding from the HORUS source tree.
+///
+/// This used to run `cargo install --path .`, which resolves against the
+/// process's current working directory. `horus self update` is a command
+/// people naturally run from inside a project, so it built and installed
+/// *that* package — running its `build.rs` and proc-macro dependencies as the
+/// user, then dropping its binaries into `~/.cargo/bin`, which is on PATH
+/// ahead of the real CLI — and printed "Upgraded to <version>" either way.
+/// The artifact must come from the resolved HORUS source tree, never from
+/// `std::env::current_dir()`, and the success line must be earned.
 pub(crate) fn upgrade_horus(version: &str) -> Result<()> {
+    // `version` is whatever the registry's JSON said. Since it is about to
+    // reach a process argument and be reported to the user as installed,
+    // require it to be plain semver first: a hostile response cannot then
+    // smuggle a leading `-` through as a cargo flag.
+    semver::Version::parse(version)
+        .with_context(|| format!("registry reported a non-semver version {:?}", version))?;
+
     println!("  Building horus {}...", version.cyan());
 
-    // Try cargo install from source
+    let src_root = crate::commands::run::find_horus_source_dir()
+        .context("cannot locate the HORUS source tree to build from; set HORUS_SOURCE")?;
+    // find_horus_source_dir() returns the workspace root, whose Cargo.toml is a
+    // virtual manifest — `cargo install --path` needs the package directory.
+    let manifest_dir = src_root.join("horus_manager");
+    let manifest = manifest_dir.join("Cargo.toml");
+    let manifest_text = std::fs::read_to_string(&manifest)
+        .with_context(|| format!("reading {}", manifest.display()))?;
+    anyhow::ensure!(
+        manifest_text.contains("name = \"horus_manager\""),
+        "{} is not the horus_manager package; refusing to install from it",
+        manifest.display()
+    );
+
+    let manual_hint = format!(
+        "cargo install --path {} --locked --force",
+        manifest_dir.display()
+    );
+
+    // --locked so the build cannot silently pick up newer transitive deps;
+    // --force because the same version may already be installed.
     let status = std::process::Command::new("cargo")
-        .args(["install", "--path", "."])
+        .current_dir(&manifest_dir)
+        .args(["install", "--path", ".", "--locked", "--force"])
         .status();
 
     match status {
         Ok(s) if s.success() => {
-            println!("  {} Upgraded to {}", "*".green(), version.green());
+            // A cargo exit code of 0 is not proof that the horus on PATH is
+            // the new one, so ask the installed binary what it is rather than
+            // asserting the upgrade happened.
+            match installed_horus_version() {
+                Some(installed) if installed == version => {
+                    println!("  {} Upgraded to {}", "*".green(), version.green());
+                }
+                Some(installed) => {
+                    println!(
+                        "  {} Install completed, but the installed horus reports {} (expected {})",
+                        "!".yellow(),
+                        installed.yellow(),
+                        version.dimmed()
+                    );
+                }
+                None => {
+                    println!(
+                        "  {} Install completed, but the installed horus could not be run to confirm its version",
+                        "!".yellow()
+                    );
+                }
+            }
         }
         _ => {
             println!(
                 "  {} Auto-upgrade failed. Manual upgrade: {}",
                 "!".yellow(),
-                "cargo install --path .".dimmed()
+                manual_hint.dimmed()
             );
         }
     }
 
     Ok(())
+}
+
+/// Ask the `horus` binary in the cargo bin directory — where `cargo install`
+/// just wrote — which version it is. `None` when it cannot be found or run.
+fn installed_horus_version() -> Option<String> {
+    let bin_name = if cfg!(windows) { "horus.exe" } else { "horus" };
+    let bin = cargo_bin_dir()?.join(bin_name);
+    if !bin.exists() {
+        return None;
+    }
+    let output = std::process::Command::new(&bin)
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // clap prints "horus <version>".
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .nth(1)
+        .map(str::to_string)
+}
+
+/// The directory `cargo install` writes binaries to: `$CARGO_HOME/bin`,
+/// falling back to `~/.cargo/bin`.
+fn cargo_bin_dir() -> Option<std::path::PathBuf> {
+    match std::env::var("CARGO_HOME") {
+        Ok(home) if !home.is_empty() => Some(std::path::PathBuf::from(home).join("bin")),
+        _ => dirs::home_dir().map(|h| h.join(".cargo").join("bin")),
+    }
 }
 
 /// Check the latest version of a plugin package from the registry API.
@@ -378,48 +467,91 @@ mod tests {
 
     // ── upgrade_horus ───────────────────────────────────────────────────
 
-    #[test]
-    fn upgrade_horus_returns_ok_even_on_failure() {
-        // upgrade_horus always returns Ok even if cargo install fails
-        // (it prints a fallback message instead of erroring)
-        // Run from temp dir where there's no Cargo.toml so cargo install fails fast
+    /// Point HORUS_SOURCE at an isolated tree that carries the marker
+    /// `find_horus_source_dir` looks for but no `horus_manager` package, run
+    /// `f`, and restore the environment. Every upgrade_horus test needs this:
+    /// the build now comes from the resolved source tree, so without it a test
+    /// on a developer machine would resolve the real workspace and start a
+    /// full release build of the CLI.
+    fn with_isolated_horus_source<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        // CWD_LOCK doubles as the serialization point for process-global env.
         let _guard = crate::CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        let original = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
-        std::env::set_current_dir(tmp.path()).unwrap();
+        std::fs::create_dir_all(tmp.path().join("horus")).unwrap();
+        std::fs::write(
+            tmp.path().join("horus/Cargo.toml"),
+            "[package]\nname = \"horus\"\n",
+        )
+        .unwrap();
 
-        let result = upgrade_horus("99.99.99");
-        std::env::set_current_dir(original).unwrap();
-
-        result.unwrap();
+        let old_val = std::env::var("HORUS_SOURCE").ok();
+        std::env::set_var("HORUS_SOURCE", tmp.path());
+        let result = f(tmp.path());
+        match old_val {
+            Some(v) => std::env::set_var("HORUS_SOURCE", v),
+            None => std::env::remove_var("HORUS_SOURCE"),
+        }
+        result
     }
 
     #[test]
-    fn upgrade_horus_with_empty_version() {
-        // Run from temp dir so cargo install fails fast instead of building
-        let _guard = crate::CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = tempfile::tempdir().unwrap();
-        let original = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
-        std::env::set_current_dir(tmp.path()).unwrap();
+    fn upgrade_horus_refuses_a_source_tree_without_horus_manager() {
+        // Inverted: this test used to chdir into an empty temp dir and assert
+        // Ok, pinning the old contract that the upgrade builds whatever is in
+        // the current directory. The build now comes from the resolved HORUS
+        // source tree, and a tree with no horus_manager package is an error,
+        // not a silent no-op.
+        let result = with_isolated_horus_source(|_| upgrade_horus("99.99.99"));
+        let err = result.expect_err("no horus_manager package should be fatal");
+        assert!(
+            err.to_string().contains("Cargo.toml"),
+            "error should name the manifest it could not read: {}",
+            err
+        );
+    }
 
+    #[test]
+    fn upgrade_horus_rejects_non_semver_version() {
+        // Regression: `version` comes from registry JSON and is passed to
+        // cargo, so it is validated before anything is executed. The empty
+        // string used to reach the build step and return Ok.
         let result = upgrade_horus("");
-        std::env::set_current_dir(original).unwrap();
+        assert!(result.is_err(), "empty version must be rejected");
 
-        result.unwrap();
+        let result = upgrade_horus("--path");
+        assert!(
+            result.is_err(),
+            "a version that looks like a cargo flag must be rejected",
+        );
     }
 
     #[test]
-    fn upgrade_horus_with_real_looking_version() {
-        // Run from temp dir so cargo install fails fast instead of building
-        let _guard = crate::CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = tempfile::tempdir().unwrap();
-        let original = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
-        std::env::set_current_dir(tmp.path()).unwrap();
+    fn upgrade_horus_does_not_depend_on_the_current_directory() {
+        // Regression for the cwd build: standing in a valid Cargo package must
+        // not make the upgrade build it. With HORUS_SOURCE isolated the call
+        // fails on the missing horus_manager manifest no matter where we
+        // stand, which is exactly the point — cwd is not consulted.
+        let cwd_pkg = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(cwd_pkg.path().join("src")).unwrap();
+        std::fs::write(
+            cwd_pkg.path().join("Cargo.toml"),
+            "[package]\nname = \"totally-not-horus\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(cwd_pkg.path().join("src/main.rs"), "fn main() {}").unwrap();
 
-        let result = upgrade_horus("0.2.0");
-        std::env::set_current_dir(original).unwrap();
+        let result = with_isolated_horus_source(|_| {
+            let original = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
+            std::env::set_current_dir(cwd_pkg.path()).unwrap();
+            let result = upgrade_horus("0.2.0");
+            std::env::set_current_dir(original).unwrap();
+            result
+        });
 
-        result.unwrap();
+        assert!(
+            result.is_err(),
+            "upgrade must resolve the HORUS source tree, not the cwd package",
+        );
     }
 
     // ── list_installed_plugins ──────────────────────────────────────────
@@ -645,22 +777,17 @@ mod tests {
     }
 
     #[test]
-    fn upgrade_horus_does_not_propagate_command_failure() {
-        // The function catches command failures and prints a message
-        // instead of returning Err. Verify this contract.
-        // Run from a temp dir where there's no Cargo.toml — cargo install --path .
-        // will definitely fail.
-        let _guard = crate::CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = tempfile::tempdir().unwrap();
-        let original = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
-
-        std::env::set_current_dir(tmp.path()).unwrap();
-        let result = upgrade_horus("1.0.0");
-        std::env::set_current_dir(original).unwrap();
-
+    fn upgrade_horus_reports_an_unusable_source_tree() {
+        // Inverted: this used to assert Ok because a failing `cargo install`
+        // is only printed, not propagated. That is still true of the build
+        // step, but the pre-flight checks that replaced the cwd build — semver
+        // validation and locating a real horus_manager manifest — do return
+        // Err, so a source tree that cannot be built from is now reported
+        // rather than swallowed.
+        let result = with_isolated_horus_source(|_| upgrade_horus("1.0.0"));
         assert!(
-            result.is_ok(),
-            "upgrade_horus should return Ok even when cargo install fails",
+            result.is_err(),
+            "an unusable HORUS source tree should be reported, not swallowed",
         );
     }
 

--- a/horus_manager/src/commands/upgrade.rs
+++ b/horus_manager/src/commands/upgrade.rs
@@ -515,14 +515,9 @@ mod tests {
         // Regression: `version` comes from registry JSON and is passed to
         // cargo, so it is validated before anything is executed. The empty
         // string used to reach the build step and return Ok.
-        let result = upgrade_horus("");
-        assert!(result.is_err(), "empty version must be rejected");
-
-        let result = upgrade_horus("--path");
-        assert!(
-            result.is_err(),
-            "a version that looks like a cargo flag must be rejected",
-        );
+        upgrade_horus("").expect_err("empty version must be rejected");
+        upgrade_horus("--path")
+            .expect_err("a version that looks like a cargo flag must be rejected");
     }
 
     #[test]
@@ -548,10 +543,7 @@ mod tests {
             result
         });
 
-        assert!(
-            result.is_err(),
-            "upgrade must resolve the HORUS source tree, not the cwd package",
-        );
+        result.expect_err("upgrade must resolve the HORUS source tree, not the cwd package");
     }
 
     // ── list_installed_plugins ──────────────────────────────────────────
@@ -784,11 +776,8 @@ mod tests {
         // validation and locating a real horus_manager manifest — do return
         // Err, so a source tree that cannot be built from is now reported
         // rather than swallowed.
-        let result = with_isolated_horus_source(|_| upgrade_horus("1.0.0"));
-        assert!(
-            result.is_err(),
-            "an unusable HORUS source tree should be reported, not swallowed",
-        );
+        with_isolated_horus_source(|_| upgrade_horus("1.0.0"))
+            .expect_err("an unusable HORUS source tree should be reported, not swallowed");
     }
 
     #[test]

--- a/horus_manager/src/commands/upgrade.rs
+++ b/horus_manager/src/commands/upgrade.rs
@@ -3,7 +3,7 @@
 //! Checks for newer versions of horus and installed plugins,
 //! downloads and installs updates.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::*;
 
 /// Run `horus self update`.

--- a/horus_manager/src/lockfile.rs
+++ b/horus_manager/src/lockfile.rs
@@ -2,7 +2,22 @@
 //!
 //! Tracks pinned versions for all dependency sources (registry, crates.io, PyPI)
 //! alongside toolchain versions, system dependencies, and feature flags.
-//! This is the single source of truth for reproducible builds across machines.
+//!
+//! ## Known limitation: the pins are recorded, not yet enforced
+//!
+//! This module used to claim to be "the single source of truth for
+//! reproducible builds across machines". It is not one yet, and saying so hid
+//! the gap. `[[package]]` entries are written by the resolver and read back by
+//! [`HorusLockfile::get_pinned`], but no install path consults them: the pip,
+//! crates.io and registry installers still take their versions from the
+//! manifest and fall back to `latest`, so a checkout of a committed
+//! `horus.lock` on a clean machine can install a different version than the
+//! one recorded. `LockedPackage::checksum` is likewise written (always `None`
+//! today) and never compared against a download. Only `config_hash` is
+//! consulted, and it merely decides whether resolution can be skipped.
+//!
+//! Until the resolver applies `get_pinned` before installing, treat this file
+//! as a record of what *was* resolved, not a guarantee of what *will* be.
 //!
 //! ## Format (v4)
 //!
@@ -224,6 +239,19 @@ impl HorusLockfile {
         self.packages
             .sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.name.cmp(&b.name)));
     }
+
+    /// Get the pinned version for a package, if any.
+    ///
+    /// This lived behind `#[cfg(test)]`, which is why the pins were written
+    /// and never enforced: nothing outside the test module could read them.
+    /// It is production API now so the resolver can apply a pin before
+    /// installing; see the module-level note on what is still missing.
+    pub fn get_pinned(&self, name: &str, source: &str) -> Option<&str> {
+        self.packages
+            .iter()
+            .find(|p| p.name == name && p.source == source)
+            .map(|p| p.version.as_str())
+    }
 }
 
 #[cfg(test)]
@@ -232,14 +260,6 @@ impl HorusLockfile {
     pub fn unpin(&mut self, name: &str, source: &str) {
         self.packages
             .retain(|p| !(p.name == name && p.source == source));
-    }
-
-    /// Get the pinned version for a package, if any.
-    pub fn get_pinned(&self, name: &str, source: &str) -> Option<&str> {
-        self.packages
-            .iter()
-            .find(|p| p.name == name && p.source == source)
-            .map(|p| p.version.as_str())
     }
 
     /// Get all pinned packages for a given source.

--- a/horus_manager/src/manifest.rs
+++ b/horus_manager/src/manifest.rs
@@ -291,7 +291,10 @@ pub struct NetworkConfig {
     /// Shared secret for peer filtering (NOT security).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret: Option<String>,
-    /// Enabled optimizers (e.g., ["fusion", "delta"]).
+    /// Enabled optimizers (e.g., ["fusion", "spatial"]).
+    ///
+    /// "delta" is NOT supported: it encodes but never decodes, so enabling it
+    /// corrupts replicated data. `OptimizerChain::from_config` refuses it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub optimize: Option<Vec<String>>,
     /// Safety heartbeat settings.

--- a/horus_manager/src/manifest.rs
+++ b/horus_manager/src/manifest.rs
@@ -1186,8 +1186,17 @@ fn table_header(content: &str, span: &std::ops::Range<usize>) -> Option<String> 
 /// `public/` directory is live at this address on the next merge, and
 /// `published_schema_is_current` in `tests/docs_manifest.rs` fails the build if
 /// the committed copy stops matching what the structs generate.
+///
+/// The host is the documentation site's own, because that site is what serves
+/// `public/`. It read `docs.horus-registry.dev` long after horus-docs made
+/// `docs.horusrobotics.dev` canonical (its commit 2adcb0c pointed the
+/// canonicals, sitemap and robots there), which left the one URL `horus schema`
+/// stamps into every `$schema` field as the only address in this repository
+/// that no longer resolved to the docs — and made
+/// `the_configuration_page_publishes_the_schema_url` fail against a page that
+/// was in fact publishing the right one.
 pub const MANIFEST_SCHEMA_URL: &str =
-    "https://docs.horus-registry.dev/schema/horus.toml.schema.json";
+    "https://docs.horusrobotics.dev/schema/horus.toml.schema.json";
 
 // ─── Unknown-key warning on load ────────────────────────────────────────────
 

--- a/horus_manager/src/registry/install.rs
+++ b/horus_manager/src/registry/install.rs
@@ -584,14 +584,23 @@ impl RegistryClient {
         // key, never against the installing user's own key.
         if let Some(ref sig_hex) = pkg_signature {
             verify_against_publisher_key(&bytes, sig_hex, package_name, None, "Package")?;
-        } else if crate::paths::publisher_key_path(package_name, None).is_some() {
-            // A publisher key is on file for this package but it arrived
-            // unsigned — that is a downgrade, and worth saying so.
-            log::warn!(
-                "Package {} is NOT signed, but a publisher key is on file for it. \
-                 Its integrity cannot be verified.",
-                package_name
-            );
+        } else if let Some(key_path) = crate::paths::publisher_key_path(package_name, None) {
+            // A publisher key on file is the user's statement that this
+            // package must verify against it. The signature field comes out of
+            // the registry's own response, so treating its absence as a
+            // fallback let the very party signatures defend against strip them
+            // and walk into the success path — the old code only logged a
+            // log::warn!, invisible at the default level. Missing signature
+            // with a key on file is a verification failure, not a downgrade.
+            return Err(anyhow!(
+                "Package {}@{} arrived UNSIGNED, but a publisher key is on file at {}.\n\
+                 Installing that key means this package must verify against it, so an \
+                 unsigned download is a downgrade, not a fallback. Refusing to install.\n\
+                 If the publisher genuinely stopped signing, remove the key explicitly.",
+                package_name,
+                version_str,
+                key_path.display()
+            ));
         }
 
         // Calculate checksum and verify against server
@@ -1084,15 +1093,23 @@ impl RegistryClient {
         // A same-origin checksum a compromised registry also controls is not
         // authentication; a signature the registry cannot forge (it lacks the private
         // key) is. Same policy as source install: a signed binary MUST verify against a
-        // configured public key; an unsigned binary only warns when a key is configured.
+        // configured public key, and an unsigned binary with a key on file is a
+        // verification FAILURE. It used to only log::warn! — invisible at the default
+        // level — which let whoever shaped the response strip the signature field and
+        // reach the success path, on the fast path most installs take.
         if let Some(ref sig_hex) = pkg_signature {
             verify_against_publisher_key(&bytes, sig_hex, package_name, None, "Pre-built binary")?;
-        } else if crate::paths::publisher_key_path(package_name, None).is_some() {
-            log::warn!(
-                "Pre-built binary for {} is NOT signed, but a publisher key is on file for it. \
-                 Its integrity cannot be verified.",
-                package_name
-            );
+        } else if let Some(key_path) = crate::paths::publisher_key_path(package_name, None) {
+            return Err(anyhow!(
+                "Pre-built binary for {}@{} arrived UNSIGNED, but a publisher key is on \
+                 file at {}.\n\
+                 Installing that key means this package must verify against it, so an \
+                 unsigned download is a downgrade, not a fallback. Refusing to install.\n\
+                 If the publisher genuinely stopped signing, remove the key explicitly.",
+                package_name,
+                version_str,
+                key_path.display()
+            ));
         }
 
         // Determine installation directory (same logic as source install)

--- a/horus_manager/src/registry/install.rs
+++ b/horus_manager/src/registry/install.rs
@@ -2377,18 +2377,77 @@ impl RegistryClient {
         use crate::workspace::InstallTarget;
         use std::process::Command;
 
+        // `package_name` reaches this from registry/manifest data with no
+        // validation on any install path, and it is about to become a file
+        // name. A distribution name legitimately never contains a separator or
+        // `..`, so reject rather than sanitize — a rewritten name would point
+        // the reference at the wrong package. `validate_package_name` is the
+        // wrong grammar here: it rejects names PyPI allows.
+        if package_name.is_empty()
+            || package_name.contains(['/', '\\'])
+            || package_name.contains("..")
+        {
+            return Err(anyhow!(
+                "Refusing to create a system reference for {:?}: a package name must not \
+                 contain a path separator or '..'",
+                package_name
+            ));
+        }
+
         println!("  {} Creating reference to system package...", "".green());
 
-        // Find actual system package location
+        // Find actual system package location.
+        //
+        // This used to build the program text with
+        // `format!("import {}; print({}.__file__)", ...)`. A PyPI distribution
+        // name is not a Python identifier, so every hyphenated package
+        // (`python-dateutil`) produced a SyntaxError and the misleading
+        // "Failed to locate system package"; and because `package_name` is
+        // never run through any validator on the install paths, a name
+        // carrying a newline made both interpolations land on comment lines
+        // and left an attacker-chosen statement in between. Resolve the
+        // distribution's import name through importlib.metadata instead, with
+        // the name travelling in argv against constant program text — the same
+        // rule `probe_imports` follows.
+        const LOCATE: &str = r#"import sys, importlib, importlib.metadata as md
+name = sys.argv[1]
+cands = []
+try:
+    top = md.distribution(name).read_text("top_level.txt")
+    if top:
+        cands += top.split()
+except Exception:
+    pass
+cands += [name.replace("-", "_"), name]
+for c in cands:
+    try:
+        m = importlib.import_module(c)
+    except Exception:
+        continue
+    f = getattr(m, "__file__", None)
+    if f:
+        print(f)
+        break
+    p = list(getattr(m, "__path__", []) or [])
+    if p:
+        print(p[0] + "/__init__.py")
+        break
+else:
+    sys.exit(1)
+"#;
+
         let output = Command::new("python3")
-            .args([
-                "-c",
-                &format!("import {}; print({}.__file__)", package_name, package_name),
-            ])
+            .arg("-c")
+            .arg(LOCATE)
+            .arg(package_name)
             .output()?;
 
         if !output.status.success() {
-            return Err(anyhow!("Failed to locate system package"));
+            return Err(anyhow!(
+                "Failed to locate system package {}: {}",
+                package_name,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
         }
 
         let package_file = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -2672,5 +2731,35 @@ mod python_requirement_tests {
         assert!(!is_safe_python_requirement(""));
         assert!(!is_safe_python_requirement("   "));
         assert!(!is_safe_python_requirement(&"a".repeat(257)));
+    }
+}
+
+#[cfg(test)]
+mod system_reference_tests {
+    use super::*;
+
+    /// Regression: `create_system_reference_python` joined the package name
+    /// straight into `<packages_dir>/<name>.system.json`, and no install path
+    /// validates that name, so registry metadata naming `../..` wrote the
+    /// reference outside the packages directory. The name is now rejected
+    /// before anything is created.
+    #[test]
+    fn system_reference_rejects_path_shaped_names() {
+        let client = RegistryClient::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let target = crate::workspace::InstallTarget::Local(tmp.path().to_path_buf());
+
+        for bad in ["../evil", "a/b", "..", "", "x/../../y"] {
+            let err = client
+                .create_system_reference_python(bad, "1.0.0", &target)
+                .expect_err("a path-shaped package name must be refused");
+            assert!(
+                err.to_string().contains("path separator"),
+                "unexpected error for {bad:?}: {err}"
+            );
+        }
+
+        // Nothing was written for any of them.
+        assert!(!tmp.path().join(".horus/packages").exists());
     }
 }

--- a/horus_manager/src/registry/publish.rs
+++ b/horus_manager/src/registry/publish.rs
@@ -383,13 +383,24 @@ impl RegistryClient {
         };
 
         let safe_name = package_name_to_path(&name);
-        let tar_path = std::env::temp_dir().join(format!("{}-{}.tar.gz", safe_name, version));
 
+        // The archive is built in memory rather than at
+        // `<temp_dir>/<name>-<version>.tar.gz`. That path was derived only from
+        // the package name and version — both public, both printed a line
+        // earlier — and `File::create` neither uses O_EXCL nor refuses to
+        // follow symlinks, so on a shared host another user could pre-create it
+        // and control the bytes across the write-then-read-back gap, getting
+        // their tarball signed and uploaded under the publisher's API key.
+        // The bytes were fully buffered for the upload and the signature
+        // anyway, so the round-trip through the filesystem bought nothing; this
+        // also removes the world-readable copy of the source tree in /tmp and
+        // the orphaned file left behind when an early return (the secret scan
+        // below) skipped the cleanup.
         let included_files: Vec<(String, u64)>;
+        let package_data: Vec<u8>;
         {
             let custom_excludes = load_horusignore(current_dir);
-            let tar_file = fs::File::create(&tar_path)?;
-            let encoder = GzEncoder::new(tar_file, Compression::default());
+            let encoder = GzEncoder::new(Vec::new(), Compression::default());
             let mut tar_builder = Builder::new(encoder);
             let mut file_count = 0u64;
             let mut files_list: Vec<(String, u64)> = Vec::new();
@@ -445,7 +456,9 @@ impl RegistryClient {
                 }
             }
 
-            tar_builder.finish()?;
+            // into_inner() finishes the tar stream, then the encoder finish()
+            // flushes the gzip trailer and hands back the buffer.
+            package_data = tar_builder.into_inner()?.finish()?;
             println!(
                 "   Packaged {} files (excluded .git, target, .env, etc.)",
                 file_count
@@ -489,9 +502,6 @@ impl RegistryClient {
                 secret_files.len()
             ));
         }
-
-        let package_data = fs::read(&tar_path)?;
-        fs::remove_file(&tar_path)?;
 
         let size_mb = package_data.len() as f64 / (1024.0 * 1024.0);
         println!("   Package size: {:.2} MB", size_mb);

--- a/horus_manager/tests/docs_contract.rs
+++ b/horus_manager/tests/docs_contract.rs
@@ -23,7 +23,21 @@
 //! it has not run, and for months every "live docs" job in
 //! `.github/workflows/docs-contract.yml` did exactly that.
 //!
-//! Run: `cargo test -p horus_manager --test docs_contract`
+//! That rule collides with tier 1 of the same workflow, which is hermetic by
+//! definition — it checks out this repository and nothing else — so every test
+//! here that opens a page is `#[ignore]`d, the way `docs_manifest.rs` and
+//! `docs_examples_cpp.rs` already mark theirs. Tier 1 then runs what it can
+//! genuinely run (the skip-or-fail policy, and the wiring guard below) and
+//! tier 2 runs everything with `--include-ignored`. Without that split the
+//! hermetic job ran eleven docs tests against no docs and failed all eleven,
+//! daily, on main.
+//!
+//! `#[ignore]` is the same lever that hid these tests before, so it gets the
+//! guard `install_contract.rs` puts on its network tests:
+//! [`the_live_docs_job_runs_the_tests_this_file_ignores`] fails if the live job
+//! stops asking for them. Skipping is still never silent on CI.
+//!
+//! Run: `cargo test -p horus_manager --test docs_contract -- --include-ignored`
 
 use horus_manager::manifest_lint::KNOWN_TOP_LEVEL;
 use std::path::{Path, PathBuf};
@@ -109,6 +123,114 @@ fn a_missing_checkout_is_fatal_under_ci() {
     resolve_docs(None, true);
 }
 
+// ─── The workflow wiring ─────────────────────────────────────────────────────
+//
+// The two tests above are the whole reason a docs test cannot simply run in the
+// hermetic tier, and the `#[ignore]` that keeps it out of there is the reason
+// the next test exists.
+
+/// The body of one job in a workflow file.
+///
+/// Jobs are the two-space-indented keys under `jobs:`; the block runs to the
+/// next one. Same shape as `workflow_job` in `examples_contract.rs` — copied
+/// rather than shared because integration tests are separate binaries and this
+/// is nine lines.
+fn workflow_job(workflow: &str, job: &str) -> String {
+    let header = format!("  {job}:");
+    let mut body = Vec::new();
+    let mut inside = false;
+    for line in workflow.lines() {
+        if line.trim_end() == header {
+            inside = true;
+            continue;
+        }
+        if inside {
+            let next_key = line.starts_with("  ")
+                && !line.starts_with("   ")
+                && !line.trim_start().starts_with('#');
+            if next_key {
+                break;
+            }
+            body.push(line);
+        }
+    }
+    assert!(!body.is_empty(), "no job `{job}` in docs-contract.yml");
+    body.join("\n")
+}
+
+/// The `run:` lines in one job that invoke this test binary.
+///
+/// Comments are dropped: the workflow discusses `--test docs_contract` in prose
+/// in both jobs, including one comment quoting an `--ignored` invocation that
+/// no longer exists.
+fn docs_contract_steps(job: &str) -> Vec<&str> {
+    job.lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with('#') && l.contains("--test docs_contract"))
+        .collect()
+}
+
+/// Ignoring the docs tests is only acceptable if something still runs them.
+///
+/// This is the guarantee `docs_root_or_skip` makes, restated at the level the
+/// `#[ignore]` moved it to. A missing checkout still cannot pass silently — but
+/// a *missing invocation* now can, because an ignored test that nobody asks for
+/// is reported by cargo as `ok. 11 ignored` and by the job as green. That is
+/// the exact failure mode the module comment describes for `SKIP:`, one layer
+/// out, so it gets a check rather than a promise.
+#[test]
+fn the_live_docs_job_runs_the_tests_this_file_ignores() {
+    let workflow = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("horus_manager has a parent")
+        .join(".github/workflows/docs-contract.yml");
+    let wf = std::fs::read_to_string(&workflow)
+        .unwrap_or_else(|e| panic!("{} must be readable: {e}", workflow.display()));
+
+    let live = workflow_job(&wf, "contract-live");
+    let live_steps = docs_contract_steps(&live);
+    assert!(
+        !live_steps.is_empty(),
+        "contract-live no longer runs docs_contract at all, so nothing reads \
+         the pages: the tests here are `#[ignore]`d and the hermetic job has no \
+         checkout to read."
+    );
+    // `--include-ignored`, not `--ignored`: the skip-policy tests above are not
+    // ignored and are worth running against a real checkout too.
+    assert!(
+        live_steps.iter().any(|l| l.contains("--include-ignored")),
+        "contract-live runs docs_contract without `--include-ignored`, so every \
+         page-reading test here is skipped and the job reports success for \
+         checking nothing:\n  {}",
+        live_steps.join("\n  ")
+    );
+    assert!(
+        live.contains("HORUS_DOCS_DIR"),
+        "contract-live does not point HORUS_DOCS_DIR at its horus-docs \
+         checkout, so the docs tests would fail on the missing-checkout \
+         assertion instead of reading the pages"
+    );
+
+    // The other direction. The hermetic tier checks out this repository and
+    // nothing else, so asking it for the ignored tests puts it straight back
+    // into failing all of them by design.
+    let hermetic = workflow_job(&wf, "contract-hermetic");
+    let hermetic_steps = docs_contract_steps(&hermetic);
+    assert!(
+        !hermetic_steps.is_empty(),
+        "contract-hermetic no longer runs docs_contract, so this guard and the \
+         skip-policy tests do not run on a PR"
+    );
+    for step in &hermetic_steps {
+        assert!(
+            !step.contains("ignored"),
+            "contract-hermetic asks docs_contract for ignored tests, but it \
+             checks out no docs — every one of them fails on the \
+             missing-checkout assertion:\n  {step}"
+        );
+    }
+}
+
 fn config_reference() -> Option<String> {
     let path = docs_root_or_skip()?.join("content/docs/package-management/configuration.mdx");
     std::fs::read_to_string(path).ok()
@@ -116,6 +238,7 @@ fn config_reference() -> Option<String> {
 
 /// Every table the manifest accepts must appear in the reference.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn the_configuration_reference_covers_every_manifest_table() {
     // `config_reference` goes through `docs_root_or_skip`, so a missing
     // checkout has already failed the test if this is CI.
@@ -151,6 +274,7 @@ fn the_configuration_reference_covers_every_manifest_table() {
 /// The reference should show each table in use, not merely name it in a list.
 /// A key that only appears inside the Quick Reference block is not documented.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn each_table_gets_a_section_not_just_a_mention() {
     // `config_reference` goes through `docs_root_or_skip`, so a missing
     // checkout has already failed the test if this is CI.
@@ -199,6 +323,7 @@ fn each_table_gets_a_section_not_just_a_mention() {
 /// The lifecycle hooks are the most recently added surface and the easiest to
 /// ship undocumented, so they get their own check.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn every_hook_phase_is_documented() {
     // `config_reference` goes through `docs_root_or_skip`, so a missing
     // checkout has already failed the test if this is CI.
@@ -222,6 +347,7 @@ fn every_hook_phase_is_documented() {
 /// A guard on the guard: if the reference file moves or is renamed, the tests
 /// above would skip forever and report nothing. This fails instead.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn the_configuration_reference_is_where_we_think_it_is() {
     let Some(root) = docs_root_or_skip() else {
         return;
@@ -245,6 +371,7 @@ fn the_configuration_reference_is_where_we_think_it_is() {
 /// read about what it will do to their machine — and it installs a kernel
 /// package and edits `/etc/security/limits.conf`.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn commands_the_cli_suggests_are_documented() {
     let Some(root) = docs_root_or_skip() else {
         return;
@@ -297,6 +424,7 @@ fn commands_the_cli_suggests_are_documented() {
 /// Also asserts the two lists stay identical. `PrevNextNav.tsx` says in a
 /// comment that it "must match DocsSidebar.tsx", and nothing checked it.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn every_docs_page_is_reachable_from_the_navigation() {
     let Some(root) = docs_root_or_skip() else {
         return;
@@ -423,6 +551,7 @@ fn every_docs_page_is_reachable_from_the_navigation() {
 /// Encoded as a test rather than as prose in a config file because prose in a
 /// config file is what was there before.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn every_tutorial_exists_in_every_language() {
     let Some(root) = docs_root_or_skip() else {
         return;
@@ -757,6 +886,7 @@ fn environment_surface(repo: &Path) -> EnvSurface {
 /// 2. The scan covered one language and one direction. See
 ///    [`environment_surface`].
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn every_environment_variable_is_in_the_reference_page() {
     let Some(root) = docs_root_or_skip() else {
         return;
@@ -917,6 +1047,7 @@ fn subject_headings(text: &str) -> std::collections::BTreeSet<String> {
 /// share a heading or two, and the failure this catches is a page growing back
 /// a whole second copy of another one.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn concepts_pages_do_not_restate_the_language_references() {
     let Some(root) = docs_root_or_skip() else {
         return;
@@ -1019,6 +1150,7 @@ fn concepts_pages_do_not_restate_the_language_references() {
 /// A route resolves as `<slug>.mdx` or `<slug>/index.mdx` — the same two
 /// lookups `lib/mdx.tsx` performs.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn every_navigation_link_resolves_to_a_page() {
     let Some(docs) = docs_root_or_skip() else {
         return;
@@ -1076,6 +1208,7 @@ fn every_navigation_link_resolves_to_a_page() {
 /// a reader in the Rust section was sent past the Rust Guide into Examples and
 /// only reached the guide after all of Python.
 #[test]
+#[ignore = "needs a horus-docs checkout; wired into the docs-contract workflow"]
 fn prev_next_navigation_is_derived_from_the_sidebar() {
     let Some(docs) = docs_root_or_skip() else {
         return;

--- a/horus_manager/tests/install_contract.rs
+++ b/horus_manager/tests/install_contract.rs
@@ -35,6 +35,39 @@ fn install_sh() -> String {
     std::fs::read_to_string(repo_root().join("install.sh")).expect("install.sh must exist")
 }
 
+/// The executable part of a shell line, with any trailing comment removed.
+///
+/// A `#` opens a comment only at the start of a word, so `${REPO}#ref` is code
+/// while `cmd  # note` is not. The cheap `split('#')` used elsewhere in this
+/// file is fine for scanners whose pattern never appears in prose, but install.sh
+/// quotes the *old, broken* clone guard verbatim in a comment explaining why it
+/// no longer does that. A scanner that reads comments fails the script for
+/// documenting the very bug it fixed.
+fn shell_code(line: &str) -> &str {
+    let mut at_word_start = true;
+    for (i, c) in line.char_indices() {
+        if c == '#' && at_word_start {
+            return &line[..i];
+        }
+        at_word_start = c.is_whitespace();
+    }
+    line
+}
+
+/// Does this line pipe `git clone` into another command?
+///
+/// `||` is not a pipe. Anything else after `git clone` on the line is, and with
+/// `pipefail` off a pipeline reports only its *last* command's status.
+fn clone_is_piped(code: &str) -> bool {
+    let Some(pos) = code.find("git clone") else {
+        return false;
+    };
+    let bytes = &code.as_bytes()[pos..];
+    bytes.iter().enumerate().any(|(i, &b)| {
+        b == b'|' && bytes.get(i.wrapping_sub(1)) != Some(&b'|') && bytes.get(i + 1) != Some(&b'|')
+    })
+}
+
 /// The shipped binary is meant to carry `schema` — the crate comment says so.
 /// Disabling default features contradicts that and, for a while, did not build.
 #[test]
@@ -504,16 +537,39 @@ fn the_repository_manifest_passes_the_validator_it_ships() {
 #[test]
 fn install_sh_tests_the_real_status_of_git_clone() {
     let text = install_sh();
+
+    // A pipeline only masks the clone's status while `pipefail` is off, which is
+    // the state install.sh is actually in (`set -e` alone, line 15). If it ever
+    // turns pipefail on, piping is no longer the bug this guards.
+    let pipefail_is_on = text.lines().any(|l| {
+        shell_code(l).contains("set -o pipefail") || shell_code(l).contains("set -eo pipe")
+    });
+
+    let mut clones = 0;
     for (n, line) in text.lines().enumerate() {
-        if line.contains("git clone") && line.contains('|') && line.contains("tail") {
+        let code = shell_code(line);
+        if !code.contains("git clone") {
+            continue;
+        }
+        clones += 1;
+        if !pipefail_is_on && clone_is_piped(code) {
             panic!(
-                "install.sh:{} pipes git clone into tail, so its exit status is \
-                 discarded (no `set -o pipefail`):\n  {}",
+                "install.sh:{} pipes git clone into another command, so the \
+                 pipeline reports that command's status and the clone's failure \
+                 is discarded (the script sets `set -e` but not \
+                 `set -o pipefail`):\n  {}",
                 n + 1,
                 line.trim()
             );
         }
     }
+
+    assert!(
+        clones > 0,
+        "no `git clone` found in install.sh's executable lines — either the \
+         script no longer fetches source or this scan is broken, and the test \
+         is vacuous"
+    );
 
     // The cache directory is deleted before the fetched tree is moved into it,
     // so the fetch must be proven complete first.

--- a/horus_manager/tests/install_contract.rs
+++ b/horus_manager/tests/install_contract.rs
@@ -492,3 +492,62 @@ fn the_repository_manifest_passes_the_validator_it_ships() {
         );
     }
 }
+
+/// A failed `git clone` must actually stop the install.
+///
+/// The guard used to read `if ! git clone ... 2>&1 | tail -1; then`. install.sh
+/// sets `set -e` but not `set -o pipefail`, so the pipeline reports *tail*'s
+/// status — always 0 — and the failure branch was unreachable. A dead clone
+/// then fell through to `rm -rf "$HORUS_SRC_DIR"`, destroying a working cached
+/// source tree and replacing it with an empty one, while printing
+/// "Installation complete!".
+#[test]
+fn install_sh_tests_the_real_status_of_git_clone() {
+    let text = install_sh();
+    for (n, line) in text.lines().enumerate() {
+        if line.contains("git clone") && line.contains('|') && line.contains("tail") {
+            panic!(
+                "install.sh:{} pipes git clone into tail, so its exit status is \
+                 discarded (no `set -o pipefail`):\n  {}",
+                n + 1,
+                line.trim()
+            );
+        }
+    }
+
+    // The cache directory is deleted before the fetched tree is moved into it,
+    // so the fetch must be proven complete first.
+    let marker = text
+        .find("horus/Cargo.toml\" ]")
+        .expect("install.sh must validate the fetched tree before caching it");
+    let destructive = text
+        .find("rm -rf \"$HORUS_SRC_DIR\"")
+        .expect("install.sh clears the cache dir before moving the new tree in");
+    assert!(
+        marker < destructive,
+        "install.sh deletes the cached source tree before checking that the \
+         freshly fetched one is usable"
+    );
+}
+
+/// install.sh must not assign to `TMPDIR`.
+///
+/// It did, and then `rm -rf`'d the directory. `TMPDIR` is exported on macOS and
+/// in most CI images, so every child the script spawns afterwards — mktemp,
+/// rustup's installer, cargo, rustc, cc/ld — inherited a scratch directory that
+/// no longer existed, and the build died in the linker with an error that named
+/// no cause the user could act on.
+#[test]
+fn install_sh_does_not_clobber_the_exported_tmpdir() {
+    let text = install_sh();
+    for (n, line) in text.lines().enumerate() {
+        let code = line.split('#').next().unwrap_or("").trim();
+        if code.starts_with("TMPDIR=") || code.starts_with("export TMPDIR=") {
+            panic!(
+                "install.sh:{} overwrites the exported POSIX TMPDIR:\n  {}",
+                n + 1,
+                line.trim()
+            );
+        }
+    }
+}

--- a/horus_manager/tests/translation_contract.rs
+++ b/horus_manager/tests/translation_contract.rs
@@ -84,7 +84,7 @@ fn latency_figures(body: &str) -> Vec<String> {
             .collect();
         if cleaned.contains('-') || cleaned.contains('\u{2013}') {
             let parts: Vec<&str> = cleaned
-                .split(|c| c == '-' || c == '\u{2013}')
+                .split(['-', '\u{2013}'])
                 .filter(|s| !s.is_empty())
                 .collect();
             if parts.len() == 2 && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit())) {

--- a/horus_net/src/config.rs
+++ b/horus_net/src/config.rs
@@ -26,7 +26,10 @@ pub struct NetConfig {
     /// Posture for acting on authenticated remote e-stop packets.
     /// `HORUS_ESTOP_KEY` is mandatory. Env: HORUS_ESTOP_REMOTE = warn | off.
     pub estop_remote: EstopRemotePolicy,
-    /// Enabled optimizers (e.g., ["fusion", "delta"]).
+    /// Enabled optimizers (e.g., ["fusion", "spatial"]).
+    ///
+    /// "delta" is NOT supported: it encodes but never decodes, so enabling it
+    /// corrupts replicated data. `OptimizerChain::from_config` refuses it.
     pub optimizers: Vec<String>,
     /// Per-topic overrides.
     pub topic_overrides: std::collections::HashMap<String, TopicNetConfig>,

--- a/horus_net/src/config.rs
+++ b/horus_net/src/config.rs
@@ -66,11 +66,23 @@ impl EstopRemotePolicy {
 }
 
 /// Import control configuration.
+///
+/// This is reach reduction, NOT an authorization control: the data plane is
+/// unauthenticated (see the crate docs' trust model), so whatever this admits,
+/// *any* host that can send UDP to this process can write into local SHM —
+/// including actuation topics. The shipped default is [`Auto`](Self::Auto),
+/// which is what makes zero-config LAN replication work; choose
+/// [`Deny`](Self::Deny) (`HORUS_NET_IMPORT=deny`) on any network where an
+/// untrusted host might be reachable.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum ImportConfig {
-    /// Deny all imports.
+    /// Deny all imports. The only setting that keeps a remote host from writing
+    /// into local SHM on a network you do not fully control.
     Deny,
     /// Auto: import topics we subscribe to but don't publish.
+    ///
+    /// Admits any topic this process subscribes to, from any peer that passes
+    /// the source-address filter, with no proof of the sender's identity.
     #[default]
     Auto,
     /// Explicit list of allowed topic patterns.

--- a/horus_net/src/config.rs
+++ b/horus_net/src/config.rs
@@ -70,9 +70,9 @@ impl EstopRemotePolicy {
 /// This is reach reduction, NOT an authorization control: the data plane is
 /// unauthenticated (see the crate docs' trust model), so whatever this admits,
 /// *any* host that can send UDP to this process can write into local SHM —
-/// including actuation topics. The shipped default is [`Auto`](Self::Auto),
+/// including actuation topics. The shipped default is [`ImportConfig::Auto`],
 /// which is what makes zero-config LAN replication work; choose
-/// [`Deny`](Self::Deny) (`HORUS_NET_IMPORT=deny`) on any network where an
+/// [`ImportConfig::Deny`] (`HORUS_NET_IMPORT=deny`) on any network where an
 /// untrusted host might be reachable.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum ImportConfig {

--- a/horus_net/src/fragment.rs
+++ b/horus_net/src/fragment.rs
@@ -508,7 +508,6 @@ mod tests {
     }
 
     /// Same, with an explicit sender id — the reassembly key includes it.
-    #[allow(clippy::too_many_arguments)]
     fn part_frag_from(
         sender: u16,
         topic: u32,
@@ -585,7 +584,10 @@ mod tests {
         b1.payload = vec![0xB2; 1000];
 
         assert!(reasm.feed(a0).is_none());
-        assert!(reasm.feed(b0).is_none(), "B's fragment 0 is not a duplicate");
+        assert!(
+            reasm.feed(b0).is_none(),
+            "B's fragment 0 is not a duplicate"
+        );
         assert_eq!(reasm.pending_count(), 2, "one buffer per sender");
 
         let msg = reasm.feed(b1).expect("B's message completes on its own");

--- a/horus_net/src/fragment.rs
+++ b/horus_net/src/fragment.rs
@@ -39,6 +39,14 @@ pub const FRAGMENT_TIMEOUT: Duration = Duration::from_millis(100);
 /// A single fragment ready to be sent.
 #[derive(Debug, Clone)]
 pub struct Fragment {
+    /// Sender identity (`PacketHeader::sender_id_hash`) on the receive side.
+    ///
+    /// Part of the reassembly key. `fragment_id` is a per-process counter that
+    /// every `Fragmenter` starts at 0, so it is identical across hosts: without
+    /// the sender, two peers publishing the same topic land in one reassembly
+    /// buffer and a message is spliced together out of both of their fragments.
+    /// The send side leaves it 0 — only the receiver keys on it.
+    pub sender_id_hash: u16,
     pub topic_hash: u32,
     pub sequence: u32,
     pub timestamp_ns: u64,
@@ -70,6 +78,7 @@ impl Fragmenter {
         if msg.payload.len() <= MAX_FRAGMENT_PAYLOAD {
             // No fragmentation needed — return as single fragment
             return vec![Fragment {
+                sender_id_hash: 0,
                 topic_hash: msg.topic_hash,
                 sequence: msg.sequence,
                 timestamp_ns: msg.timestamp_ns,
@@ -105,6 +114,7 @@ impl Fragmenter {
             .iter()
             .enumerate()
             .map(|(i, chunk)| Fragment {
+                sender_id_hash: 0,
                 topic_hash: msg.topic_hash,
                 sequence: msg.sequence,
                 timestamp_ns: msg.timestamp_ns,
@@ -160,8 +170,15 @@ pub struct ReassembledMessage {
 
 /// Reassembles fragments into complete messages.
 pub struct Reassembler {
-    /// Pending messages keyed by (topic_hash, fragment_id).
-    pending: HashMap<(u32, u32), PendingMessage>,
+    /// Pending messages keyed by (sender_id_hash, topic_hash, fragment_id).
+    ///
+    /// The sender is part of the key. Keyed on (topic_hash, fragment_id) alone,
+    /// fragments from *different* senders sharing a topic merged into one
+    /// buffer — and since slot filling is first-write-wins, whichever host's
+    /// fragment arrived first owned that region and the genuine one was
+    /// discarded as a duplicate. Two robots publishing the same topic both
+    /// start their fragment counter at 0, so this needed no attacker.
+    pending: HashMap<(u16, u32, u32), PendingMessage>,
 }
 
 impl Reassembler {
@@ -202,7 +219,7 @@ impl Reassembler {
             });
         }
 
-        let key = (frag.topic_hash, frag.fragment_id);
+        let key = (frag.sender_id_hash, frag.topic_hash, frag.fragment_id);
 
         // Bound 3: cap concurrent partial messages. Refuse to open a NEW reassembly
         // buffer once at capacity (existing keys may still receive their fragments).
@@ -367,6 +384,7 @@ mod tests {
     fn reassemble_single_fragment() {
         let mut reasm = Reassembler::new();
         let frag = Fragment {
+            sender_id_hash: 0,
             topic_hash: 100,
             sequence: 1,
             timestamp_ns: 999,
@@ -443,6 +461,7 @@ mod tests {
         let mut reasm = Reassembler::new();
         // Feed partial fragment set
         let frag = Fragment {
+            sender_id_hash: 0,
             topic_hash: 100,
             sequence: 1,
             timestamp_ns: 0,
@@ -485,7 +504,22 @@ mod tests {
         total: u32,
         bytes: usize,
     ) -> Fragment {
+        part_frag_from(0, topic, id, index, count, total, bytes)
+    }
+
+    /// Same, with an explicit sender id — the reassembly key includes it.
+    #[allow(clippy::too_many_arguments)]
+    fn part_frag_from(
+        sender: u16,
+        topic: u32,
+        id: u32,
+        index: u16,
+        count: u16,
+        total: u32,
+        bytes: usize,
+    ) -> Fragment {
         Fragment {
+            sender_id_hash: sender,
             topic_hash: topic,
             sequence: 0,
             timestamp_ns: 0,
@@ -533,6 +567,33 @@ mod tests {
             .feed(part_frag(999_999, 999_999, 0, 2, 2000, 1000))
             .is_none());
         assert_eq!(reasm.pending_count(), MAX_PENDING_MESSAGES);
+    }
+
+    #[test]
+    fn fragments_from_different_senders_do_not_splice() {
+        // Regression: keyed on (topic_hash, fragment_id) alone, two peers that
+        // both publish "pointcloud" — each starting its fragment counter at 0 —
+        // filled ONE buffer, and the completed message was half of each.
+        let mut reasm = Reassembler::new();
+        let topic = topic_hash("pointcloud");
+
+        let mut a0 = part_frag_from(0xAAAA, topic, 0, 0, 2, 2000, 1000);
+        a0.payload = vec![0xA1; 1000];
+        let mut b0 = part_frag_from(0xBBBB, topic, 0, 0, 2, 2000, 1000);
+        b0.payload = vec![0xB1; 1000];
+        let mut b1 = part_frag_from(0xBBBB, topic, 0, 1, 2, 2000, 1000);
+        b1.payload = vec![0xB2; 1000];
+
+        assert!(reasm.feed(a0).is_none());
+        assert!(reasm.feed(b0).is_none(), "B's fragment 0 is not a duplicate");
+        assert_eq!(reasm.pending_count(), 2, "one buffer per sender");
+
+        let msg = reasm.feed(b1).expect("B's message completes on its own");
+        assert!(
+            msg.payload.iter().all(|b| *b == 0xB1 || *b == 0xB2),
+            "reassembled message must contain no bytes from the other sender"
+        );
+        assert_eq!(reasm.pending_count(), 1, "A's partial message is untouched");
     }
 
     #[test]

--- a/horus_net/src/heartbeat.rs
+++ b/horus_net/src/heartbeat.rs
@@ -77,6 +77,8 @@ pub struct SafetyHeartbeat {
     our_peer_id: [u8; 16],
     /// Monotonic heartbeat sequence counter.
     sequence: u32,
+    /// Whether the heartbeat-table-full warning has already been emitted.
+    cap_warned: bool,
 }
 
 impl SafetyHeartbeat {
@@ -99,6 +101,7 @@ impl SafetyHeartbeat {
             peers: HashMap::new(),
             our_peer_id,
             sequence: 0,
+            cap_warned: false,
         }
     }
 
@@ -116,11 +119,33 @@ impl SafetyHeartbeat {
             peers: HashMap::new(),
             our_peer_id,
             sequence: 0,
+            cap_warned: false,
         }
     }
 
     /// Register a matched peer for heartbeat tracking.
+    ///
+    /// Capped at `netfilter::MAX_PEERS`, the same ceiling `PeerTable` enforces.
+    /// This table used to have no bound at all while its only caller registered
+    /// every announcement unconditionally — including the ones `PeerTable`
+    /// refused once full — so a flood of forged peer ids grew it without limit
+    /// AND made `tick` transmit a heartbeat every 50 ms to each announcement's
+    /// (spoofable) source address, forever. The caller now gates on the peer
+    /// table's answer; this cap is the defence in depth so a future caller that
+    /// forgets cannot re-open the same hole.
     pub fn add_peer(&mut self, peer_id: PeerId, addr: SocketAddr) {
+        if !self.peers.contains_key(&peer_id) && self.peers.len() >= crate::netfilter::MAX_PEERS {
+            if !self.cap_warned {
+                self.cap_warned = true;
+                horus_core::terminal::eprint_line(&format!(
+                    "[horus_net] Heartbeat table is full ({} peers); ignoring further \
+                     registrations. If this is not a real fleet of that size, a host is \
+                     forging peer ids — check HORUS_NET_ALLOW_PEERS. (Fires once.)",
+                    crate::netfilter::MAX_PEERS
+                ));
+            }
+            return;
+        }
         let now = Instant::now();
         self.peers.entry(peer_id).or_insert(PeerHeartbeatState {
             addr,
@@ -138,6 +163,17 @@ impl SafetyHeartbeat {
     /// Remove a peer (e.g., when discovery marks it dead).
     pub fn remove_peer(&mut self, peer_id: &PeerId) {
         self.peers.remove(peer_id);
+    }
+
+    /// Drop every tracked peer for which `keep` returns false.
+    ///
+    /// The replicator re-syncs this table against the peer table once per
+    /// discovery interval. Removal used to happen only through `remove_peer`
+    /// on a newly-dead peer, so an entry for a peer that never made it into
+    /// (or was silently evicted from) `PeerTable` was never removed and kept
+    /// emitting heartbeats indefinitely.
+    pub fn retain_peers<F: FnMut(&PeerId) -> bool>(&mut self, mut keep: F) {
+        self.peers.retain(|id, _| keep(id));
     }
 
     /// Update address for a peer (e.g., if their data port changed).

--- a/horus_net/src/lib.rs
+++ b/horus_net/src/lib.rs
@@ -10,6 +10,38 @@
 //!
 //! The network layer activates automatically when remote horus peers exist on the LAN,
 //! and costs nothing when they don't.
+//!
+//! ## Trust model — READ BEFORE DEPLOYING
+//!
+//! **Topic replication is unauthenticated.** There is no MAC, no handshake and no
+//! source binding on the data path: a datagram that reaches the port and passes
+//! the source-address filter is treated as coming from a legitimate peer. Any
+//! host that can send UDP to this process — anything inside the allowed peer
+//! ranges, which default to private/loopback/link-local — can therefore:
+//!
+//! - **Write arbitrary bytes into local SHM topics.** One forged discovery
+//!   announcement claiming to publish `cmd_vel`, then one forged data packet, and
+//!   the local subscriber reads the attacker's value as if a local publisher had
+//!   sent it. This includes actuation commands.
+//! - **Impersonate a peer.** `HORUS_NET_SECRET` is a cleartext FNV-1a value in
+//!   every announcement, so it stops accidental cross-fleet mixing, not an
+//!   attacker; `sender_id_hash` is 16 bits and attacker-chosen; the type-hash
+//!   check compares against a hash the *sender* announced.
+//! - **Replay any packet it captured**, including a captured `cmd_vel`.
+//! - **Consume bounded resources**: peer table, heartbeat table, reassembly
+//!   buffers and system-topic rates are all capped, so a flood degrades
+//!   throughput rather than exhausting memory — but it is not kept out.
+//!
+//! What *is* authenticated: the e-stop channel only. `_horus.estop` packets carry
+//! an HMAC keyed by `HORUS_ESTOP_KEY` (see [`mac`]) and are rejected outright
+//! when no key is provisioned.
+//!
+//! Consequently: **run `horus_net` only on a network you trust as much as you
+//! trust the robot.** On a shared or reachable network, disable it
+//! (`HORUS_NO_NETWORK=1`), or set `HORUS_NET_IMPORT=deny` to refuse remote writes
+//! into local SHM, and narrow `HORUS_NET_ALLOW_PEERS` to the exact peer
+//! addresses. Authenticating the data plane (per-datagram MAC + replay window)
+//! is a wire-format change and is not implemented.
 
 pub mod config;
 pub mod discovery;

--- a/horus_net/src/optimize/delta.rs
+++ b/horus_net/src/optimize/delta.rs
@@ -17,6 +17,15 @@ use crate::wire::{InMessage, OutMessage};
 const DEFAULT_KEYFRAME_INTERVAL: u32 = 100;
 
 /// Delta optimizer — tracks per-topic state and sends diffs.
+///
+/// **Not usable as a replication optimizer today, and deliberately refused by
+/// [`OptimizerChain::from_config`](crate::optimize::OptimizerChain::from_config).**
+/// Only the encode half exists: `on_outgoing` replaces the payload with a region
+/// stream, `on_incoming` is a no-op, and no wire flag marks a packet as
+/// delta-encoded, so a receiver writes the region stream into SHM as if it were
+/// the message body. Finishing it needs a per-message delta bit on the wire
+/// (`MessageHeader` has no spare room today) plus a per-topic last-received
+/// payload cache applied in `on_incoming`.
 pub struct DeltaOptimizer {
     /// Per topic_hash: last sent payload bytes.
     last_sent: HashMap<u32, Vec<u8>>,
@@ -109,10 +118,11 @@ impl Optimizer for DeltaOptimizer {
     }
 
     fn on_incoming(&mut self, _messages: &mut Vec<InMessage>) {
-        // Delta decoding: receiver would need to track state and reconstruct.
-        // For now, deltas are self-describing (changed byte regions with offsets),
-        // so the receiver can apply them independently.
-        // Full implementation deferred until we have a delta wire format.
+        // Still a no-op — and that is exactly why `from_config` refuses to
+        // install this optimizer. The comment that used to sit here claimed the
+        // receiver "can apply [deltas] independently"; it cannot, because no
+        // code in this crate parses the (offset, length, data) region format and
+        // nothing on the wire says a payload is a delta at all.
     }
 
     fn name(&self) -> &str {

--- a/horus_net/src/optimize/mod.rs
+++ b/horus_net/src/optimize/mod.rs
@@ -54,7 +54,19 @@ impl OptimizerChain {
         for name in names {
             match name.as_str() {
                 "fusion" => chain.add(Box::new(fusion::FusionOptimizer::new())),
-                "delta" => chain.add(Box::new(delta::DeltaOptimizer::new())),
+                // NOT enabled. `DeltaOptimizer::on_outgoing` replaces the payload
+                // with a region stream, but `on_incoming` is a no-op and nothing
+                // on the wire marks a packet as delta-encoded — so the receiver
+                // hands the region stream to `ShmRingWriter::write` as if it were
+                // the message body. POD topics then fail the size check and the
+                // remote subscriber silently freezes between keyframes; non-POD
+                // topics store the stream and deserialize garbage. Refuse loudly
+                // rather than corrupt replicated robot data from a config value
+                // the docs advertised as supported.
+                "delta" => horus_core::terminal::eprint_line(
+                    "[horus_net] Optimizer 'delta' is not implemented on the receive side \
+                     and would silently drop or corrupt replicated data. Ignoring.",
+                ),
                 "spatial" => chain.add(Box::new(spatial::SpatialOptimizer::new())),
                 "predict" => chain.add(Box::new(predict::PredictOptimizer::new())),
                 other => horus_core::terminal::eprint_line(&format!(
@@ -217,8 +229,17 @@ mod tests {
 
     #[test]
     fn from_config_builds_chain() {
-        let chain = OptimizerChain::from_config(&["fusion".into(), "delta".into()]);
+        let chain = OptimizerChain::from_config(&["fusion".into(), "spatial".into()]);
         assert_eq!(chain.len(), 2);
+    }
+
+    #[test]
+    fn from_config_refuses_delta() {
+        // Inverted: this used to assert that "delta" was added to the chain.
+        // Enabling it corrupts replicated data (encode side only, no decoder),
+        // so a shipped configuration naming it must produce no optimizer.
+        let chain = OptimizerChain::from_config(&["fusion".into(), "delta".into()]);
+        assert_eq!(chain.len(), 1, "delta must not be installed");
     }
 
     #[test]

--- a/horus_net/src/peer.rs
+++ b/horus_net/src/peer.rs
@@ -81,7 +81,17 @@ impl PeerTable {
     }
 
     /// Update or insert a peer from a received announcement.
-    pub fn update_peer(&mut self, announcement: &PeerAnnouncement) {
+    ///
+    /// Returns `true` when the announcement actually landed in the table (a
+    /// refresh of a known peer, or a successful insert) and `false` when it was
+    /// refused because the table is full of live peers.
+    ///
+    /// The return value is load-bearing, not informational: callers that build
+    /// further per-peer state from an announcement (the safety heartbeat, which
+    /// then transmits to the announcement's spoofable source address every
+    /// 50 ms) must not create that state for a peer this table refused, or the
+    /// cap here bounds nothing.
+    pub fn update_peer(&mut self, announcement: &PeerAnnouncement) -> bool {
         if let Some(existing) = self.peers.get_mut(&announcement.peer_id) {
             existing.addr = announcement.source_addr;
             existing.data_port = announcement.data_port;
@@ -89,6 +99,7 @@ impl PeerTable {
             existing.last_seen = Instant::now();
             existing.alive = true;
             existing.secret_hash = announcement.secret_hash;
+            return true;
         } else {
             // Announcements are unauthenticated and peer_id is attacker-chosen,
             // so an uncapped table is both a memory DoS and a CPU one: every
@@ -116,7 +127,7 @@ impl PeerTable {
                                 crate::netfilter::MAX_PEERS
                             ));
                         }
-                        return;
+                        return false;
                     }
                 }
             }
@@ -133,6 +144,7 @@ impl PeerTable {
                 },
             );
         }
+        true
     }
 
     /// Check liveness of all peers. Mark dead if stale.

--- a/horus_net/src/presence.rs
+++ b/horus_net/src/presence.rs
@@ -399,16 +399,72 @@ mod tests {
         assert!(!is_safe_path_component("."));
     }
 
-    /// Build a minimal presence wire payload with a chosen host_id and no nodes.
-    fn presence_payload(namespace: &str, host_id: &str) -> Vec<u8> {
+    /// Build a minimal presence wire payload with a chosen host_id and nodes.
+    fn presence_payload_with_nodes(namespace: &str, host_id: &str, nodes: &[&str]) -> Vec<u8> {
         let mut buf = Vec::new();
         buf.extend_from_slice(&(namespace.len() as u16).to_le_bytes());
         buf.extend_from_slice(namespace.as_bytes());
         buf.extend_from_slice(&(host_id.len() as u16).to_le_bytes());
         buf.extend_from_slice(host_id.as_bytes());
         buf.extend_from_slice(&0u64.to_le_bytes()); // timestamp
-        buf.extend_from_slice(&0u16.to_le_bytes()); // node_count = 0
+        buf.extend_from_slice(&(nodes.len() as u16).to_le_bytes());
+        for name in nodes {
+            buf.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            buf.extend_from_slice(name.as_bytes());
+            buf.extend_from_slice(&0.0f64.to_bits().to_le_bytes());
+        }
         buf
+    }
+
+    /// Build a minimal presence wire payload with a chosen host_id and no nodes.
+    fn presence_payload(namespace: &str, host_id: &str) -> Vec<u8> {
+        presence_payload_with_nodes(namespace, host_id, &[])
+    }
+
+    #[test]
+    fn json_escape_neutralises_quotes_and_controls() {
+        assert_eq!(json_escape(r#"a"b"#), r#"a\"b"#);
+        assert_eq!(json_escape("a\\b"), "a\\\\b");
+        assert_eq!(json_escape("a\nb"), "a\\nb");
+        assert_eq!(json_escape("a\u{1}b"), "a\\u0001b");
+        assert_eq!(json_escape("plain-name.1"), "plain-name.1");
+    }
+
+    #[test]
+    fn safe_component_rejects_json_metacharacters() {
+        // host_id is interpolated as a JSON value, not just used as a filename.
+        assert!(!is_safe_path_component("a\"b"));
+        assert!(!is_safe_path_component("a\nb"));
+    }
+
+    #[test]
+    fn wire_node_names_cannot_inject_json_structure() {
+        // A remote peer used to author JSON *structure* through a node name:
+        // the name below closed the object and started a second, fabricated
+        // node that `horus node list` reported as real.
+        let mut recv = PresenceReceiver::new();
+        let ns = recv.local_namespace.clone();
+        let hostile = r#"x","is_bridged":true,"name":"fake"#;
+        recv.handle_broadcast(&presence_payload_with_nodes(
+            &ns,
+            "injtest",
+            &[hostile, "real_node"],
+        ));
+
+        let path = horus_sys::shm::shm_nodes_dir().join("remote_injtest.json");
+        let content = std::fs::read_to_string(&path).expect("presence file must be written");
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            !content.contains("is_bridged"),
+            "wire node name authored JSON structure: {content}"
+        );
+        assert!(
+            content.contains("real_node"),
+            "a well-formed node in the same broadcast must survive: {content}"
+        );
+        // The document must still be one flat object with one nodes array.
+        assert_eq!(content.matches("\"nodes\"").count(), 1);
     }
 
     #[test]

--- a/horus_net/src/presence.rs
+++ b/horus_net/src/presence.rs
@@ -30,8 +30,53 @@ fn is_safe_path_component(name: &str) -> bool {
     if name.contains('/') || name.contains('\\') || name.contains('\0') || name.contains("..") {
         return false;
     }
+    // `host_id` is interpolated as a JSON *value* as well as used as a filename,
+    // and this check used to look only at path safety — a quote character passed
+    // happily and let a remote peer author JSON structure in the presence file.
+    if name.contains('"') || name.chars().any(|c| (c as u32) < 0x20) {
+        return false;
+    }
     let mut comps = Path::new(name).components();
     matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
+}
+
+/// Escape a wire-supplied string for interpolation into the presence JSON.
+///
+/// `host_id` and node names arrive from an unauthenticated UDP peer and are
+/// pasted into a JSON document with `format!`. Without escaping, a node named
+/// `x","rate_hz":0},{"name":"fake` authors JSON *structure*, so a remote party
+/// decides what `horus node list` reports about the fleet — and an unbalanced
+/// quote makes the document unparseable, taking the host's presence out
+/// entirely. The module encodes JSON by hand on purpose (no serde here), so the
+/// escaper is the fix that fits: quote, backslash and every control character.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Whether a wire-supplied node name is a plain identifier.
+///
+/// Node names had no validation at all: any length, any bytes. Bounding them
+/// and restricting them to identifier characters keeps a hostile broadcast from
+/// filling the presence file with megabytes of arbitrary text (and is a second
+/// line of defence behind `json_escape`).
+fn is_plain_node_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
 }
 
 /// Manages incoming remote presence data — writes presence files to disk.
@@ -148,6 +193,10 @@ impl PresenceReceiver {
             let name = String::from_utf8_lossy(&data[pos..pos + name_len]).to_string();
             pos += name_len;
 
+            // Skip just this node, not the whole broadcast: one malformed entry
+            // should not cost us the rest of a peer's presence.
+            let name_ok = is_plain_node_name(&name);
+
             // Rate Hz (f64)
             if pos + 8 > data.len() {
                 break;
@@ -165,9 +214,13 @@ impl PresenceReceiver {
             let rate_hz = f64::from_bits(rate_bits);
             pos += 8;
 
+            if !name_ok {
+                continue;
+            }
+
             nodes_json.push(format!(
                 r#"{{"name":"{}","rate_hz":{}}}"#,
-                name,
+                json_escape(&name),
                 if rate_hz.is_finite() {
                     format!("{:.1}", rate_hz)
                 } else {
@@ -188,9 +241,9 @@ impl PresenceReceiver {
         // Write JSON presence file
         let json = format!(
             r#"{{"host_id":"{}","is_remote":true,"last_seen_ns":{},"namespace":"{}","nodes":[{}]}}"#,
-            host_id,
+            json_escape(&host_id),
             timestamp_ns,
-            namespace,
+            json_escape(&namespace),
             nodes_json.join(",")
         );
 

--- a/horus_net/src/registry.rs
+++ b/horus_net/src/registry.rs
@@ -242,6 +242,17 @@ impl TopicRegistry {
         *self.on_change.write().unwrap() = Some(Box::new(callback));
     }
 
+    /// Drop the change callback.
+    ///
+    /// This registry is a process-lifetime singleton while the callback the
+    /// replicator installs borrows resources owned by its event loop. Without a
+    /// way to clear it, every topic unregistered after the replicator thread
+    /// exited — which is exactly what scheduler shutdown does — still ran a
+    /// callback whose resources were gone.
+    pub fn clear_on_change(&self) {
+        *self.on_change.write().unwrap() = None;
+    }
+
     fn notify_change(&self) {
         if let Some(cb) = self.on_change.read().unwrap().as_ref() {
             cb();
@@ -377,6 +388,33 @@ mod tests {
         reg.unregister("a", TopicRole::Publisher);
 
         assert_eq!(counter.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn cleared_callback_stops_firing() {
+        // Regression: the replicator's callback holds resources tied to its
+        // event loop, and the registry outlives that loop. Unregistering a topic
+        // after shutdown must not run a stale callback.
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let reg = make_registry();
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+        reg.set_on_change(move || {
+            counter_clone.fetch_add(1, Ordering::Relaxed);
+        });
+
+        reg.register("a", 1, 1, TopicRole::Publisher, true);
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+
+        reg.clear_on_change();
+        reg.unregister("a", TopicRole::Publisher);
+        reg.register("b", 2, 2, TopicRole::Subscriber, true);
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "callback must not fire after being cleared"
+        );
     }
 
     #[test]

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -888,8 +888,8 @@ impl Replicator {
             // peer table reported as newly dead; a peer evicted to make room
             // for another (peer.rs cap path) is never reported that way, so its
             // heartbeat entry would otherwise live — and transmit — forever.
-            self.heartbeat
-                .retain_peers(|id| self.peers.get(id).is_some());
+            let known = &self.peers;
+            self.heartbeat.retain_peers(|id| known.get(id).is_some());
 
             if let Some(msg) = check_no_peers_diagnostic(
                 self.peers.alive_count(),

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -331,8 +331,17 @@ impl Replicator {
             {
                 return;
             }
-            self.peers.update_peer(&ann);
-            self.heartbeat.add_peer(ann.peer_id, ann.source_addr);
+            // Only register a heartbeat emitter for a peer the table actually
+            // accepted. This used to be unconditional, so every announcement
+            // the (capped) peer table refused still created an uncapped
+            // heartbeat entry keyed on the attacker-chosen peer_id — one that
+            // nothing ever removed and that `tick` used to transmit to the
+            // announcement's spoofable source address every 50 ms, forever.
+            // One forged datagram bought permanent outbound traffic aimed
+            // wherever the sender liked.
+            if self.peers.update_peer(&ann) {
+                self.heartbeat.add_peer(ann.peer_id, ann.source_addr);
+            }
             // Record peer discovery to blackbox
             horus_core::scheduling::record_external_event(
                 horus_core::scheduling::BlackBoxEvent::NetPeerDiscovered {
@@ -798,6 +807,14 @@ impl Replicator {
                 self.update_matches();
             }
 
+            // Re-sync heartbeat membership against the peer table every
+            // discovery interval. `remove_peer` above only fires for peers the
+            // peer table reported as newly dead; a peer evicted to make room
+            // for another (peer.rs cap path) is never reported that way, so its
+            // heartbeat entry would otherwise live — and transmit — forever.
+            self.heartbeat
+                .retain_peers(|id| self.peers.get(id).is_some());
+
             if let Some(msg) = check_no_peers_diagnostic(
                 self.peers.alive_count(),
                 self.start_time,
@@ -1151,6 +1168,31 @@ mod tests {
             1,
             "real announcement registers a peer"
         );
+    }
+
+    #[test]
+    fn forged_announcement_flood_cannot_grow_the_heartbeat_table() {
+        // Regression for the UDP-reflector leak: the heartbeat table had no cap
+        // of any kind and was populated unconditionally from every announcement,
+        // including the ones the (capped) peer table refused. A flood of forged
+        // peer ids grew it without bound and made every entry transmit to the
+        // announcement's source address every 50ms, forever.
+        let mut rep = test_replicator();
+        let from: SocketAddr = "127.0.0.1:9100".parse().unwrap();
+        for i in 0..(crate::netfilter::MAX_PEERS * 4) {
+            let mut peer_id = [0u8; 16];
+            peer_id[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            let mut buf = [0u8; 4096];
+            let len =
+                crate::discovery::encode_announcement(&peer_id, 9100, &[0u8; 4], &[], &mut buf);
+            rep.process_packet(&buf[..len], from);
+            assert!(
+                rep.heartbeat.peer_count() <= crate::netfilter::MAX_PEERS,
+                "heartbeat table exceeded the peer cap at iteration {i}: {}",
+                rep.heartbeat.peer_count()
+            );
+        }
+        assert!(rep.peers.total_count() <= crate::netfilter::MAX_PEERS);
     }
 
     #[test]

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -424,6 +424,12 @@ impl Replicator {
                     let payload = buf[payload_start..].to_vec();
 
                     let frag = crate::fragment::Fragment {
+                        // The reassembly key includes the sender: `fragment_id`
+                        // is a per-process counter every peer starts at 0, so
+                        // without this two peers publishing the same topic
+                        // reassemble into a single buffer and one message is
+                        // spliced together from both of their fragments.
+                        sender_id_hash: header.sender_id_hash,
                         topic_hash: mh.topic_hash,
                         sequence: mh.sequence,
                         timestamp_ns: mh.timestamp_ns,

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -598,11 +598,20 @@ impl Replicator {
         let payload_len = payload.len();
         encoding::process_incoming_payload(&mut payload, msg.encoding, payload_len);
 
-        // Write to local SHM
+        // Write to local SHM.
+        //
+        // `write` returns false when the payload does not match the topic's
+        // layout (a POD topic whose type_size differs, most often). The result
+        // used to be discarded and `record_topic_recv` bumped unconditionally,
+        // so a subscriber that never saw another sample still looked, in the
+        // metrics, like it was receiving everything.
         if let Some(writer) = self.find_writer_by_hash(msg.topic_hash) {
-            writer.write(&payload, msg.encoding);
-            self.metrics
-                .record_topic_recv(msg.topic_hash, payload.len());
+            if writer.write(&payload, msg.encoding) {
+                self.metrics
+                    .record_topic_recv(msg.topic_hash, payload.len());
+            } else {
+                self.metrics.record_topic_drop(msg.topic_hash);
+            }
         }
 
         // Send ACK for latched messages

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -225,9 +225,8 @@ impl Replicator {
                 std::io::Error::last_os_error()
             ));
         } else {
-            let notify_fd = unsafe {
-                <std::os::fd::OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(notify_fd)
-            };
+            let notify_fd =
+                unsafe { <std::os::fd::OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(notify_fd) };
             self.registry.set_on_change(move || {
                 let val: u64 = 1;
                 unsafe {

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -201,13 +201,44 @@ impl Replicator {
             return;
         }
 
-        let shm_notify_fd = event_loop.shm_notify_fd();
-        self.registry.set_on_change(move || {
-            let val: u64 = 1;
-            unsafe {
-                libc::write(shm_notify_fd, &val as *const u64 as *const libc::c_void, 8);
-            }
-        });
+        // Never hand a raw fd across an ownership boundary. `shm_notify_fd` is
+        // owned by `event_loop`, which lives on this stack frame, but the
+        // callback is installed into the process-lifetime registry singleton and
+        // outlives it: every `Topic<T>` dropped during scheduler shutdown — which
+        // happens AFTER this thread has joined and `EpollLoop::drop` has closed
+        // the descriptor — still wrote 8 bytes to that descriptor *number*. By
+        // then the number may have been reissued to an unrelated file the
+        // shutdown path opened (blackbox WAL flush, crash report), and the
+        // discarded return value made the corruption silent.
+        //
+        // The closure now owns a dup of the eventfd description instead. Writing
+        // into it after shutdown is harmless — nothing reads it — and it is
+        // released when `clear_on_change` below drops the callback.
+        let notify_fd = unsafe { libc::dup(event_loop.shm_notify_fd()) };
+        if notify_fd < 0 {
+            // Not fatal: `handle_timer` drives the export path every tick, so
+            // losing the wakeup only delays a newly registered topic's first
+            // export by up to TIMER_INTERVAL.
+            horus_core::terminal::eprint_line(&format!(
+                "[horus_net] Could not duplicate the export notify fd ({}); topic \
+                 registration will not wake the event loop early",
+                std::io::Error::last_os_error()
+            ));
+        } else {
+            let notify_fd = unsafe {
+                <std::os::fd::OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(notify_fd)
+            };
+            self.registry.set_on_change(move || {
+                let val: u64 = 1;
+                unsafe {
+                    libc::write(
+                        std::os::fd::AsRawFd::as_raw_fd(&notify_fd),
+                        &val as *const u64 as *const libc::c_void,
+                        8,
+                    );
+                }
+            });
+        }
 
         while self.running.load(Ordering::Relaxed) {
             let events = match event_loop.wait(1000) {
@@ -234,6 +265,12 @@ impl Replicator {
                 self.handle_timer();
             }
         }
+
+        // Drop the callback before `event_loop` goes out of scope. The registry
+        // is a process-lifetime singleton, so a callback left installed here
+        // survives this thread and keeps firing on every topic unregistered
+        // during scheduler shutdown.
+        self.registry.clear_on_change();
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -667,7 +704,23 @@ impl Replicator {
                 };
 
                 let mut send_buf = [0u8; 65536];
-                let len = wire::encode_single(&header, &frag_msg, &mut send_buf);
+                // A fragmented message MUST carry a FragmentHeader. This used
+                // to call `encode_single` for every fragment, which emits none,
+                // while the receive path reads one straight after the
+                // MessageHeader — so it consumed the first 12 bytes of the
+                // chunk as fragment metadata and reassembly of anything over
+                // MAX_FRAGMENT_PAYLOAD never produced the original message.
+                let len = if frag.fragment_count > 1 {
+                    let fh = wire::FragmentHeader {
+                        fragment_id: frag.fragment_id,
+                        fragment_index: frag.fragment_index,
+                        fragment_count: frag.fragment_count,
+                        total_payload_len: frag.total_payload_len,
+                    };
+                    wire::encode_fragment(&header, &frag_msg, &fh, &mut send_buf)
+                } else {
+                    wire::encode_single(&header, &frag_msg, &mut send_buf)
+                };
                 // 0 = did not fit; skip rather than send a truncated packet.
                 if len == 0 {
                     continue;

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -480,6 +480,15 @@ impl Replicator {
     }
 
     /// Process a single incoming data message (shared by regular and reassembled paths).
+    ///
+    /// **Nothing on this path authenticates the sender.** `peer_filter` limits
+    /// *reach*, the import guard limits *which topics*, and the type-hash check
+    /// compares against a hash the sender itself announced — so a host inside the
+    /// allowed peer range can write arbitrary bytes into any importable local SHM
+    /// topic, actuation commands included, and can replay anything it captured.
+    /// Only `_horus.estop` is authenticated (HMAC, `HORUS_ESTOP_KEY`). See the
+    /// crate-level trust model; closing this needs a per-datagram MAC and a
+    /// replay window, which is a wire-format change.
     fn process_incoming_message(
         &mut self,
         header: &PacketHeader,

--- a/horus_net/src/wire.rs
+++ b/horus_net/src/wire.rs
@@ -473,6 +473,60 @@ pub fn encode_single(header: &PacketHeader, msg: &OutMessage, buf: &mut [u8]) ->
     total
 }
 
+/// Encode one fragment of a split message: `[PacketHeader][MessageHeader][FragmentHeader][chunk]`.
+///
+/// Returns the number of bytes written, or 0 if `buf` is too small (same
+/// contract as [`encode_single`]: callers MUST treat 0 as "not encoded").
+///
+/// The fragmented send path used to call `encode_single`, which emits no
+/// `FragmentHeader` at all, while the receive path (`Replicator::process_packet`)
+/// reads one at `PacketHeader::SIZE + MessageHeader::SIZE`. Every fragmented
+/// message was therefore parsed with the first 12 bytes of its payload
+/// interpreted as fragment metadata — a garbage `fragment_count`/`total_len` —
+/// so nothing over 1400 bytes ever reassembled correctly.
+pub fn encode_fragment(
+    header: &PacketHeader,
+    msg: &OutMessage,
+    fragment: &FragmentHeader,
+    buf: &mut [u8],
+) -> usize {
+    let total =
+        PacketHeader::SIZE + MessageHeader::SIZE + FragmentHeader::SIZE + msg.payload.len();
+    if buf.len() < total {
+        horus_core::terminal::eprint_line(&format!(
+            "[horus_net] Dropping a {}-byte fragment on topic hash {:#x} — it does not fit \
+             the {}-byte send buffer",
+            msg.payload.len(),
+            msg.topic_hash,
+            buf.len()
+        ));
+        return 0;
+    }
+
+    header.encode(&mut buf[..PacketHeader::SIZE]);
+
+    let msg_header = MessageHeader {
+        topic_hash: msg.topic_hash,
+        payload_len: msg.payload.len() as u32,
+        timestamp_ns: msg.timestamp_ns,
+        sequence: msg.sequence,
+        priority: msg.priority,
+        reliability: msg.reliability,
+        encoding: msg.encoding,
+        source_host: 0,
+    };
+    let mh_start = PacketHeader::SIZE;
+    msg_header.encode(&mut buf[mh_start..mh_start + MessageHeader::SIZE]);
+
+    let fh_start = mh_start + MessageHeader::SIZE;
+    fragment.encode(&mut buf[fh_start..fh_start + FragmentHeader::SIZE]);
+
+    let payload_start = fh_start + FragmentHeader::SIZE;
+    buf[payload_start..payload_start + msg.payload.len()].copy_from_slice(&msg.payload);
+
+    total
+}
+
 /// Encode multiple messages into a single batched packet.
 /// Returns the number of bytes written.
 pub fn encode_batch(header: &PacketHeader, msgs: &[OutMessage], buf: &mut [u8]) -> usize {

--- a/horus_net/src/wire.rs
+++ b/horus_net/src/wire.rs
@@ -490,8 +490,7 @@ pub fn encode_fragment(
     fragment: &FragmentHeader,
     buf: &mut [u8],
 ) -> usize {
-    let total =
-        PacketHeader::SIZE + MessageHeader::SIZE + FragmentHeader::SIZE + msg.payload.len();
+    let total = PacketHeader::SIZE + MessageHeader::SIZE + FragmentHeader::SIZE + msg.payload.len();
     if buf.len() < total {
         horus_core::terminal::eprint_line(&format!(
             "[horus_net] Dropping a {}-byte fragment on topic hash {:#x} — it does not fit \

--- a/horus_net/tests/phase3_validation.rs
+++ b/horus_net/tests/phase3_validation.rs
@@ -211,13 +211,16 @@ fn production_scenario_link_loss_safe_state() {
 
 #[test]
 fn all_optimizers_chain() {
+    // Inverted: this used to expect all four names to install an optimizer.
+    // "delta" is now refused by from_config — it encodes on the send side and
+    // has no decoder, so enabling it silently drops or corrupts replicated data.
     let chain = OptimizerChain::from_config(&[
         "fusion".into(),
         "delta".into(),
         "spatial".into(),
         "predict".into(),
     ]);
-    assert_eq!(chain.len(), 4);
+    assert_eq!(chain.len(), 3, "delta must not be installed");
 }
 
 #[test]

--- a/horus_net/tests/wire_integration.rs
+++ b/horus_net/tests/wire_integration.rs
@@ -260,7 +260,11 @@ fn fnv1a_hash_10k_no_collisions() {
 fn fragment_header_roundtrip_over_udp() {
     let (sender, receiver, recv_addr) = loopback_pair();
 
-    // Simulate a fragment packet: packet header + message header + fragment header + payload
+    // The real fragment layout, produced by the encoder the replicator uses:
+    // [PacketHeader][MessageHeader][FragmentHeader][chunk]. This test used to
+    // hand-roll a PacketHeader+FragmentHeader packet with no MessageHeader —
+    // a third layout matching neither the sender nor the receiver, which is
+    // how the missing FragmentHeader on the send path stayed hidden.
     let pkt_header = PacketHeader::new(PacketFlags::empty().with(PacketFlags::FRAGMENT), 0x5555, 1);
     let frag = FragmentHeader {
         fragment_id: 42,
@@ -268,29 +272,45 @@ fn fragment_header_roundtrip_over_udp() {
         fragment_count: 3,
         total_payload_len: 4200,
     };
+    let payload = b"fragment zero data".to_vec();
+    let msg = OutMessage {
+        topic_name: "pointcloud".into(),
+        topic_hash: topic_hash("pointcloud"),
+        payload: payload.clone(),
+        timestamp_ns: 777,
+        sequence: 9,
+        priority: Priority::Normal,
+        reliability: Reliability::None,
+        encoding: Encoding::PodLe,
+    };
 
     let mut send_buf = [0u8; 256];
-    pkt_header.encode(&mut send_buf[..PacketHeader::SIZE]);
-    frag.encode(&mut send_buf[PacketHeader::SIZE..PacketHeader::SIZE + FragmentHeader::SIZE]);
-    let payload = b"fragment zero data";
-    let data_start = PacketHeader::SIZE + FragmentHeader::SIZE;
-    send_buf[data_start..data_start + payload.len()].copy_from_slice(payload);
-    let total = data_start + payload.len();
+    let total = encode_fragment(&pkt_header, &msg, &frag, &mut send_buf);
+    assert_eq!(
+        total,
+        PacketHeader::SIZE + MessageHeader::SIZE + FragmentHeader::SIZE + payload.len()
+    );
 
     sender.send_to(&send_buf[..total], recv_addr).unwrap();
 
     let mut recv_buf = [0u8; 256];
     let (n, _) = receiver.recv_from(&mut recv_buf).unwrap();
 
+    // Decode exactly the way Replicator::process_packet does.
     let header = PacketHeader::decode(&recv_buf[..n]).unwrap();
     assert!(header.flags.fragment());
 
-    let decoded_frag = FragmentHeader::decode(&recv_buf[PacketHeader::SIZE..]).unwrap();
+    let mh = MessageHeader::decode(&recv_buf[PacketHeader::SIZE..n]).unwrap();
+    assert_eq!(mh.topic_hash, topic_hash("pointcloud"));
+    assert_eq!(mh.sequence, 9);
+
+    let fh_start = PacketHeader::SIZE + MessageHeader::SIZE;
+    let decoded_frag = FragmentHeader::decode(&recv_buf[fh_start..n]).unwrap();
     assert_eq!(decoded_frag.fragment_id, 42);
     assert_eq!(decoded_frag.fragment_index, 0);
     assert_eq!(decoded_frag.fragment_count, 3);
     assert_eq!(decoded_frag.total_payload_len, 4200);
 
-    let recv_payload = &recv_buf[data_start..data_start + payload.len()];
-    assert_eq!(recv_payload, payload);
+    let data_start = fh_start + FragmentHeader::SIZE;
+    assert_eq!(&recv_buf[data_start..n], &payload[..]);
 }

--- a/horus_py/src/depth_image.rs
+++ b/horus_py/src/depth_image.rs
@@ -159,7 +159,7 @@ impl PyDepthImage {
             }
         }
         dict.set_item("shape", PyTuple::new(py, &shape)?)?;
-        dict.set_item("typestr", tensor.dtype.numpy_typestr())?;
+        dict.set_item("typestr", tensor.dtype().numpy_typestr())?;
 
         let ptr = this.inner.pool().data_ptr(tensor) as usize;
         dict.set_item("data", (ptr, false))?;

--- a/horus_py/src/image.rs
+++ b/horus_py/src/image.rs
@@ -247,7 +247,7 @@ impl PyImage {
         }
 
         dict.set_item("shape", PyTuple::new(py, &shape)?)?;
-        dict.set_item("typestr", tensor.dtype.numpy_typestr())?;
+        dict.set_item("typestr", tensor.dtype().numpy_typestr())?;
 
         let ptr = this.inner.pool().data_ptr(tensor) as usize;
         dict.set_item("data", (ptr, false))?;

--- a/horus_py/src/pointcloud.rs
+++ b/horus_py/src/pointcloud.rs
@@ -131,7 +131,7 @@ impl PyPointCloud {
             }
         }
         dict.set_item("shape", PyTuple::new(py, &shape)?)?;
-        dict.set_item("typestr", tensor.dtype.numpy_typestr())?;
+        dict.set_item("typestr", tensor.dtype().numpy_typestr())?;
 
         let ptr = this.inner.pool().data_ptr(tensor) as usize;
         dict.set_item("data", (ptr, false))?;

--- a/horus_py/src/rate.rs
+++ b/horus_py/src/rate.rs
@@ -59,7 +59,8 @@ impl PyRate {
     // period — the GIL is process-wide, so running the loop in a "dedicated
     // background thread" was no escape from it.
     fn sleep(&mut self, py: Python<'_>) {
-        py.detach(|| self.inner.sleep());
+        let inner = &mut self.inner;
+        py.detach(|| inner.sleep());
     }
 
     /// Actual achieved frequency in Hz (exponentially smoothed).

--- a/horus_py/src/rate.rs
+++ b/horus_py/src/rate.rs
@@ -23,8 +23,8 @@ use horus_core::core::timer::Rate;
 /// print(f"Actual: {rate.actual_hz():.1f} Hz")
 /// ```
 ///
-/// Note: ``sleep()`` blocks the calling thread. In multi-threaded Python code,
-/// the GIL is NOT released during sleep. Use in dedicated background threads.
+/// Note: ``sleep()`` blocks the calling thread, but releases the GIL for the
+/// duration of the sleep, so other Python threads keep running.
 #[pyclass(name = "Rate")]
 pub struct PyRate {
     inner: Rate,
@@ -52,8 +52,14 @@ impl PyRate {
     ///
     /// If work took longer than the period, sleep is skipped and the next
     /// cycle catches up (drift compensation).
-    fn sleep(&mut self) {
-        self.inner.sleep();
+    ///
+    /// Releases the GIL for the duration of the sleep.
+    // This is a real blocking OS sleep of up to one full period. It used to run
+    // with the GIL held, which froze every other Python thread for that whole
+    // period — the GIL is process-wide, so running the loop in a "dedicated
+    // background thread" was no escape from it.
+    fn sleep(&mut self, py: Python<'_>) {
+        py.detach(|| self.inner.sleep());
     }
 
     /// Actual achieved frequency in Hz (exponentially smoothed).

--- a/horus_py/src/scheduler.rs
+++ b/horus_py/src/scheduler.rs
@@ -89,6 +89,11 @@ struct PyNodeAdapter {
     cached_info: Option<Py<PyNodeInfo>>,
     stop_requested: Arc<AtomicBool>,
     scheduler_running: Arc<AtomicBool>,
+    /// Whether each callback takes the `NodeInfo` argument, decided once from
+    /// its signature (see `resolve_takes_info`) and never re-derived.
+    init_takes_info: Option<bool>,
+    tick_takes_info: Option<bool>,
+    shutdown_takes_info: Option<bool>,
 }
 
 /// Render a Python exception the way Python renders it: type, message, and the
@@ -116,6 +121,49 @@ fn describe_py_error(py: Python<'_>, err: &PyErr) -> String {
     }
 }
 
+/// Does `obj.<name>` take the `NodeInfo` argument? Resolved once from the
+/// callable's signature and cached in `cache`.
+///
+/// This used to be decided by catching a `TypeError` from the one-argument
+/// call and retrying with no arguments. That is not a sound test: a
+/// `TypeError` raised by arbitrary user code *inside* the callback body —
+/// `None + 1`, `int(None)`, a wrong argument to a library call — is
+/// indistinguishable from the arity error the call machinery raises *before*
+/// the body runs. So a node whose `tick` sent a command and then hit a
+/// `TypeError` had its whole body executed a second time, putting a duplicate
+/// command on the wire before the error finally propagated; and for the
+/// equally common `def tick(self, info):` the retry failed with "missing 1
+/// required positional argument", and that — not the real exception and its
+/// traceback — is what reached the operator.
+///
+/// `inspect.signature` on a bound method already excludes `self`, and asking
+/// the signature to bind a single positional argument answers the question
+/// exactly, including for `*args`, keyword-only and `**kwargs` forms.
+/// Callables `inspect` cannot introspect (C functions, some builtins) get the
+/// documented one-argument form; a real mismatch there now fails loudly
+/// instead of silently re-running the body.
+fn resolve_takes_info(
+    cache: &mut Option<bool>,
+    py: Python<'_>,
+    obj: &Py<PyAny>,
+    name: &str,
+) -> bool {
+    if let Some(known) = *cache {
+        return known;
+    }
+    let takes_info = match obj.bind(py).getattr(name) {
+        Ok(bound) => py
+            .import("inspect")
+            .and_then(|inspect| inspect.call_method1("signature", (bound,)))
+            .map(|sig| sig.call_method1("bind", (py.None(),)).is_ok())
+            .unwrap_or(true),
+        // No such attribute: let the call itself raise the AttributeError.
+        Err(_) => true,
+    };
+    *cache = Some(takes_info);
+    takes_info
+}
+
 impl CoreNode for PyNodeAdapter {
     fn name(&self) -> &str {
         &self.node_name
@@ -134,21 +182,29 @@ impl CoreNode for PyNodeAdapter {
 
             self.cached_info = Some(py_info.clone_ref(py));
 
-            let result = self
-                .py_object
-                .call_method1(py, "init", (py_info,))
-                .or_else(|e| {
-                    // Only fall back to no-arg if the method doesn't accept info parameter.
-                    // TypeError = wrong signature. All other errors propagate.
-                    if e.is_instance_of::<pyo3::exceptions::PyTypeError>(py) {
-                        self.py_object.call_method0(py, "init")
-                    } else {
-                        Err(e)
-                    }
-                });
+            let takes_info =
+                resolve_takes_info(&mut self.init_takes_info, py, &self.py_object, "init");
+            let result = if takes_info {
+                self.py_object.call_method1(py, "init", (py_info,))
+            } else {
+                self.py_object.call_method0(py, "init")
+            };
 
             match result {
-                Ok(_) => Ok(()),
+                Ok(_) => {
+                    // Resolve the other two callbacks' arity here: the GIL is
+                    // already held, `init` has had its chance to bind them,
+                    // and the tick path then never pays for `inspect`.
+                    let _ =
+                        resolve_takes_info(&mut self.tick_takes_info, py, &self.py_object, "tick");
+                    let _ = resolve_takes_info(
+                        &mut self.shutdown_takes_info,
+                        py,
+                        &self.py_object,
+                        "shutdown",
+                    );
+                    Ok(())
+                }
                 Err(e) => {
                     if e.is_instance_of::<pyo3::exceptions::PyKeyboardInterrupt>(py) {
                         self.stop_requested.store(true, Ordering::Relaxed);
@@ -200,16 +256,13 @@ impl CoreNode for PyNodeAdapter {
             // (see module-level GIL/lock safety comment).  If the Python code
             // calls back into Rust (e.g., topic.send()), that is safe because
             // node_context and self.inner are unlocked.
-            let result = self
-                .py_object
-                .call_method1(py, "tick", (py_info,))
-                .or_else(|e| {
-                    if e.is_instance_of::<pyo3::exceptions::PyTypeError>(py) {
-                        self.py_object.call_method0(py, "tick")
-                    } else {
-                        Err(e)
-                    }
-                });
+            let takes_info =
+                resolve_takes_info(&mut self.tick_takes_info, py, &self.py_object, "tick");
+            let result = if takes_info {
+                self.py_object.call_method1(py, "tick", (py_info,))
+            } else {
+                self.py_object.call_method0(py, "tick")
+            };
 
             match result {
                 Ok(_) => {
@@ -291,16 +344,13 @@ impl CoreNode for PyNodeAdapter {
                 .map_err(|e| HorusError::node(&self.node_name, e.to_string()))?
             };
 
-            let result = self
-                .py_object
-                .call_method1(py, "shutdown", (py_info,))
-                .or_else(|e| {
-                    if e.is_instance_of::<pyo3::exceptions::PyTypeError>(py) {
-                        self.py_object.call_method0(py, "shutdown")
-                    } else {
-                        Err(e)
-                    }
-                });
+            let takes_info =
+                resolve_takes_info(&mut self.shutdown_takes_info, py, &self.py_object, "shutdown");
+            let result = if takes_info {
+                self.py_object.call_method1(py, "shutdown", (py_info,))
+            } else {
+                self.py_object.call_method0(py, "shutdown")
+            };
 
             match result {
                 Ok(_) => Ok(()),
@@ -656,6 +706,9 @@ impl PyScheduler {
             cached_info: None,
             stop_requested: self.stop_requested.clone(),
             scheduler_running: self.scheduler_running.clone(),
+            init_takes_info: None,
+            tick_takes_info: None,
+            shutdown_takes_info: None,
         };
 
         let mut config = NodeRegistration::new(Box::new(adapter)).order(order);

--- a/horus_py/src/scheduler.rs
+++ b/horus_py/src/scheduler.rs
@@ -164,6 +164,38 @@ fn resolve_takes_info(
     takes_info
 }
 
+/// Invoke `obj.<name>`, with or without the `NodeInfo` argument, according to
+/// the cached arity decision.
+///
+/// The one retry left here is safe where the old blanket `TypeError` retry was
+/// not: it fires only when the `TypeError` carries no traceback, which means
+/// the call machinery rejected the arguments *before* entering any Python
+/// frame, so no user code can have run — let alone run twice. An exception
+/// raised inside the callback body always carries a traceback and is passed
+/// straight through. In practice only callables `inspect` could not introspect
+/// reach this path.
+fn call_node_callback(
+    cache: &mut Option<bool>,
+    py: Python<'_>,
+    obj: &Py<PyAny>,
+    name: &str,
+    info: Py<PyNodeInfo>,
+) -> PyResult<Py<PyAny>> {
+    if !resolve_takes_info(cache, py, obj, name) {
+        return obj.call_method0(py, name);
+    }
+    match obj.call_method1(py, name, (info,)) {
+        Err(e)
+            if e.is_instance_of::<pyo3::exceptions::PyTypeError>(py)
+                && e.traceback(py).is_none() =>
+        {
+            *cache = Some(false);
+            obj.call_method0(py, name)
+        }
+        other => other,
+    }
+}
+
 impl CoreNode for PyNodeAdapter {
     fn name(&self) -> &str {
         &self.node_name
@@ -182,13 +214,13 @@ impl CoreNode for PyNodeAdapter {
 
             self.cached_info = Some(py_info.clone_ref(py));
 
-            let takes_info =
-                resolve_takes_info(&mut self.init_takes_info, py, &self.py_object, "init");
-            let result = if takes_info {
-                self.py_object.call_method1(py, "init", (py_info,))
-            } else {
-                self.py_object.call_method0(py, "init")
-            };
+            let result = call_node_callback(
+                &mut self.init_takes_info,
+                py,
+                &self.py_object,
+                "init",
+                py_info,
+            );
 
             match result {
                 Ok(_) => {
@@ -256,13 +288,13 @@ impl CoreNode for PyNodeAdapter {
             // (see module-level GIL/lock safety comment).  If the Python code
             // calls back into Rust (e.g., topic.send()), that is safe because
             // node_context and self.inner are unlocked.
-            let takes_info =
-                resolve_takes_info(&mut self.tick_takes_info, py, &self.py_object, "tick");
-            let result = if takes_info {
-                self.py_object.call_method1(py, "tick", (py_info,))
-            } else {
-                self.py_object.call_method0(py, "tick")
-            };
+            let result = call_node_callback(
+                &mut self.tick_takes_info,
+                py,
+                &self.py_object,
+                "tick",
+                py_info,
+            );
 
             match result {
                 Ok(_) => {
@@ -344,13 +376,13 @@ impl CoreNode for PyNodeAdapter {
                 .map_err(|e| HorusError::node(&self.node_name, e.to_string()))?
             };
 
-            let takes_info =
-                resolve_takes_info(&mut self.shutdown_takes_info, py, &self.py_object, "shutdown");
-            let result = if takes_info {
-                self.py_object.call_method1(py, "shutdown", (py_info,))
-            } else {
-                self.py_object.call_method0(py, "shutdown")
-            };
+            let result = call_node_callback(
+                &mut self.shutdown_takes_info,
+                py,
+                &self.py_object,
+                "shutdown",
+                py_info,
+            );
 
             match result {
                 Ok(_) => Ok(()),

--- a/horus_py/src/tensor.rs
+++ b/horus_py/src/tensor.rs
@@ -363,7 +363,7 @@ impl PyTensorHandle {
         dict.set_item("shape", PyTuple::new(py, &shape)?)?;
 
         // Type string
-        let typestr = dtype_numpy_typestr(tensor.dtype);
+        let typestr = dtype_numpy_typestr(tensor.dtype());
         dict.set_item("typestr", typestr)?;
 
         // Data pointer and read-only flag
@@ -433,7 +433,7 @@ impl PyTensorHandle {
         dict.set_item("shape", PyTuple::new(py, &shape)?)?;
 
         // Type string
-        let typestr = dtype_numpy_typestr(tensor.dtype);
+        let typestr = dtype_numpy_typestr(tensor.dtype());
         dict.set_item("typestr", typestr)?;
 
         // Use handle.data_ptr() which goes through pool.data_ptr().

--- a/horus_py/src/topic.rs
+++ b/horus_py/src/topic.rs
@@ -56,7 +56,7 @@ use horus_types::{
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use serde::{de::DeserializeOwned, Serialize};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 
 use crate::depth_image::PyDepthImage;
 use crate::image::PyImage;
@@ -79,10 +79,20 @@ use crate::messages::{
 use crate::pointcloud::PyPointCloud;
 use crate::tensor::PyTensorHandle;
 
-/// Acquire a read lock, converting a poisoned lock into a PyRuntimeError.
+/// Acquire the topic's lock, converting a poisoned lock into a PyRuntimeError.
+///
+/// This was a *read* lock on an `RwLock`, and every recv path plus every
+/// pool-backed send path used it. That handed out N simultaneous `&Topic<T>` to
+/// N Python threads, while `horus_core` requires exclusive access: every
+/// `Topic` method takes `&self` and then mutates unsynchronised `UnsafeCell`
+/// cursor state and `Cell` keep-alive state. Two threads calling `recv()` on
+/// one `horus.Topic` raced on `local_tail` (duplicated or lost messages, and a
+/// data race outright); two calling `send()` on an image topic could release
+/// the same pool slot twice. `Topic` is now `!Sync` in horus_core, and the lock
+/// here is a `Mutex` so no shared-borrow path can be reintroduced by accident.
 #[inline]
-fn read_lock<T>(lock: &RwLock<T>) -> PyResult<std::sync::RwLockReadGuard<'_, T>> {
-    lock.read()
+fn topic_lock<T>(lock: &Mutex<T>) -> PyResult<std::sync::MutexGuard<'_, T>> {
+    lock.lock()
         .map_err(|e| PyRuntimeError::new_err(format!("Topic lock poisoned: {e}")))
 }
 
@@ -133,12 +143,12 @@ fn log_ipc_event(
 macro_rules! pod_topic_types {
     ( $( ($rust_ty:ident, $py_ty:ident) ),* $(,)? ) => {
         enum TopicType {
-            $( $rust_ty(Arc<RwLock<Topic<$rust_ty>>>), )*
-            Image(Arc<RwLock<Topic<Image>>>),
-            PointCloud(Arc<RwLock<Topic<PointCloud>>>),
-            DepthImage(Arc<RwLock<Topic<DepthImage>>>),
-            Tensor(Arc<RwLock<Topic<horus_core::types::Tensor>>>),
-            Generic(Arc<RwLock<Topic<GenericMessage>>>),
+            $( $rust_ty(Arc<Mutex<Topic<$rust_ty>>>), )*
+            Image(Arc<Mutex<Topic<Image>>>),
+            PointCloud(Arc<Mutex<Topic<PointCloud>>>),
+            DepthImage(Arc<Mutex<Topic<DepthImage>>>),
+            Tensor(Arc<Mutex<Topic<horus_core::types::Tensor>>>),
+            Generic(Arc<Mutex<Topic<GenericMessage>>>),
         }
 
         macro_rules! topic_dispatch {
@@ -161,7 +171,7 @@ macro_rules! pod_topic_types {
                 let tt = match type_name {
                     $( stringify!($rust_ty) => {
                         let topic = create_topic::<$rust_ty>(endpoint, cap)?;
-                        TopicType::$rust_ty(Arc::new(RwLock::new(topic)))
+                        TopicType::$rust_ty(Arc::new(Mutex::new(topic)))
                     }, )*
                     _ => return Ok(None),
                 };
@@ -183,7 +193,7 @@ macro_rules! pod_topic_types {
                                 Some(val.log_summary())
                             } else { None };
                             let topic_ref = topic.clone();
-                            py.detach(|| { topic_ref.write().expect("lock").send(val); });
+                            py.detach(|| { topic_ref.lock().expect("lock").send(val); });
                             if let Some(s) = summary {
                                 log_ipc_event(py, node, &self.name, s,
                                     start.elapsed().as_nanos() as u64, "log_pub");
@@ -205,7 +215,7 @@ macro_rules! pod_topic_types {
                         TopicType::$rust_ty(topic) => {
                             let topic_ref = topic.clone();
                             let msg_opt = py.detach(|| {
-                                topic_ref.read().expect("lock").recv()
+                                topic_ref.lock().expect("lock").recv()
                             });
                             if let Some(val) = msg_opt {
                                 if node.is_some() {
@@ -407,24 +417,24 @@ impl PyTopic {
             match type_name.as_str() {
                 "Image" => {
                     let topic = create_pool_topic::<Image>(&effective_endpoint, cap)?;
-                    TopicType::Image(Arc::new(RwLock::new(topic)))
+                    TopicType::Image(Arc::new(Mutex::new(topic)))
                 }
                 "PointCloud" => {
                     let topic = create_pool_topic::<PointCloud>(&effective_endpoint, cap)?;
-                    TopicType::PointCloud(Arc::new(RwLock::new(topic)))
+                    TopicType::PointCloud(Arc::new(Mutex::new(topic)))
                 }
                 "DepthImage" => {
                     let topic = create_pool_topic::<DepthImage>(&effective_endpoint, cap)?;
-                    TopicType::DepthImage(Arc::new(RwLock::new(topic)))
+                    TopicType::DepthImage(Arc::new(Mutex::new(topic)))
                 }
                 "Tensor" | "TensorHandle" => {
                     let topic =
                         create_pool_topic::<horus_core::types::Tensor>(&effective_endpoint, cap)?;
-                    TopicType::Tensor(Arc::new(RwLock::new(topic)))
+                    TopicType::Tensor(Arc::new(Mutex::new(topic)))
                 }
                 _ => {
                     let topic = create_topic::<GenericMessage>(&effective_endpoint, cap)?;
-                    TopicType::Generic(Arc::new(RwLock::new(topic)))
+                    TopicType::Generic(Arc::new(Mutex::new(topic)))
                 }
             }
         };
@@ -473,7 +483,7 @@ impl PyTopic {
                 let img = py_img.inner().clone();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.read().expect("topic lock poisoned").send(&img);
+                    topic_ref.lock().expect("topic lock poisoned").send(&img);
                     true
                 });
                 if node.is_some() {
@@ -493,7 +503,7 @@ impl PyTopic {
                 let pc = py_pc.inner().clone();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.read().expect("topic lock poisoned").send(&pc);
+                    topic_ref.lock().expect("topic lock poisoned").send(&pc);
                     true
                 });
                 if node.is_some() {
@@ -513,7 +523,7 @@ impl PyTopic {
                 let depth = py_depth.inner().clone();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.read().expect("topic lock poisoned").send(&depth);
+                    topic_ref.lock().expect("topic lock poisoned").send(&depth);
                     true
                 });
                 if node.is_some() {
@@ -554,7 +564,7 @@ impl PyTopic {
                     .data_slice()
                     .map_err(|e| PyRuntimeError::new_err(format!("tensor read failed: {e}")))?;
                 let success = py.detach(|| -> PyResult<bool> {
-                    let t = topic_ref.read().expect("topic lock poisoned");
+                    let t = topic_ref.lock().expect("topic lock poisoned");
                     let dst = t
                         .alloc_tensor(&shape, dtype, device)
                         .map_err(|e| PyRuntimeError::new_err(format!("pool alloc failed: {e}")))?;
@@ -600,7 +610,7 @@ impl PyTopic {
                 let log_summary = msg.log_summary();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.write().expect("topic lock poisoned").send(msg);
+                    topic_ref.lock().expect("topic lock poisoned").send(msg);
                     true
                 });
                 if node.is_some() {
@@ -646,7 +656,7 @@ impl PyTopic {
         match &self.topic_type {
             TopicType::Image(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.read().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
                 if let Some(img) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -666,7 +676,7 @@ impl PyTopic {
             }
             TopicType::PointCloud(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.read().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
                 if let Some(pc) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -686,7 +696,7 @@ impl PyTopic {
             }
             TopicType::DepthImage(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.read().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
                 if let Some(depth) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -712,7 +722,7 @@ impl PyTopic {
                 // against a cross-pool descriptor instead of silently handing back
                 // a null data pointer.
                 let msg_opt =
-                    py.detach(|| topic_ref.read().expect("topic lock poisoned").recv_handle());
+                    py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv_handle());
                 if let Some(handle) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -740,7 +750,7 @@ impl PyTopic {
             }
             TopicType::Generic(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.read().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
                 if let Some(msg) = msg_opt {
                     if node.is_some() {
                         use horus::core::LogSummary;
@@ -793,259 +803,259 @@ impl PyTopic {
     #[getter]
     fn backend_type(&self) -> String {
         match &self.topic_type {
-            TopicType::CmdVel(t) => read_lock(t)
+            TopicType::CmdVel(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Pose2D(t) => read_lock(t)
+            TopicType::Pose2D(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Pose3D(t) => read_lock(t)
+            TopicType::Pose3D(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Imu(t) => read_lock(t)
+            TopicType::Imu(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Odometry(t) => read_lock(t)
+            TopicType::Odometry(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::LaserScan(t) => read_lock(t)
+            TopicType::LaserScan(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::JointState(t) => read_lock(t)
+            TopicType::JointState(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Clock(t) => read_lock(t)
+            TopicType::Clock(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::TimeReference(t) => read_lock(t)
+            TopicType::TimeReference(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Image(t) => read_lock(t)
+            TopicType::Image(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PointCloud(t) => read_lock(t)
+            TopicType::PointCloud(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::DepthImage(t) => read_lock(t)
+            TopicType::DepthImage(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Geometry types
-            TopicType::Twist(t) => read_lock(t)
+            TopicType::Twist(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Vector3(t) => read_lock(t)
+            TopicType::Vector3(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Point3(t) => read_lock(t)
+            TopicType::Point3(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Quaternion(t) => read_lock(t)
+            TopicType::Quaternion(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::TransformStamped(t) => read_lock(t)
+            TopicType::TransformStamped(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PoseStamped(t) => read_lock(t)
+            TopicType::PoseStamped(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PoseWithCovariance(t) => read_lock(t)
+            TopicType::PoseWithCovariance(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::TwistWithCovariance(t) => read_lock(t)
+            TopicType::TwistWithCovariance(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Accel(t) => read_lock(t)
+            TopicType::Accel(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::AccelStamped(t) => read_lock(t)
+            TopicType::AccelStamped(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Control types
-            TopicType::MotorCommand(t) => read_lock(t)
+            TopicType::MotorCommand(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::ServoCommand(t) => read_lock(t)
+            TopicType::ServoCommand(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::DifferentialDriveCommand(t) => read_lock(t)
+            TopicType::DifferentialDriveCommand(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PidConfig(t) => read_lock(t)
+            TopicType::PidConfig(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::TrajectoryPoint(t) => read_lock(t)
+            TopicType::TrajectoryPoint(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::JointCommand(t) => read_lock(t)
+            TopicType::JointCommand(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Sensor types
-            TopicType::RangeSensor(t) => read_lock(t)
+            TopicType::RangeSensor(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::BatteryState(t) => read_lock(t)
+            TopicType::BatteryState(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::NavSatFix(t) => read_lock(t)
+            TopicType::NavSatFix(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::MagneticField(t) => read_lock(t)
+            TopicType::MagneticField(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Temperature(t) => read_lock(t)
+            TopicType::Temperature(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::FluidPressure(t) => read_lock(t)
+            TopicType::FluidPressure(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Illuminance(t) => read_lock(t)
+            TopicType::Illuminance(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Diagnostics types
-            TopicType::Heartbeat(t) => read_lock(t)
+            TopicType::Heartbeat(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::DiagnosticStatus(t) => read_lock(t)
+            TopicType::DiagnosticStatus(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::EmergencyStop(t) => read_lock(t)
+            TopicType::EmergencyStop(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::ResourceUsage(t) => read_lock(t)
+            TopicType::ResourceUsage(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Force types
-            TopicType::WrenchStamped(t) => read_lock(t)
+            TopicType::WrenchStamped(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::ForceCommand(t) => read_lock(t)
+            TopicType::ForceCommand(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::ContactInfo(t) => read_lock(t)
+            TopicType::ContactInfo(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Navigation types
-            TopicType::NavGoal(t) => read_lock(t)
+            TopicType::NavGoal(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::GoalResult(t) => read_lock(t)
+            TopicType::GoalResult(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PathPlan(t) => read_lock(t)
+            TopicType::PathPlan(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Input types
-            TopicType::JoystickInput(t) => read_lock(t)
+            TopicType::JoystickInput(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::KeyboardInput(t) => read_lock(t)
+            TopicType::KeyboardInput(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Detection/Perception types
-            TopicType::BoundingBox2D(t) => read_lock(t)
+            TopicType::BoundingBox2D(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::BoundingBox3D(t) => read_lock(t)
+            TopicType::BoundingBox3D(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Detection(t) => read_lock(t)
+            TopicType::Detection(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Detection3D(t) => read_lock(t)
+            TopicType::Detection3D(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::SegmentationMask(t) => read_lock(t)
+            TopicType::SegmentationMask(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Tracking types
-            TopicType::TrackedObject(t) => read_lock(t)
+            TopicType::TrackedObject(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::TrackingHeader(t) => read_lock(t)
+            TopicType::TrackingHeader(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Landmark types
-            TopicType::Landmark(t) => read_lock(t)
+            TopicType::Landmark(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Landmark3D(t) => read_lock(t)
+            TopicType::Landmark3D(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::LandmarkArray(t) => read_lock(t)
+            TopicType::LandmarkArray(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Perception helper types
-            TopicType::PointField(t) => read_lock(t)
+            TopicType::PointField(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PlaneDetection(t) => read_lock(t)
+            TopicType::PlaneDetection(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::PlaneArray(t) => read_lock(t)
+            TopicType::PlaneArray(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Vision types
-            TopicType::CompressedImage(t) => read_lock(t)
+            TopicType::CompressedImage(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::CameraInfo(t) => read_lock(t)
+            TopicType::CameraInfo(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::RegionOfInterest(t) => read_lock(t)
+            TopicType::RegionOfInterest(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::StereoInfo(t) => read_lock(t)
+            TopicType::StereoInfo(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Force types (additional)
-            TopicType::ImpedanceParameters(t) => read_lock(t)
+            TopicType::ImpedanceParameters(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::HapticFeedback(t) => read_lock(t)
+            TopicType::HapticFeedback(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::TactileArray(t) => read_lock(t)
+            TopicType::TactileArray(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Diagnostics types (additional)
-            TopicType::DiagnosticValue(t) => read_lock(t)
+            TopicType::DiagnosticValue(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::DiagnosticReport(t) => read_lock(t)
+            TopicType::DiagnosticReport(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::NodeHeartbeat(t) => read_lock(t)
+            TopicType::NodeHeartbeat(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::SafetyStatus(t) => read_lock(t)
+            TopicType::SafetyStatus(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
             // Navigation types (additional)
-            TopicType::Waypoint(t) => read_lock(t)
+            TopicType::Waypoint(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::NavPath(t) => read_lock(t)
+            TopicType::NavPath(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::VelocityObstacle(t) => read_lock(t)
+            TopicType::VelocityObstacle(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::VelocityObstacles(t) => read_lock(t)
+            TopicType::VelocityObstacles(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::OccupancyGrid(t) => read_lock(t)
+            TopicType::OccupancyGrid(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::CostMap(t) => read_lock(t)
+            TopicType::CostMap(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::AudioFrame(t) => read_lock(t)
+            TopicType::AudioFrame(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Tensor(t) => read_lock(t)
+            TopicType::Tensor(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
-            TopicType::Generic(t) => read_lock(t)
+            TopicType::Generic(t) => topic_lock(t)
                 .map(|g| g.backend_name().to_string())
                 .unwrap_or_default(),
         }
@@ -1060,101 +1070,101 @@ impl PyTopic {
             let dict = pyo3::types::PyDict::new(py);
 
             let metrics = match &self.topic_type {
-                TopicType::CmdVel(t) => read_lock(t)?.metrics(),
-                TopicType::Pose2D(t) => read_lock(t)?.metrics(),
-                TopicType::Pose3D(t) => read_lock(t)?.metrics(),
-                TopicType::Imu(t) => read_lock(t)?.metrics(),
-                TopicType::Odometry(t) => read_lock(t)?.metrics(),
-                TopicType::LaserScan(t) => read_lock(t)?.metrics(),
-                TopicType::JointState(t) => read_lock(t)?.metrics(),
-                TopicType::Clock(t) => read_lock(t)?.metrics(),
-                TopicType::TimeReference(t) => read_lock(t)?.metrics(),
-                TopicType::Image(t) => read_lock(t)?.metrics(),
-                TopicType::PointCloud(t) => read_lock(t)?.metrics(),
-                TopicType::DepthImage(t) => read_lock(t)?.metrics(),
+                TopicType::CmdVel(t) => topic_lock(t)?.metrics(),
+                TopicType::Pose2D(t) => topic_lock(t)?.metrics(),
+                TopicType::Pose3D(t) => topic_lock(t)?.metrics(),
+                TopicType::Imu(t) => topic_lock(t)?.metrics(),
+                TopicType::Odometry(t) => topic_lock(t)?.metrics(),
+                TopicType::LaserScan(t) => topic_lock(t)?.metrics(),
+                TopicType::JointState(t) => topic_lock(t)?.metrics(),
+                TopicType::Clock(t) => topic_lock(t)?.metrics(),
+                TopicType::TimeReference(t) => topic_lock(t)?.metrics(),
+                TopicType::Image(t) => topic_lock(t)?.metrics(),
+                TopicType::PointCloud(t) => topic_lock(t)?.metrics(),
+                TopicType::DepthImage(t) => topic_lock(t)?.metrics(),
                 // Geometry types
-                TopicType::Twist(t) => read_lock(t)?.metrics(),
-                TopicType::Vector3(t) => read_lock(t)?.metrics(),
-                TopicType::Point3(t) => read_lock(t)?.metrics(),
-                TopicType::Quaternion(t) => read_lock(t)?.metrics(),
-                TopicType::TransformStamped(t) => read_lock(t)?.metrics(),
-                TopicType::PoseStamped(t) => read_lock(t)?.metrics(),
-                TopicType::PoseWithCovariance(t) => read_lock(t)?.metrics(),
-                TopicType::TwistWithCovariance(t) => read_lock(t)?.metrics(),
-                TopicType::Accel(t) => read_lock(t)?.metrics(),
-                TopicType::AccelStamped(t) => read_lock(t)?.metrics(),
+                TopicType::Twist(t) => topic_lock(t)?.metrics(),
+                TopicType::Vector3(t) => topic_lock(t)?.metrics(),
+                TopicType::Point3(t) => topic_lock(t)?.metrics(),
+                TopicType::Quaternion(t) => topic_lock(t)?.metrics(),
+                TopicType::TransformStamped(t) => topic_lock(t)?.metrics(),
+                TopicType::PoseStamped(t) => topic_lock(t)?.metrics(),
+                TopicType::PoseWithCovariance(t) => topic_lock(t)?.metrics(),
+                TopicType::TwistWithCovariance(t) => topic_lock(t)?.metrics(),
+                TopicType::Accel(t) => topic_lock(t)?.metrics(),
+                TopicType::AccelStamped(t) => topic_lock(t)?.metrics(),
                 // Control types
-                TopicType::MotorCommand(t) => read_lock(t)?.metrics(),
-                TopicType::ServoCommand(t) => read_lock(t)?.metrics(),
-                TopicType::DifferentialDriveCommand(t) => read_lock(t)?.metrics(),
-                TopicType::PidConfig(t) => read_lock(t)?.metrics(),
-                TopicType::TrajectoryPoint(t) => read_lock(t)?.metrics(),
-                TopicType::JointCommand(t) => read_lock(t)?.metrics(),
+                TopicType::MotorCommand(t) => topic_lock(t)?.metrics(),
+                TopicType::ServoCommand(t) => topic_lock(t)?.metrics(),
+                TopicType::DifferentialDriveCommand(t) => topic_lock(t)?.metrics(),
+                TopicType::PidConfig(t) => topic_lock(t)?.metrics(),
+                TopicType::TrajectoryPoint(t) => topic_lock(t)?.metrics(),
+                TopicType::JointCommand(t) => topic_lock(t)?.metrics(),
                 // Sensor types
-                TopicType::RangeSensor(t) => read_lock(t)?.metrics(),
-                TopicType::BatteryState(t) => read_lock(t)?.metrics(),
-                TopicType::NavSatFix(t) => read_lock(t)?.metrics(),
-                TopicType::MagneticField(t) => read_lock(t)?.metrics(),
-                TopicType::Temperature(t) => read_lock(t)?.metrics(),
-                TopicType::FluidPressure(t) => read_lock(t)?.metrics(),
-                TopicType::Illuminance(t) => read_lock(t)?.metrics(),
+                TopicType::RangeSensor(t) => topic_lock(t)?.metrics(),
+                TopicType::BatteryState(t) => topic_lock(t)?.metrics(),
+                TopicType::NavSatFix(t) => topic_lock(t)?.metrics(),
+                TopicType::MagneticField(t) => topic_lock(t)?.metrics(),
+                TopicType::Temperature(t) => topic_lock(t)?.metrics(),
+                TopicType::FluidPressure(t) => topic_lock(t)?.metrics(),
+                TopicType::Illuminance(t) => topic_lock(t)?.metrics(),
                 // Diagnostics types
-                TopicType::Heartbeat(t) => read_lock(t)?.metrics(),
-                TopicType::DiagnosticStatus(t) => read_lock(t)?.metrics(),
-                TopicType::EmergencyStop(t) => read_lock(t)?.metrics(),
-                TopicType::ResourceUsage(t) => read_lock(t)?.metrics(),
+                TopicType::Heartbeat(t) => topic_lock(t)?.metrics(),
+                TopicType::DiagnosticStatus(t) => topic_lock(t)?.metrics(),
+                TopicType::EmergencyStop(t) => topic_lock(t)?.metrics(),
+                TopicType::ResourceUsage(t) => topic_lock(t)?.metrics(),
                 // Force types
-                TopicType::WrenchStamped(t) => read_lock(t)?.metrics(),
-                TopicType::ForceCommand(t) => read_lock(t)?.metrics(),
-                TopicType::ContactInfo(t) => read_lock(t)?.metrics(),
+                TopicType::WrenchStamped(t) => topic_lock(t)?.metrics(),
+                TopicType::ForceCommand(t) => topic_lock(t)?.metrics(),
+                TopicType::ContactInfo(t) => topic_lock(t)?.metrics(),
                 // Navigation types
-                TopicType::NavGoal(t) => read_lock(t)?.metrics(),
-                TopicType::GoalResult(t) => read_lock(t)?.metrics(),
-                TopicType::PathPlan(t) => read_lock(t)?.metrics(),
+                TopicType::NavGoal(t) => topic_lock(t)?.metrics(),
+                TopicType::GoalResult(t) => topic_lock(t)?.metrics(),
+                TopicType::PathPlan(t) => topic_lock(t)?.metrics(),
                 // Input types
-                TopicType::JoystickInput(t) => read_lock(t)?.metrics(),
-                TopicType::KeyboardInput(t) => read_lock(t)?.metrics(),
+                TopicType::JoystickInput(t) => topic_lock(t)?.metrics(),
+                TopicType::KeyboardInput(t) => topic_lock(t)?.metrics(),
                 // Detection/Perception types
-                TopicType::BoundingBox2D(t) => read_lock(t)?.metrics(),
-                TopicType::BoundingBox3D(t) => read_lock(t)?.metrics(),
-                TopicType::Detection(t) => read_lock(t)?.metrics(),
-                TopicType::Detection3D(t) => read_lock(t)?.metrics(),
-                TopicType::SegmentationMask(t) => read_lock(t)?.metrics(),
+                TopicType::BoundingBox2D(t) => topic_lock(t)?.metrics(),
+                TopicType::BoundingBox3D(t) => topic_lock(t)?.metrics(),
+                TopicType::Detection(t) => topic_lock(t)?.metrics(),
+                TopicType::Detection3D(t) => topic_lock(t)?.metrics(),
+                TopicType::SegmentationMask(t) => topic_lock(t)?.metrics(),
                 // Tracking types
-                TopicType::TrackedObject(t) => read_lock(t)?.metrics(),
-                TopicType::TrackingHeader(t) => read_lock(t)?.metrics(),
+                TopicType::TrackedObject(t) => topic_lock(t)?.metrics(),
+                TopicType::TrackingHeader(t) => topic_lock(t)?.metrics(),
                 // Landmark types
-                TopicType::Landmark(t) => read_lock(t)?.metrics(),
-                TopicType::Landmark3D(t) => read_lock(t)?.metrics(),
-                TopicType::LandmarkArray(t) => read_lock(t)?.metrics(),
+                TopicType::Landmark(t) => topic_lock(t)?.metrics(),
+                TopicType::Landmark3D(t) => topic_lock(t)?.metrics(),
+                TopicType::LandmarkArray(t) => topic_lock(t)?.metrics(),
                 // Perception helper types
-                TopicType::PointField(t) => read_lock(t)?.metrics(),
-                TopicType::PlaneDetection(t) => read_lock(t)?.metrics(),
-                TopicType::PlaneArray(t) => read_lock(t)?.metrics(),
+                TopicType::PointField(t) => topic_lock(t)?.metrics(),
+                TopicType::PlaneDetection(t) => topic_lock(t)?.metrics(),
+                TopicType::PlaneArray(t) => topic_lock(t)?.metrics(),
                 // Vision types
-                TopicType::CompressedImage(t) => read_lock(t)?.metrics(),
-                TopicType::CameraInfo(t) => read_lock(t)?.metrics(),
-                TopicType::RegionOfInterest(t) => read_lock(t)?.metrics(),
-                TopicType::StereoInfo(t) => read_lock(t)?.metrics(),
+                TopicType::CompressedImage(t) => topic_lock(t)?.metrics(),
+                TopicType::CameraInfo(t) => topic_lock(t)?.metrics(),
+                TopicType::RegionOfInterest(t) => topic_lock(t)?.metrics(),
+                TopicType::StereoInfo(t) => topic_lock(t)?.metrics(),
                 // Force types (additional)
-                TopicType::ImpedanceParameters(t) => read_lock(t)?.metrics(),
-                TopicType::HapticFeedback(t) => read_lock(t)?.metrics(),
-                TopicType::TactileArray(t) => read_lock(t)?.metrics(),
+                TopicType::ImpedanceParameters(t) => topic_lock(t)?.metrics(),
+                TopicType::HapticFeedback(t) => topic_lock(t)?.metrics(),
+                TopicType::TactileArray(t) => topic_lock(t)?.metrics(),
                 // Diagnostics types (additional)
-                TopicType::DiagnosticValue(t) => read_lock(t)?.metrics(),
-                TopicType::DiagnosticReport(t) => read_lock(t)?.metrics(),
-                TopicType::NodeHeartbeat(t) => read_lock(t)?.metrics(),
-                TopicType::SafetyStatus(t) => read_lock(t)?.metrics(),
+                TopicType::DiagnosticValue(t) => topic_lock(t)?.metrics(),
+                TopicType::DiagnosticReport(t) => topic_lock(t)?.metrics(),
+                TopicType::NodeHeartbeat(t) => topic_lock(t)?.metrics(),
+                TopicType::SafetyStatus(t) => topic_lock(t)?.metrics(),
                 // Navigation types (additional)
-                TopicType::Waypoint(t) => read_lock(t)?.metrics(),
-                TopicType::NavPath(t) => read_lock(t)?.metrics(),
-                TopicType::VelocityObstacle(t) => read_lock(t)?.metrics(),
-                TopicType::VelocityObstacles(t) => read_lock(t)?.metrics(),
-                TopicType::OccupancyGrid(t) => read_lock(t)?.metrics(),
-                TopicType::CostMap(t) => read_lock(t)?.metrics(),
-                TopicType::AudioFrame(t) => read_lock(t)?.metrics(),
-                TopicType::Tensor(t) => read_lock(t)?.metrics(),
-                TopicType::Generic(t) => read_lock(t)?.metrics(),
+                TopicType::Waypoint(t) => topic_lock(t)?.metrics(),
+                TopicType::NavPath(t) => topic_lock(t)?.metrics(),
+                TopicType::VelocityObstacle(t) => topic_lock(t)?.metrics(),
+                TopicType::VelocityObstacles(t) => topic_lock(t)?.metrics(),
+                TopicType::OccupancyGrid(t) => topic_lock(t)?.metrics(),
+                TopicType::CostMap(t) => topic_lock(t)?.metrics(),
+                TopicType::AudioFrame(t) => topic_lock(t)?.metrics(),
+                TopicType::Tensor(t) => topic_lock(t)?.metrics(),
+                TopicType::Generic(t) => topic_lock(t)?.metrics(),
             };
 
             dict.set_item("messages_sent", metrics.messages_sent())?;
@@ -1192,7 +1202,7 @@ impl PyTopic {
         topic_dispatch!(
             &self.topic_type,
             t,
-            read_lock(t).map(|g| g.pending_count()).unwrap_or(0)
+            topic_lock(t).map(|g| g.pending_count()).unwrap_or(0)
         )
     }
 
@@ -1204,7 +1214,7 @@ impl PyTopic {
         topic_dispatch!(
             &self.topic_type,
             t,
-            read_lock(t).map(|g| g.pub_count()).unwrap_or(0)
+            topic_lock(t).map(|g| g.pub_count()).unwrap_or(0)
         )
     }
 
@@ -1216,7 +1226,7 @@ impl PyTopic {
         topic_dispatch!(
             &self.topic_type,
             t,
-            read_lock(t).map(|g| g.sub_count()).unwrap_or(0)
+            topic_lock(t).map(|g| g.sub_count()).unwrap_or(0)
         )
     }
 
@@ -1236,7 +1246,7 @@ impl PyTopic {
         macro_rules! rl {
             ($t:expr, $py:expr, $PyT:ident) => {{
                 let tr = $t.clone();
-                let msg_opt = $py.detach(|| tr.read().expect("topic lock poisoned").read_latest());
+                let msg_opt = $py.detach(|| tr.lock().expect("topic lock poisoned").read_latest());
                 match msg_opt {
                     Some(msg) => Ok(Some(Py::new($py, $PyT { inner: msg })?.into_any())),
                     None => Ok(None),
@@ -1421,30 +1431,30 @@ where
 mod tests {
     use super::*;
 
-    /// read_lock succeeds on a healthy (non-poisoned) lock.
+    /// topic_lock succeeds on a healthy (non-poisoned) lock.
     /// PyResult can be constructed without a Python runtime.
     #[test]
-    fn read_lock_succeeds_on_healthy_lock() {
-        let lock = RwLock::new(42u32);
-        let guard = read_lock(&lock).expect("read_lock should succeed on healthy lock");
+    fn topic_lock_succeeds_on_healthy_lock() {
+        let lock = Mutex::new(42u32);
+        let guard = topic_lock(&lock).expect("topic_lock should succeed on healthy lock");
         assert_eq!(*guard, 42);
     }
 
-    /// read_lock returns Err on a poisoned lock.
+    /// topic_lock returns Err on a poisoned lock.
     #[test]
-    fn read_lock_returns_error_on_poisoned_lock() {
-        let lock = Arc::new(RwLock::new(42u32));
+    fn topic_lock_returns_error_on_poisoned_lock() {
+        let lock = Arc::new(Mutex::new(42u32));
         let lock2 = lock.clone();
 
-        // Poison the lock by panicking while holding a write guard
+        // Poison the lock by panicking while holding the guard
         let _ = std::thread::spawn(move || {
-            let _guard = lock2.write().unwrap();
+            let _guard = lock2.lock().unwrap();
             panic!("intentional poison");
         })
         .join();
 
-        let result = read_lock(&lock);
-        assert!(result.is_err(), "read_lock should fail on poisoned lock");
+        let result = topic_lock(&lock);
+        assert!(result.is_err(), "topic_lock should fail on poisoned lock");
     }
 
     /// log_py_callback does not panic on Err (it logs and swallows).
@@ -1454,17 +1464,24 @@ mod tests {
         log_py_callback(err_result, "test_method", "test_topic");
     }
 
-    /// Multiple concurrent readers can hold read_lock simultaneously.
+    /// INVERTED: this test used to assert that four threads could hold the
+    /// topic guard *simultaneously* — which is precisely the bug. A `Topic`
+    /// method mutates unsynchronised local state through `&self`, so the guard
+    /// must be exclusive. Four threads incrementing under it must produce
+    /// exactly four increments; with the old shared read guard the
+    /// read-modify-write could lose updates (and was UB besides).
     #[test]
-    fn read_lock_allows_concurrent_readers() {
-        let lock = Arc::new(RwLock::new(99u32));
+    fn topic_lock_is_exclusive_not_shared() {
+        let lock = Arc::new(Mutex::new(0u32));
 
         let handles: Vec<_> = (0..4)
             .map(|_| {
                 let lock = lock.clone();
                 std::thread::spawn(move || {
-                    let guard = read_lock(&lock).unwrap();
-                    assert_eq!(*guard, 99);
+                    for _ in 0..1000 {
+                        let mut guard = topic_lock(&lock).unwrap();
+                        *guard += 1;
+                    }
                 })
             })
             .collect();
@@ -1472,5 +1489,10 @@ mod tests {
         for h in handles {
             h.join().unwrap();
         }
+        assert_eq!(
+            *topic_lock(&lock).unwrap(),
+            4000,
+            "the topic guard must serialise all access, not just writers"
+        );
     }
 }

--- a/horus_sys/src/process/mod.rs
+++ b/horus_sys/src/process/mod.rs
@@ -317,16 +317,38 @@ pub fn is_zombie(pid: u32) -> bool {
     }
     #[cfg(target_os = "macos")]
     {
-        // SAFETY: proc_pidinfo with PROC_PIDTBSDINFO fills a proc_bsdinfo for a
-        // pid we already know exists; the same call is used by
-        // pid_start_time_macos below.
+        // The third argument is not spare padding: for the bsdinfo flavors a
+        // non-zero `arg` is precisely what asks XNU to look in the zombie list.
+        //
+        //     if (flavor == PROC_PIDTBSDINFO || ...) { if (arg) findzomb = 1; }
+        //     if ((p = proc_find(pid)) == PROC_NULL) {
+        //             if (findzomb) p = proc_find_zombref(pid);
+        //             if (p == PROC_NULL) { error = ESRCH; goto out; }
+        //             zombie = 1;
+        //     }
+        //
+        // and proc_find() deliberately refuses a process whose p_stat is SZOMB.
+        // So with arg = 0 the call returns ESRCH for exactly the processes this
+        // function exists to recognise — libproc turns that into a 0 return, the
+        // size check below fails, and every zombie was answered "not a zombie".
+        // macOS was therefore still running the pre-LIVE-12 behaviour Linux was
+        // fixed out of: a SIGKILLed node under a parent that never waits stayed
+        // Running forever and its SHM namespace was never reclaimed. Passing 1
+        // makes the zombie reachable, with pbi_status carrying the p_stat we
+        // came for. (pid_start_time_macos below deliberately keeps arg = 0: an
+        // unreadable start time reads as 0 there, which already means "treat
+        // this pid as gone", so a zombie needs no special case.)
+        //
+        // SAFETY: proc_pidinfo fills a caller-owned proc_bsdinfo; we hand it the
+        // struct's real size and only read the result back when the kernel
+        // reports having written exactly that many bytes.
         unsafe {
             let mut info: libc::proc_bsdinfo = std::mem::zeroed();
             let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
             let n = libc::proc_pidinfo(
                 pid as libc::c_int,
                 libc::PROC_PIDTBSDINFO,
-                0,
+                1, // non-zero = also search the zombie list; see above
                 &mut info as *mut _ as *mut libc::c_void,
                 size,
             );

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -157,8 +157,70 @@ pub(super) fn set_deadline_scheduling(
     }
 }
 
+/// Snapshot of the calling thread's scheduling policy and parameters.
+///
+/// Capability probes here mutate the *calling* thread, and the caller is not a
+/// throwaway: `RuntimeCapabilities::detect()` runs on whichever thread builds a
+/// `Scheduler`, which on a hard-RT deployment (`chrt -f 80 ./node`, or an
+/// earlier `RtConfig::apply()`) is already SCHED_FIFO. The probes used to
+/// "restore" a hardcoded SCHED_OTHER/priority 0, so detection silently demoted
+/// the very thread it then reported as RT-capable. Every probe must therefore
+/// either be reversible against what was really there, or not run at all.
+struct SchedSnapshot {
+    policy: i32,
+    param: libc::sched_param,
+}
+
+/// Read the current thread's scheduling policy and parameters.
+///
+/// Returns `None` when either query fails, which is the signal to decline the
+/// probe rather than guess at a restore target.
+fn snapshot_scheduling() -> Option<SchedSnapshot> {
+    // SAFETY: pid 0 = current thread; both calls only read, and `param` is a
+    // local POD struct for which all-zero is a valid bit pattern.
+    unsafe {
+        let policy = libc::sched_getscheduler(0);
+        if policy < 0 {
+            return None;
+        }
+        let mut param: libc::sched_param = std::mem::zeroed();
+        if libc::sched_getparam(0, &mut param) != 0 {
+            return None;
+        }
+        Some(SchedSnapshot { policy, param })
+    }
+}
+
+/// Put the calling thread back exactly where `snapshot_scheduling` found it.
+fn restore_scheduling(snapshot: &SchedSnapshot) {
+    // SAFETY: pid 0 = current thread; policy and param came from this thread.
+    let ret = unsafe { libc::sched_setscheduler(0, snapshot.policy, &snapshot.param) };
+    if ret != 0 {
+        // A demotion must never be silent — it costs the caller its RT guarantee.
+        log::warn!(
+            "RT capability probe failed to restore scheduling policy {} priority {}: {}",
+            snapshot.policy,
+            snapshot.param.sched_priority,
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
 /// Check if SCHED_DEADLINE is available on this kernel.
 pub(super) fn has_deadline_capability() -> bool {
+    // A thread already running SCHED_DEADLINE proves the kernel supports it,
+    // and probing would clobber its reservation.
+    // SAFETY: pid 0 = current thread; sched_getscheduler only reads.
+    if unsafe { libc::sched_getscheduler(0) } == SCHED_DEADLINE_POLICY as i32 {
+        return true;
+    }
+
+    // The probe below can unexpectedly succeed and move this thread onto
+    // SCHED_DEADLINE, so it is only safe to run if it can be undone exactly.
+    let Some(snapshot) = snapshot_scheduling() else {
+        return false;
+    };
+
     // Try with minimal valid params — kernel will reject with EPERM (no privilege)
     // or EBUSY (admission) but NOT ENOSYS (unsupported). ENOSYS means no support.
     let attr = SchedAttr {
@@ -174,11 +236,9 @@ pub(super) fn has_deadline_capability() -> bool {
     // SAFETY: dry-run probe — we expect this to fail (EPERM) but not ENOSYS.
     let result = unsafe { libc::syscall(SYS_SCHED_SETATTR, 0i32, &attr as *const _, 0u32) };
     if result == 0 {
-        // Unexpectedly succeeded — restore to SCHED_OTHER
-        let normal = sched_param_with_priority(0);
-        unsafe {
-            libc::sched_setscheduler(0, libc::SCHED_OTHER, &normal);
-        }
+        // Unexpectedly succeeded — put back the policy the thread actually had,
+        // not a hardcoded SCHED_OTHER.
+        restore_scheduling(&snapshot);
         return true;
     }
     let err = std::io::Error::last_os_error();
@@ -203,19 +263,59 @@ pub(super) fn lock_memory() -> anyhow::Result<()> {
     }
 }
 
-/// Check whether RT priority can be set (dry-run via sched_setscheduler).
+/// Check whether RT priority can be set.
+///
+/// Answered read-only wherever possible. The previous implementation probed by
+/// calling `sched_setscheduler(0, SCHED_FIFO, 1)` on the caller and then forcing
+/// SCHED_OTHER priority 0, so a thread deployed the normal hard-RT way was
+/// stripped of its real-time class by the very check that reported RT as
+/// available — and the scheduler's tick loop, which runs on that thread, then
+/// ran time-shared while `rt_priority_available` said otherwise.
 pub(super) fn can_set_rt_priority() -> bool {
-    // Try to set a low RT priority — if it succeeds, we have permission.
-    // Immediately restore to SCHED_OTHER afterward.
+    // A thread already on an RT policy demonstrably holds the privilege, so
+    // there is nothing to probe — and probing is exactly what used to break it.
+    // SAFETY: pid 0 = current thread; sched_getscheduler only reads.
+    let current_policy = unsafe { libc::sched_getscheduler(0) };
+    if current_policy == libc::SCHED_FIFO
+        || current_policy == libc::SCHED_RR
+        || current_policy == SCHED_DEADLINE_POLICY as i32
+    {
+        return true;
+    }
+
+    // Root can always raise the scheduling class.
+    // SAFETY: geteuid cannot fail and mutates nothing.
+    if unsafe { libc::geteuid() } == 0 {
+        return true;
+    }
+
+    // A non-zero RLIMIT_RTPRIO ceiling means unprivileged SCHED_FIFO is allowed.
+    // SAFETY: getrlimit only writes into the local rlimit struct.
+    let rtprio_allowed = unsafe {
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        libc::getrlimit(libc::RLIMIT_RTPRIO, &mut rlim) == 0 && rlim.rlim_cur > 0
+    };
+    if rtprio_allowed {
+        return true;
+    }
+
+    // Inconclusive — e.g. CAP_SYS_NICE granted with no RTPRIO ceiling. Fall back
+    // to the live probe, but only when it can be undone exactly; if the thread's
+    // current policy cannot be read back, decline to probe rather than risk
+    // leaving the caller on a scheduling class it never chose.
+    let Some(snapshot) = snapshot_scheduling() else {
+        return false;
+    };
+
     let param = sched_param_with_priority(1);
     // SAFETY: pid 0 = current thread; params are valid
     let result = unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &param) };
 
     if result == 0 {
-        // Restore normal scheduling
-        let normal_param = sched_param_with_priority(0);
-        // SAFETY: restoring to SCHED_OTHER
-        unsafe { libc::sched_setscheduler(0, libc::SCHED_OTHER, &normal_param) };
+        restore_scheduling(&snapshot);
         true
     } else {
         false

--- a/horus_sys/src/rt/mod.rs
+++ b/horus_sys/src/rt/mod.rs
@@ -394,6 +394,58 @@ mod tests {
         let _ = can_set_rt_priority(); // just verify it doesn't panic
     }
 
+    /// The capability probe must not change the caller's scheduling class.
+    ///
+    /// `RuntimeCapabilities::detect()` calls this on whichever thread builds a
+    /// `Scheduler`, and the scheduler's tick loop then runs on that same thread.
+    /// The probe used to set SCHED_FIFO and "restore" a hardcoded SCHED_OTHER
+    /// priority 0, so a process deployed with `chrt -f 80` had its tick loop
+    /// silently demoted to the time-sharing class while the detection it just
+    /// ran reported RT as available.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_can_set_rt_priority_leaves_thread_policy_untouched() {
+        // A scratch thread, so a failure here cannot disturb the rest of the
+        // suite. If the process happens to be privileged the thread is put on
+        // SCHED_FIFO first, which is the case that used to be destroyed.
+        std::thread::spawn(|| {
+            // SAFETY: pid 0 = current thread; sched_param is a POD struct for
+            // which all-zero is a valid bit pattern.
+            unsafe {
+                let mut param: libc::sched_param = std::mem::zeroed();
+                param.sched_priority = 10;
+                libc::sched_setscheduler(0, libc::SCHED_FIFO, &param);
+            }
+
+            // SAFETY: pid 0 = current thread; both calls only read.
+            let (policy_before, prio_before) = unsafe {
+                let mut param: libc::sched_param = std::mem::zeroed();
+                libc::sched_getparam(0, &mut param);
+                (libc::sched_getscheduler(0), param.sched_priority)
+            };
+
+            let _ = can_set_rt_priority();
+
+            // SAFETY: same read-only queries as above.
+            let (policy_after, prio_after) = unsafe {
+                let mut param: libc::sched_param = std::mem::zeroed();
+                libc::sched_getparam(0, &mut param);
+                (libc::sched_getscheduler(0), param.sched_priority)
+            };
+
+            assert_eq!(
+                policy_before, policy_after,
+                "can_set_rt_priority() changed the calling thread's scheduling policy"
+            );
+            assert_eq!(
+                prio_before, prio_after,
+                "can_set_rt_priority() changed the calling thread's priority"
+            );
+        })
+        .join()
+        .unwrap();
+    }
+
     #[test]
     fn test_pin_to_cores_empty_is_ok() {
         pin_to_cores(&[]).unwrap();

--- a/horus_sys/src/rt/windows.rs
+++ b/horus_sys/src/rt/windows.rs
@@ -13,7 +13,11 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
         preempt_rt: false,
         max_priority: 31, // Windows thread priorities range 0-31
         min_priority: 1,
-        memory_locking: true, // VirtualLock available
+        // `lock_memory()` below pins the working set with
+        // SetProcessWorkingSetSizeEx; nothing in this backend calls VirtualLock,
+        // and the pin needs SeIncreaseWorkingSetPrivilege, so this advertises
+        // only that a mechanism exists — not that it will succeed unelevated.
+        memory_locking: true,
         cpu_affinity: true,
         kernel_version: get_windows_version(),
         cpu_count,
@@ -56,17 +60,26 @@ pub(super) fn set_realtime_priority(_priority: i32) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Lock memory on Windows via SetProcessWorkingSetSize.
+/// Lock memory on Windows via SetProcessWorkingSetSizeEx.
 ///
 /// Windows has no `mlockall()` equivalent. Instead:
-/// 1. `SetProcessWorkingSetSize` with min=max pins the working set,
-///    preventing the OS from paging out process memory under pressure.
-/// 2. This is the closest Windows equivalent to Linux `mlockall(MCL_CURRENT)`.
+/// 1. `SetProcessWorkingSetSizeEx` with hard min/max limits pins the working
+///    set, preventing the OS from paging out process memory under pressure.
+/// 2. This is the closest Windows equivalent to Linux `mlockall(MCL_CURRENT)`,
+///    though still weaker: it bounds the working set rather than pinning every
+///    page.
 ///
-/// Note: Requires SeIncreaseWorkingSetPrivilege (granted by default to admins).
-/// On non-admin processes, this may fail silently — we log and return Ok.
+/// Requires SeIncreaseWorkingSetPrivilege (granted by default to admins).
+/// Failure returns `Err` rather than `Ok`: the `Result` is the only channel by
+/// which `RtConfig::apply()` learns memory was not locked, and swallowing the
+/// error here made a non-elevated process report `RtApplyResult::FullSuccess`
+/// while its RT nodes still took page-fault stalls. Returning `Err` lets
+/// RtConfig record an honest `RtDegradation::MemoryLockUnavailable`, matching
+/// the macOS stub.
 pub(super) fn lock_memory() -> anyhow::Result<()> {
-    use windows_sys::Win32::System::Memory::SetProcessWorkingSetSizeEx;
+    use windows_sys::Win32::System::Memory::{
+        SetProcessWorkingSetSizeEx, QUOTA_LIMITS_HARDWS_MAX_ENABLE, QUOTA_LIMITS_HARDWS_MIN_ENABLE,
+    };
     use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
     // Get current working set size to compute minimum
@@ -78,25 +91,28 @@ pub(super) fn lock_memory() -> anyhow::Result<()> {
     let min_ws: usize = 256 * 1024 * 1024; // 256 MB
     let max_ws: usize = 512 * 1024 * 1024; // 512 MB
 
+    // Flags 0 requests *soft* limits, which the OS may ignore under pressure —
+    // the opposite of what the previous comment here claimed. MIN_ENABLE |
+    // MAX_ENABLE is what actually enforces the limits as hard.
+    let flags = QUOTA_LIMITS_HARDWS_MIN_ENABLE | QUOTA_LIMITS_HARDWS_MAX_ENABLE;
+
     // SAFETY: process is a valid pseudo-handle from GetCurrentProcess.
-    // Flags=0 means hard min/max limits (QUOTA_LIMITS_HARDWS_MIN_ENABLE | MAX_ENABLE)
-    let result = unsafe { SetProcessWorkingSetSizeEx(process, min_ws, max_ws, 0) };
+    let result = unsafe { SetProcessWorkingSetSizeEx(process, min_ws, max_ws, flags) };
 
     if result == 0 {
         let err = std::io::Error::last_os_error();
-        log::warn!(
-            "Windows: SetProcessWorkingSetSize failed (non-fatal): {}. \
-             RT nodes may experience occasional page fault jitter. \
-             Run as administrator for guaranteed memory locking.",
+        anyhow::bail!(
+            "SetProcessWorkingSetSizeEx failed: {}. Windows working-set pinning \
+             requires SeIncreaseWorkingSetPrivilege; run elevated for memory locking.",
             err
         );
-    } else {
-        log::debug!(
-            "Windows: Working set pinned to {}-{} MB (memory locked)",
-            min_ws / (1024 * 1024),
-            max_ws / (1024 * 1024)
-        );
     }
+
+    log::debug!(
+        "Windows: Working set pinned to {}-{} MB (hard limits)",
+        min_ws / (1024 * 1024),
+        max_ws / (1024 * 1024)
+    );
 
     Ok(())
 }

--- a/horus_sys/src/shm/fallback.rs
+++ b/horus_sys/src/shm/fallback.rs
@@ -28,6 +28,19 @@ impl ShmRegion {
         let file = OpenOptions::new().read(true).write(true).open(&path)?;
         let size = file.metadata()?.len() as usize;
         anyhow::ensure!(size >= minimum_size, "existing SHM region is too small");
+        // Take the same shared lock `new()` does. The module contract is that
+        // *every* holder keeps LOCK_SH for the lifetime of its region — that is
+        // what makes the last-one-out check in `drop` correct. A holder that
+        // joined here without the lock was invisible to it.
+        //
+        // SAFETY: file.as_raw_fd() is a valid open fd; LOCK_SH is a valid flock op.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH) } != 0 {
+            anyhow::bail!(
+                "Failed to acquire shared lock on SHM file '{}': {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            );
+        }
         let mmap = unsafe { MmapOptions::new().len(size).map_mut(&file)? };
         Ok(Self {
             mmap,
@@ -177,9 +190,34 @@ impl ShmRegion {
 
 impl Drop for ShmRegion {
     fn drop(&mut self) {
-        if self.owner && self.path.exists() {
+        // Remove the backing file only if nobody else still has it open.
+        //
+        // "Owner" records only who won the race to create the file, which says
+        // nothing about who is still using it. Removing on that basis alone
+        // broke the ordinary publisher restart: the creator exited, took the
+        // file with it, every subscriber stayed mapped to an orphaned inode that
+        // nobody would write to again, and the next publisher created a fresh
+        // file — two groups on different memory, no error on either side. This
+        // is the same non-blocking LOCK_EX last-one-out test the Linux backend
+        // uses; the LOCK_SH taken in `new()`/`open_existing()` is what it reads.
+        //
+        // Deliberately not gated on `self.owner`: whoever turns out to be last
+        // does the cleanup, or a region whose creator left first would survive
+        // until the filesystem is cleaned by hand.
+        //
+        // SAFETY: `_file` is open for the whole lifetime of `self`, so the fd is
+        // valid here; LOCK_EX | LOCK_NB is a valid flock operation.
+        let sole_holder =
+            unsafe { libc::flock(self._file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 };
+        if !sole_holder {
+            // Another holder still has it mapped — leave the region alone.
+            return;
+        }
+
+        if self.path.exists() {
             let _ = std::fs::remove_file(&self.path);
         }
+        // The exclusive lock is released with the fd when `_file` drops.
     }
 }
 

--- a/horus_sys/src/shm/macos.rs
+++ b/horus_sys/src/shm/macos.rs
@@ -1,6 +1,7 @@
 // macOS shared memory: POSIX shm_open() + mmap (Mach shared memory, RAM-backed)
 
 use anyhow::Result;
+use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 
 /// Poll the size of an open SHM fd via fstat.
@@ -37,6 +38,32 @@ fn wait_for_shm_init(fd: i32, expected_size: usize) -> std::result::Result<(), (
     Err(())
 }
 
+/// Take a shared lock that marks this process as a live holder of `name`.
+///
+/// This is the macOS answer to the Linux backend's last-one-out test (see
+/// `shm/linux.rs`'s `Drop`): unlinking on creator-ownership alone orphans every
+/// subscriber that outlives its publisher, and the restarted publisher then
+/// creates a second, unrelated section with nothing on either side detecting it.
+/// Darwin's `flock()` rejects a POSIX shm descriptor, so the shm fd cannot carry
+/// the lock — the topic's `.meta` sidecar can, and every holder opens it.
+///
+/// Best-effort: the sidecar is only metadata, so a failure here degrades to the
+/// old creator-only rule rather than failing the region outright.
+fn acquire_holder_lock(name: &str, create: bool) -> Option<std::fs::File> {
+    let path = super::shm_topics_dir().join(format!("{}.meta", super::sanitize_namespace(name)));
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(create)
+        .create(create)
+        .open(&path)
+        .ok()?;
+    // SAFETY: file.as_raw_fd() is a valid open fd; LOCK_SH is a valid flock op.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH) } != 0 {
+        return None;
+    }
+    Some(file)
+}
+
 /// Cross-platform shared memory region for high-performance IPC.
 ///
 /// macOS backend: POSIX `shm_open()` (Mach shared memory, RAM-backed).
@@ -48,6 +75,9 @@ pub struct ShmRegion {
     topic_name: String,
     size: usize,
     owner: bool,
+    /// Shared flock held for the region's lifetime so `Drop` can tell whether
+    /// anyone else is still mapped. Kept alive until after that check.
+    lock_file: Option<std::fs::File>,
 }
 
 impl ShmRegion {
@@ -80,11 +110,17 @@ impl ShmRegion {
             unsafe { libc::close(fd) };
             anyhow::bail!("existing SHM region is too small");
         }
+        // PROT_READ|PROT_WRITE, not PROT_READ. `ShmRegion` exposes one safe API
+        // across four backends and `as_slice_mut()` promises a writable slice;
+        // mapping read-only here made that slice a reference whose permissions
+        // do not match the memory, so code that works on Linux took SIGBUS on
+        // macOS at the first store. The fd above is already O_RDWR, so the
+        // writable mapping is permitted.
         let ptr = unsafe {
             libc::mmap(
                 std::ptr::null_mut(),
                 size as usize,
-                libc::PROT_READ,
+                libc::PROT_READ | libc::PROT_WRITE,
                 libc::MAP_SHARED,
                 fd,
                 0,
@@ -94,6 +130,9 @@ impl ShmRegion {
             unsafe { libc::close(fd) };
             anyhow::bail!("shm mmap failed: {}", std::io::Error::last_os_error());
         }
+        // Join the holder set so the creator cannot unlink this region out from
+        // under us. Attaching must never create the sidecar.
+        let lock_file = acquire_holder_lock(name, false);
         Ok(Self {
             ptr: ptr as *mut u8,
             fd,
@@ -101,6 +140,7 @@ impl ShmRegion {
             topic_name: name.to_string(),
             size: size as usize,
             owner: false,
+            lock_file,
         })
     }
 
@@ -253,6 +293,11 @@ impl ShmRegion {
             let _ = super::write_topic_meta(name, size);
         }
 
+        // Every holder — creator or not — keeps a shared lock on the sidecar for
+        // the lifetime of the region; that is what makes the last-one-out test
+        // in `Drop` correct.
+        let lock_file = acquire_holder_lock(name, is_owner);
+
         Ok(Self {
             ptr: ptr as *mut u8,
             fd,
@@ -260,6 +305,7 @@ impl ShmRegion {
             topic_name: name.to_string(),
             size,
             owner: is_owner,
+            lock_file,
         })
     }
 
@@ -323,10 +369,14 @@ impl ShmRegion {
             std::io::Error::last_os_error()
         );
 
-        // Unmap old region
-        libc::munmap(self.ptr as *mut libc::c_void, self.size);
-
-        // Map the larger region
+        // Map the larger region FIRST; the old mapping stays valid until it
+        // succeeds. Tearing the old one down first meant the `ensure!` below
+        // returned with `self.ptr`/`self.size` still describing address space
+        // that had just been unmapped, so `as_ptr()`/`as_slice()`/
+        // `as_slice_mut()` handed out dangling pointers and `Drop` munmapped the
+        // range a second time. Two MAP_SHARED views of the same shm fd may
+        // coexist, so nothing requires the munmap to come first. This matches
+        // the Linux and Windows backends, which already map before releasing.
         let new_ptr = libc::mmap(
             std::ptr::null_mut(),
             new_size,
@@ -340,6 +390,9 @@ impl ShmRegion {
             "mmap after grow failed: {}",
             std::io::Error::last_os_error()
         );
+
+        // Only now release the old mapping.
+        libc::munmap(self.ptr as *mut libc::c_void, self.size);
 
         self.ptr = new_ptr as *mut u8;
         self.size = new_size;
@@ -356,13 +409,40 @@ impl Drop for ShmRegion {
             libc::close(self.fd);
         }
 
-        if self.owner {
-            super::remove_topic_meta(&self.topic_name);
-            if let Ok(c_name) = std::ffi::CString::new(self.shm_name.clone()) {
-                // SAFETY: c_name is a valid null-terminated CString
-                unsafe { libc::shm_unlink(c_name.as_ptr()) };
-            }
+        // Unlink only if nobody else still has this region open.
+        //
+        // "Owner" records only who won the race to create the section, which
+        // says nothing about who is still using it. Unlinking on that basis
+        // alone broke the ordinary publisher restart: the creator exited, took
+        // the name with it, every subscriber stayed mapped to a section nobody
+        // would write to again, and the restarted publisher's
+        // `shm_open(O_CREAT|O_EXCL)` succeeded against the freed name and
+        // created a *second* one. Neither side saw an error. The Linux backend
+        // fixed this with a non-blocking LOCK_EX last-one-out test; this is the
+        // same test, taken on the `.meta` sidecar because Darwin's `flock()`
+        // rejects a POSIX shm descriptor.
+        //
+        // Deliberately not gated on `self.owner`: whoever turns out to be last
+        // does the cleanup, or a region whose creator left first would survive
+        // until reboot.
+        let sole_holder = match &self.lock_file {
+            // SAFETY: the File is open for the whole lifetime of `self`, so the
+            // fd is valid here; LOCK_EX | LOCK_NB is a valid flock operation.
+            Some(f) => unsafe { libc::flock(f.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 },
+            // No sidecar lock available: fall back to the old creator rule
+            // rather than leaking the region forever.
+            None => self.owner,
+        };
+        if !sole_holder {
+            return;
         }
+
+        super::remove_topic_meta(&self.topic_name);
+        if let Ok(c_name) = std::ffi::CString::new(self.shm_name.clone()) {
+            // SAFETY: c_name is a valid null-terminated CString
+            unsafe { libc::shm_unlink(c_name.as_ptr()) };
+        }
+        // The exclusive lock is released with the fd when `lock_file` drops.
     }
 }
 

--- a/horus_sys/src/shm/mod.rs
+++ b/horus_sys/src/shm/mod.rs
@@ -46,11 +46,12 @@ fn sanitize_namespace(ns: &str) -> String {
         .collect()
 }
 
-/// A namespace private to one cargo target directory, for test binaries.
+/// A namespace private to one cargo build directory, for test binaries.
 ///
-/// Cargo builds test harnesses — and the helper binaries they spawn — into
-/// `<target>/<profile>/deps/`. Anything running from there is a test, and tests
-/// must not share shared memory with anything else on the machine.
+/// Cargo builds test harnesses — and the helper binaries they spawn — into its
+/// own subdirectories of `<target>/<profile>/`. Anything running from there is
+/// a test, and tests must not share shared memory with anything else on the
+/// machine.
 ///
 /// Without this, every `cargo test` ran in the `"default"` namespace: the same
 /// one a robot uses. Two test runs on one box — two developers, two CI jobs, a
@@ -59,38 +60,118 @@ fn sanitize_namespace(ns: &str) -> String {
 /// `cargo test` could also disturb a robot running on the same machine, and
 /// `horus clean --shm` from a test would wipe its regions.
 ///
-/// Keying on the target directory rather than the binary keeps a harness and
+/// Keying on `<target>/<profile>` rather than on the binary keeps a harness and
 /// the helpers it spawns together — `cross_process` and `peer_process` share a
 /// `deps/` — while separating unrelated checkouts, which have different targets.
 ///
-/// Returns `None` for anything not under a `deps/` directory, so `cargo run`
-/// binaries and an installed `horus` stay in `"default"` and keep seeing each
-/// other, which is what a developer expects.
+/// Returns `None` for anything cargo did not build for its own use, so
+/// `cargo run` binaries and an installed `horus` stay in `"default"` and keep
+/// seeing each other, which is what a developer expects.
 fn cargo_test_namespace() -> Option<String> {
-    namespace_for_exe(&std::env::current_exe().ok()?)
+    let exe = std::env::current_exe().ok()?;
+    if let Some(ns) = namespace_for_exe(&exe) {
+        return Some(ns);
+    }
+
+    // A build of *this* crate carrying `cfg(test)` is a test harness by
+    // construction, whatever path it was launched from, so there is nothing
+    // left to infer from the layout. The path rule above still has to carry
+    // every other crate's harness and the helpers tests spawn; this arm only
+    // removes horus_sys's own tests from depending on it, which matters because
+    // the sanitizer jobs build with `-Zbuild-std --target <triple>` and a test
+    // binary quietly falling back to `"default"` is the exact corruption this
+    // function exists to prevent.
+    if cfg!(test) {
+        return Some(namespace_for_dir(exe.parent()?));
+    }
+
+    None
 }
 
-/// The namespace [`cargo_test_namespace`] would derive for a given executable
+/// The namespace `cargo_test_namespace` would derive for a given executable
 /// path. Split out so the rule is testable against paths this process is not
 /// actually running from.
+///
+/// An executable is one cargo built for its own use when either:
+/// - it sits in a `deps/` directory — the classic
+///   `<target>/<profile>/deps/<name>-<metadata>` layout; or
+/// - its file name carries cargo's metadata suffix: `-` followed by 16 hex
+///   digits. Cargo stamps that onto every artifact it builds and strips it only
+///   when it uplifts a *final* binary to `<target>/<profile>/<name>`, so the
+///   suffix marks a file cargo runs itself, never one a person installs, ships,
+///   or launches on a robot.
+///
+/// The second rule is what holds under the sanitizer jobs: they build with
+/// `-Zbuild-std --target <triple>`, which does not leave the harness in the
+/// plain `<profile>/deps/` shape the first rule was written for. Without it
+/// those runs landed in the shared `"default"` namespace, beside whatever else
+/// was using shared memory on the machine.
 fn namespace_for_exe(exe: &std::path::Path) -> Option<String> {
-    let deps = exe.parent()?;
-    if deps.file_name()? != "deps" {
+    let dir = exe.parent()?;
+    let built_by_cargo_for_itself =
+        dir.file_name().is_some_and(|n| n == "deps") || has_cargo_metadata_suffix(exe);
+    if !built_by_cargo_for_itself {
         return None;
     }
-    // <target>/<profile>/deps -> <target>/<profile>. Keeping the profile in
-    // means a `cargo test` and a `cargo test --release` running side by side
-    // are separated too, while a harness and the helpers it spawns — same
-    // profile, same `deps/` — stay together.
-    let target_root = deps.parent()?;
 
-    // FNV-1a over the path: short, stable, and no dependency.
+    // Key on <target>/<profile>. Keeping the profile in means a `cargo test`
+    // and a `cargo test --release` running side by side are separated too,
+    // while a harness and the helpers it spawns — same profile, same build —
+    // stay together. The fallback covers an artifact that carries the metadata
+    // suffix from a directory cargo's own layout does not explain: keying on
+    // where it sits is still better than sharing the robot's namespace.
+    let build_root = cargo_build_root(exe).unwrap_or(dir);
+    Some(namespace_for_dir(build_root))
+}
+
+/// Does this file name carry cargo's build-metadata suffix — `-` + 16 hex digits?
+fn has_cargo_metadata_suffix(exe: &std::path::Path) -> bool {
+    // `file_stem`, so a Windows `.exe` is off before the suffix is read.
+    let Some(stem) = exe.file_stem().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let Some((name, metadata)) = stem.rsplit_once('-') else {
+        return false;
+    };
+    !name.is_empty()
+        && metadata.len() == 16
+        && metadata
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// The `<target>/<profile>` directory an executable was built into, found by
+/// walking up through cargo's own subdirectories of it.
+///
+/// `deps/` holds the test harnesses; `build/<pkg>-<metadata>/out/` holds what a
+/// build script produced. Both sit directly in the profile directory, so the
+/// parent of one of them is that directory. The *outermost* match is the one to
+/// take: it keeps every artifact of a build under one namespace however deeply
+/// cargo nested it.
+fn cargo_build_root(exe: &std::path::Path) -> Option<&std::path::Path> {
+    let mut profile_dir = None;
+    // `ancestors()` yields the path itself first; skip it, since what is being
+    // matched here are directories the executable lives under.
+    for dir in exe.ancestors().skip(1) {
+        if matches!(
+            dir.file_name().and_then(|n| n.to_str()),
+            Some("deps" | "build")
+        ) {
+            profile_dir = dir.parent();
+        }
+    }
+    profile_dir
+}
+
+/// FNV-1a over a directory path, rendered as a `test_<hash>` namespace: short,
+/// stable across the processes of one build, and no dependency.
+fn namespace_for_dir(dir: &std::path::Path) -> String {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in target_root.as_os_str().as_encoded_bytes() {
+    for byte in dir.as_os_str().as_encoded_bytes() {
         hash ^= *byte as u64;
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    Some(format!("test_{hash:016x}"))
+    format!("test_{hash:016x}")
 }
 
 /// Generate the SHM namespace for this process without caching.
@@ -98,7 +179,7 @@ fn namespace_for_exe(exe: &std::path::Path) -> Option<String> {
 /// Priority:
 /// 1. `HORUS_NAMESPACE` env var (set by horus_manager when launching node graphs)
 /// 2. A namespace private to the cargo target directory, when this process is a
-///    test binary — see [`cargo_test_namespace`]
+///    test binary — see `cargo_test_namespace`
 /// 3. Otherwise the fixed shared namespace `"default"` (ROS 2 domain-0 model:
 ///    every process on the machine shares one namespace). Multi-robot isolation
 ///    is opt-in — set `HORUS_NAMESPACE` (or a launch-config `namespace`) per robot.
@@ -833,7 +914,7 @@ pub fn parse_namespace_sid(dir_name: &str) -> Option<(i32, u32)> {
 /// a pid that still answers `kill(pid, 0)` but belongs to a process that has
 /// exited and not yet been reaped is dead. Without the zombie test a session
 /// leader killed under a parent that never waits kept its whole SHM namespace
-/// marked `alive`, so [`list_namespaces`] reported it as live and
+/// marked `alive`, so [`list_all_horus_namespaces`] reported it as live and
 /// [`cleanup_stale_namespaces`] refused to reclaim it — the same defect the
 /// node list had.
 #[cfg(unix)]
@@ -1103,7 +1184,7 @@ mod tests {
     /// LIVE-12: namespace liveness is a second liveness check, and it used to
     /// have its own raw `kill(sid, 0)` with no zombie test — so a session
     /// leader killed under a parent that never reaps kept its SHM namespace
-    /// reported alive by `list_namespaces` and skipped by
+    /// reported alive by `list_all_horus_namespaces` and skipped by
     /// `cleanup_stale_namespaces` forever.
     #[test]
     #[cfg(unix)]
@@ -1457,6 +1538,60 @@ mod tests {
         );
         assert_eq!(
             namespace_for_exe(std::path::Path::new("/usr/local/bin/horus")),
+            None
+        );
+    }
+
+    #[test]
+    fn a_harness_built_for_an_explicit_target_is_still_a_test_binary() {
+        // The ASan and TSan jobs build with `-Zbuild-std --target
+        // x86_64-unknown-linux-gnu`, which does not leave the harness in the
+        // plain `<profile>/deps/` shape — it ends up under the profile's
+        // `build/.../out/`. The `deps/`-only rule returned None there, so those
+        // runs used the shared "default" namespace: a test binary writing to a
+        // robot's shared memory, which is exactly what this rule forbids.
+        let ns = namespace_for_exe(std::path::Path::new(
+            "/w/target/x86_64-unknown-linux-gnu/debug/build/horus_sys-754ee89886aac265/out/horus_sys-754ee89886aac265",
+        ));
+        assert!(
+            ns.is_some(),
+            "a harness under <profile>/build/ is still a test binary, got {ns:?}"
+        );
+        // ...and it is keyed on <target>/<profile> like every other artifact of
+        // that build, so a harness and the binaries it spawns from `deps/` of
+        // the same build still share one namespace.
+        assert_eq!(
+            ns,
+            namespace_for_exe(std::path::Path::new(
+                "/w/target/x86_64-unknown-linux-gnu/debug/deps/horus_sys-0123456789abcdef",
+            ))
+        );
+        // A different --target is a different build directory, so it is separate.
+        assert_ne!(
+            ns,
+            namespace_for_exe(std::path::Path::new(
+                "/w/target/aarch64-unknown-linux-gnu/debug/deps/horus_sys-0123456789abcdef",
+            ))
+        );
+    }
+
+    #[test]
+    fn a_shipped_binary_in_a_build_directory_stays_in_the_shared_namespace() {
+        // `build/` is one of cargo's directories, but it is also where every
+        // C++ project puts its output — horus_cpp's own examples included. Only
+        // cargo's metadata suffix (`-` + 16 hex digits) marks a file cargo runs
+        // itself, so a real binary that happens to live in a `build/` tree, or
+        // that merely has a dash in its name, keeps the shared namespace.
+        assert_eq!(
+            namespace_for_exe(std::path::Path::new("/w/horus_cpp/build/horus_talker")),
+            None
+        );
+        assert_eq!(
+            namespace_for_exe(std::path::Path::new("/usr/local/bin/horus-cli")),
+            None
+        );
+        assert_eq!(
+            namespace_for_exe(std::path::Path::new("/opt/robot/bin/horus-v2")),
             None
         );
     }

--- a/horus_sys/src/shm/windows.rs
+++ b/horus_sys/src/shm/windows.rs
@@ -4,6 +4,23 @@
 
 use anyhow::Result;
 
+/// Kernel object name for a topic's file mapping, as a NUL-terminated UTF-16
+/// string.
+///
+/// `new()`, `open_existing()` and `grow_unchecked()` must agree on this string
+/// or they address different kernel objects. `grow_unchecked` built its name
+/// from the bare topic name, omitting the `Local\horus_` prefix, so it created
+/// an unrelated private section and silently forked the topic: the grower
+/// published into the new object while every other process stayed attached to
+/// the real one, frozen at the moment of the grow with no error on either side.
+/// Defining the name once is what stops the three call sites drifting again.
+fn mapping_name_wide(name: &str) -> Vec<u16> {
+    format!("Local\\horus_{}", name)
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
 /// Cross-platform shared memory region for high-performance IPC.
 ///
 /// Windows backend: `CreateFileMappingW` with pagefile backing.
@@ -22,26 +39,63 @@ impl ShmRegion {
         anyhow::ensure!(minimum_size > 0, "SHM region size must be > 0");
         super::validate_region_name(name)?;
         use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
-        use windows_sys::Win32::System::Memory::{MapViewOfFile, OpenFileMappingW, FILE_MAP_READ};
-        let mapping_name = format!("Local\\horus_{}", name);
-        let wide_name: Vec<u16> = mapping_name.encode_utf16().chain([0]).collect();
-        let handle = unsafe { OpenFileMappingW(FILE_MAP_READ, 0, wide_name.as_ptr()) };
+        use windows_sys::Win32::System::Memory::{
+            MapViewOfFile, OpenFileMappingW, UnmapViewOfFile, VirtualQuery, FILE_MAP_ALL_ACCESS,
+            MEMORY_BASIC_INFORMATION, MEMORY_MAPPED_VIEW_ADDRESS,
+        };
+        // FILE_MAP_ALL_ACCESS, not FILE_MAP_READ. `as_slice_mut()` promises a
+        // writable slice on every backend and Linux honours it; a read-only view
+        // here turned the first store into an access violation, so safe code
+        // that works on Linux crashed on Windows.
+        let wide_name = mapping_name_wide(name);
+        let handle = unsafe { OpenFileMappingW(FILE_MAP_ALL_ACCESS, 0, wide_name.as_ptr()) };
         if handle.is_null() {
             anyhow::bail!("OpenFileMappingW failed: error {}", unsafe {
                 GetLastError()
             });
         }
-        let view = unsafe { MapViewOfFile(handle, FILE_MAP_READ, 0, 0, minimum_size) };
+        // Map the whole section (length 0) rather than just `minimum_size`, so
+        // `len()`/`as_slice()` describe the region the creator actually made —
+        // the macOS and Linux backends take their size from fstat/metadata, and
+        // storing `minimum_size` here made the same region report different
+        // lengths depending on the platform.
+        let view = unsafe { MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, 0) };
         let ptr = view.Value as *mut u8;
         if ptr.is_null() {
+            let err = unsafe { GetLastError() };
             unsafe { CloseHandle(handle) };
-            anyhow::bail!("MapViewOfFile failed: error {}", unsafe { GetLastError() });
+            anyhow::bail!("MapViewOfFile failed: error {}", err);
+        }
+        // VirtualQuery reports the extent of the mapped view; fall back to the
+        // caller's minimum if the query fails rather than claiming a size we did
+        // not measure.
+        let size = unsafe {
+            let mut info: MEMORY_BASIC_INFORMATION = std::mem::zeroed();
+            let written = VirtualQuery(
+                ptr as *const std::ffi::c_void,
+                &mut info,
+                std::mem::size_of::<MEMORY_BASIC_INFORMATION>(),
+            );
+            if written == 0 {
+                minimum_size
+            } else {
+                info.RegionSize
+            }
+        };
+        if size < minimum_size {
+            unsafe {
+                UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
+                    Value: ptr as *mut std::ffi::c_void,
+                });
+                CloseHandle(handle);
+            }
+            anyhow::bail!("existing SHM region is too small");
         }
         Ok(Self {
             ptr,
             handle,
             topic_name: name.to_string(),
-            size: minimum_size,
+            size,
             owner: false,
         })
     }
@@ -57,12 +111,7 @@ impl ShmRegion {
             CreateFileMappingW, MapViewOfFile, FILE_MAP_ALL_ACCESS, PAGE_READWRITE,
         };
 
-        let mapping_name = format!("Local\\horus_{}", name);
-
-        let wide_name: Vec<u16> = mapping_name
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let wide_name = mapping_name_wide(name);
 
         // SAFETY: INVALID_HANDLE_VALUE creates pagefile-backed mapping; wide_name is valid
         let handle = unsafe {
@@ -152,8 +201,21 @@ impl ShmRegion {
 
     /// Grow the region to `new_size` bytes without synchronization.
     ///
-    /// On Windows, file mappings cannot be resized in place. This creates a new
-    /// mapping with the larger size and copies data from the old mapping.
+    /// # Limitation
+    ///
+    /// A named Windows section cannot be resized, so this call is expected to
+    /// FAIL on Windows: it re-opens `Local\horus_<topic>` — the topic's real
+    /// kernel object — and `MapViewOfFile` refuses a view larger than the
+    /// existing section. Failing loudly is the point. Building the name from the
+    /// bare topic name instead created a private, unrelated section and reported
+    /// success, which forked the topic: the grower published into memory nobody
+    /// else was mapped to, and every subscriber sat on a sequence counter that
+    /// would never advance again.
+    ///
+    /// Real Windows growth needs a generation counter published in the topic
+    /// header (`Local\horus_<topic>_g<n>`), with other processes re-opening the
+    /// new generation by name when they observe the migration epoch change.
+    /// Until that exists, Windows auto-grow is unsupported.
     ///
     /// # Safety
     ///
@@ -173,12 +235,8 @@ impl ShmRegion {
             self.size
         );
 
-        // Create a new file mapping with the larger size
-        let name: Vec<u16> = self
-            .topic_name
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        // Same name every other call site uses — see `mapping_name_wide`.
+        let name = mapping_name_wide(&self.topic_name);
         let new_handle = CreateFileMappingW(
             INVALID_HANDLE_VALUE,
             std::ptr::null(),
@@ -194,11 +252,18 @@ impl ShmRegion {
         );
 
         let new_ptr = MapViewOfFile(new_handle, FILE_MAP_ALL_ACCESS, 0, 0, new_size);
-        anyhow::ensure!(
-            !new_ptr.Value.is_null(),
-            "MapViewOfFile for grow failed: {}",
-            std::io::Error::last_os_error()
-        );
+        if new_ptr.Value.is_null() {
+            // Capture the error before CloseHandle, which clobbers it. Without
+            // this close, every failed grow leaked a kernel handle and the
+            // pagefile-backed section it keeps alive.
+            let err = std::io::Error::last_os_error();
+            CloseHandle(new_handle);
+            anyhow::bail!(
+                "MapViewOfFile for grow failed: {}. A named Windows section \
+                 cannot be resized in place; Windows auto-grow is unsupported.",
+                err
+            );
+        }
 
         // Copy old data to new mapping
         std::ptr::copy_nonoverlapping(self.ptr, new_ptr.Value as *mut u8, self.size);

--- a/horus_sys/tests/parity_process.rs
+++ b/horus_sys/tests/parity_process.rs
@@ -157,6 +157,65 @@ fn test_pid_start_time_stable() {
     assert_eq!(st1, st2, "start time must be stable for same PID");
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Zombie (exited-but-unreaped) Processes
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Ask the operating system — never `horus_sys` — whether `pid` is a zombie.
+///
+/// This is the precondition for the test below, so it has to come from outside
+/// the code under test: asking `is_zombie()` whether the fixture is a zombie
+/// would let a broken liveness check certify its own bug, and asking
+/// `is_alive()` would make the test tautological.
+///
+/// Both branches read the kernel's own state character, which is the technique
+/// `process::spawn_unreaped_zombie` uses for the unit tests. That helper is
+/// `pub(crate)` and cannot be reached from an integration test, so it is
+/// mirrored here rather than answering "is this a zombie" a third way — if the
+/// two ever disagree, the unit and parity suites would be testing different
+/// things.
+///
+/// Linux publishes the state in the third field of `/proc/{pid}/stat`, read
+/// after the *last* `)` because the comm field sitting in front of it may
+/// itself contain spaces and parentheses. macOS has no `/proc`, so `ps` reports
+/// the same letter out of the kernel's `p_stat` (`Z`, usually suffixed: `Z+`).
+#[cfg(unix)]
+fn os_reports_zombie(pid: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap_or_default();
+        stat.rfind(')')
+            .and_then(|i| stat[i + 1..].split_whitespace().next())
+            .is_some_and(|state| state == "Z")
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::process::Command::new("ps")
+            .args(["-o", "state=", "-p", &pid.to_string()])
+            .output()
+            .ok()
+            .is_some_and(|out| String::from_utf8_lossy(&out.stdout).trim().starts_with('Z'))
+    }
+}
+
+/// Block until `pid` is observably a zombie, or give up after five seconds.
+///
+/// Exit is asynchronous from the parent's point of view, so the state has to be
+/// polled rather than assumed to have arrived by some sleep.
+#[cfg(unix)]
+fn wait_for_zombie(pid: u32) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if os_reports_zombie(pid) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 /// A killed-but-unreaped process is not alive.
 ///
 /// `kill(pid, 0)` succeeds for a zombie: the process has exited, but its entry
@@ -167,6 +226,15 @@ fn test_pid_start_time_stable() {
 ///
 /// Under `horus run` the parent reaps within milliseconds, which is why this
 /// looked like a brief blip rather than the unbounded state it is.
+///
+/// This test used to detect the zombie state through `/proc` alone and return
+/// early with a "SKIP" line everywhere else, which meant the one suite whose
+/// job is catching cross-platform divergence asserted nothing at all on macOS —
+/// and stayed green for the whole time `is_zombie()` was answering "not a
+/// zombie" for every zombie there (LIVE-12). A platform this fixture cannot be
+/// built on is a result to report, not a test to drop, so the fallback below
+/// asks `ps` instead of skipping, and failing to observe the state is a
+/// failure.
 #[cfg(unix)]
 #[test]
 fn a_killed_but_unreaped_process_is_not_alive() {
@@ -185,28 +253,15 @@ fn a_killed_but_unreaped_process_is_not_alive() {
     let handle = ProcessHandle::from_pid(pid);
 
     // Wait for it to actually become a zombie rather than assuming a timing.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    let mut became_zombie = false;
-    while std::time::Instant::now() < deadline {
-        let state = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok();
-        let is_z = state
-            .as_deref()
-            .and_then(|c| c.rfind(')').map(|i| &c[i + 1..]))
-            .and_then(|rest| rest.split_whitespace().next())
-            .map(|s| s == "Z")
-            .unwrap_or(false);
-        if is_z {
-            became_zombie = true;
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-
-    if !became_zombie {
-        // Not all platforms expose /proc; nothing to assert about.
+    if !wait_for_zombie(pid) {
+        // Reap first: the panic must not also leak the child.
         let _ = child.wait();
-        eprintln!("SKIP: could not observe the child as a zombie on this platform");
-        return;
+        panic!(
+            "pid {pid} never showed up as a zombie within 5s, so this test could not \
+             put the platform in the state it exists to check. Nothing has reaped the \
+             child — this process is its parent and has not waited on it — so either \
+             the state query above is wrong for this platform or the child never ran."
+        );
     }
 
     assert!(

--- a/horus_sys/tests/parity_shm.rs
+++ b/horus_sys/tests/parity_shm.rs
@@ -98,6 +98,83 @@ fn test_shm_rejects_empty_name() {
     assert!(result.is_err(), "empty name should be rejected");
 }
 
+/// A name no other run can collide with.
+///
+/// The two tests below assert on *ownership*, so a region left behind by an
+/// aborted earlier run would make the first `new()` attach instead of create and
+/// the assertion would fail for the wrong reason.
+fn unique_name(prefix: &str) -> String {
+    format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    )
+}
+
+/// A region joined through `open_existing` must be writable on every backend.
+///
+/// `as_slice_mut()` promises a `&mut [u8]` in the one API all four backends
+/// share, but macOS mapped `PROT_READ` and Windows `FILE_MAP_READ` in
+/// `open_existing`, so the same safe code that worked on Linux took SIGBUS /
+/// EXCEPTION_ACCESS_VIOLATION at its first store. Nothing in this suite ever
+/// built a region through `open_existing`, which is why the divergence survived.
+#[test]
+fn test_shm_open_existing_view_is_writable() {
+    let name = unique_name("parity_open_existing_rw");
+    let creator = shm::ShmRegion::new(&name, 4096).unwrap();
+
+    let mut joiner = shm::ShmRegion::open_existing(&name, 4096).unwrap();
+    joiner.as_slice_mut()[0] = 0xAB;
+
+    assert_eq!(
+        creator.as_slice()[0],
+        0xAB,
+        "a write through open_existing's view must be visible to the creator"
+    );
+
+    drop(joiner);
+    drop(creator);
+}
+
+/// The creator leaving must not take the region away from the other holders.
+///
+/// "Owner" records only who won the race to create the region. Cleaning up on
+/// that basis alone breaks the ordinary publisher restart: the creator exits,
+/// the subscribers stay mapped to something nobody will write to again, and the
+/// restarted publisher creates a *second* region with no error on either side.
+#[test]
+fn test_shm_creator_drop_does_not_orphan_other_holders() {
+    let name = unique_name("parity_holder_lifetime");
+    let creator = shm::ShmRegion::new(&name, 4096).unwrap();
+    assert!(creator.is_owner(), "sanity: first caller creates the region");
+
+    let mut joiner = shm::ShmRegion::open_existing(&name, 4096).unwrap();
+
+    // The creator leaves first — the common case when a publisher restarts.
+    drop(creator);
+
+    // The surviving holder still has live, writable memory.
+    joiner.as_slice_mut()[0] = 0x5A;
+    assert_eq!(joiner.as_slice()[0], 0x5A);
+
+    // And the restarted publisher joins the SAME region rather than creating a
+    // second one alongside it.
+    let restarted = shm::ShmRegion::new(&name, 4096).unwrap();
+    assert!(
+        !restarted.is_owner(),
+        "the region was removed while another holder still had it mapped, so \
+         the restarted publisher created a second one; its subscribers would \
+         wait forever on memory it never writes to"
+    );
+
+    drop(restarted);
+    drop(joiner);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Group 2: TopicMeta CRUD
 // ═══════════════════════════════════════════════════════════════════════════

--- a/horus_sys/tests/parity_shm.rs
+++ b/horus_sys/tests/parity_shm.rs
@@ -150,7 +150,10 @@ fn test_shm_open_existing_view_is_writable() {
 fn test_shm_creator_drop_does_not_orphan_other_holders() {
     let name = unique_name("parity_holder_lifetime");
     let creator = shm::ShmRegion::new(&name, 4096).unwrap();
-    assert!(creator.is_owner(), "sanity: first caller creates the region");
+    assert!(
+        creator.is_owner(),
+        "sanity: first caller creates the region"
+    );
 
     let mut joiner = shm::ShmRegion::open_existing(&name, 4096).unwrap();
 

--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,13 @@ mv "$CLONE_DIR" "$HORUS_SRC_DIR"
 CLONE_DIR=""
 ok "Source cached at ~/.horus/cache/horus@${SRC_VERSION}"
 
-TMPDIR=$(mktemp -d)
+# NOT the exported POSIX TMPDIR: that is the variable mktemp, cc/ld, rustc,
+# cargo, git and rustup's own installer all consult, and assigning to it here
+# handed every child process a scratch directory that the cleanup below then
+# deleted. Use a private name, and clean up from a single EXIT trap so the temp
+# dir also goes away on the error paths and on a `set -e` abort mid-download.
+HORUS_TMP=$(mktemp -d)
+trap 'rm -rf "${HORUS_TMP:-}" "${CLONE_DIR:-}"' EXIT
 
 # HORUS_BUILD_FROM_SOURCE=1 skips the pre-built binary entirely and compiles the
 # cached source. This is the documented escape hatch when the checksum
@@ -238,7 +244,7 @@ if [ "${HORUS_BUILD_FROM_SOURCE:-0}" = "1" ]; then
     HTTP_CODE="000"
 else
     info "Checking for pre-built binary..."
-    HTTP_CODE=$(curl -fsSL -o "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" -w "%{http_code}" "$RELEASE_URL" 2>/dev/null || echo "000")
+    HTTP_CODE=$(curl -fsSL -o "${HORUS_TMP}/${ASSET_NAME}.${ASSET_EXT}" -w "%{http_code}" "$RELEASE_URL" 2>/dev/null || echo "000")
 fi
 
 # Refuse early on a toolchain that cannot build HORUS.
@@ -265,7 +271,7 @@ check_rust_version() {
     ok "Rust $found (>= $required required)"
 }
 
-if [ "$HTTP_CODE" = "200" ] && [ -s "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" ]; then
+if [ "$HTTP_CODE" = "200" ] && [ -s "${HORUS_TMP}/${ASSET_NAME}.${ASSET_EXT}" ]; then
     # --- Fast path: pre-built binary, skip the compile ---
 
     # Verify the download against the release's published SHA256SUMS before
@@ -275,24 +281,21 @@ if [ "$HTTP_CODE" = "200" ] && [ -s "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" ]; th
     # installer never fetched it, so a tampered or truncated asset was executed
     # unchecked. TLS alone does not cover a compromised or substituted asset.
     info "Verifying checksum..."
-    if curl -fsSL -o "${TMPDIR}/SHA256SUMS" "$CHECKSUM_URL" 2>/dev/null && [ -s "${TMPDIR}/SHA256SUMS" ]; then
-        EXPECTED=$(grep " ${ASSET_NAME}.${ASSET_EXT}\$" "${TMPDIR}/SHA256SUMS" 2>/dev/null | awk '{print $1}' | head -1)
+    if curl -fsSL -o "${HORUS_TMP}/SHA256SUMS" "$CHECKSUM_URL" 2>/dev/null && [ -s "${HORUS_TMP}/SHA256SUMS" ]; then
+        EXPECTED=$(grep " ${ASSET_NAME}.${ASSET_EXT}\$" "${HORUS_TMP}/SHA256SUMS" 2>/dev/null | awk '{print $1}' | head -1)
         if [ -z "$EXPECTED" ]; then
-            rm -rf "$TMPDIR"
             fail "SHA256SUMS has no entry for ${ASSET_NAME}.${ASSET_EXT}. Refusing to install an unverified binary."
             exit 1
         fi
         if command -v sha256sum >/dev/null 2>&1; then
-            ACTUAL=$(sha256sum "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" | awk '{print $1}')
+            ACTUAL=$(sha256sum "${HORUS_TMP}/${ASSET_NAME}.${ASSET_EXT}" | awk '{print $1}')
         elif command -v shasum >/dev/null 2>&1; then
-            ACTUAL=$(shasum -a 256 "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" | awk '{print $1}')
+            ACTUAL=$(shasum -a 256 "${HORUS_TMP}/${ASSET_NAME}.${ASSET_EXT}" | awk '{print $1}')
         else
-            rm -rf "$TMPDIR"
             fail "Neither sha256sum nor shasum is available, so the download cannot be verified. Install one, or build from source with HORUS_BUILD_FROM_SOURCE=1."
             exit 1
         fi
         if [ "$EXPECTED" != "$ACTUAL" ]; then
-            rm -rf "$TMPDIR"
             fail "Checksum MISMATCH for ${ASSET_NAME}.${ASSET_EXT}"
             fail "  expected: $EXPECTED"
             fail "  actual:   $ACTUAL"
@@ -301,7 +304,6 @@ if [ "$HTTP_CODE" = "200" ] && [ -s "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" ]; th
         fi
         ok "Checksum verified"
     else
-        rm -rf "$TMPDIR"
         fail "Could not fetch SHA256SUMS from $CHECKSUM_URL — refusing to install an unverified binary."
         fail "Build from source instead: HORUS_BUILD_FROM_SOURCE=1 $0"
         exit 1
@@ -309,18 +311,16 @@ if [ "$HTTP_CODE" = "200" ] && [ -s "${TMPDIR}/${ASSET_NAME}.${ASSET_EXT}" ]; th
 
     info "Extracting binary..."
     if [ "$OS" = "windows" ]; then
-        unzip -q "${TMPDIR}/${ASSET_NAME}.zip" -d "$TMPDIR"
+        unzip -q "${HORUS_TMP}/${ASSET_NAME}.zip" -d "$HORUS_TMP"
     else
-        tar xzf "${TMPDIR}/${ASSET_NAME}.tar.gz" -C "$TMPDIR"
+        tar xzf "${HORUS_TMP}/${ASSET_NAME}.tar.gz" -C "$HORUS_TMP"
     fi
-    chmod +x "${TMPDIR}/${BINARY_NAME}" 2>/dev/null || true
-    mv "${TMPDIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
-    rm -rf "$TMPDIR"
+    chmod +x "${HORUS_TMP}/${BINARY_NAME}" 2>/dev/null || true
+    mv "${HORUS_TMP}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
     ok "Downloaded pre-built binary"
 
 else
     # --- Slow path: compile the cached source ---
-    rm -rf "$TMPDIR"
     warn "No pre-built binary for ${OS}-${ARCH} — building from source (~3-5 min)"
     echo ""
 

--- a/install.sh
+++ b/install.sh
@@ -185,21 +185,46 @@ fi
 
 info "Fetching HORUS source (${BRANCH})..."
 CLONE_DIR=$(mktemp -d)
-if ! git clone --depth 1 --branch "$BRANCH" "https://github.com/${REPO}.git" "$CLONE_DIR" 2>&1 | tail -1; then
+CLONE_LOG=$(mktemp)
+# `git clone ... 2>&1 | tail -1` used to be the guard here, but this script sets
+# `set -e` without `set -o pipefail`, so a pipeline reports *tail*'s status: the
+# failure branch was dead code and a failed clone sailed on to the rm -rf below.
+# Redirect to a log instead, test git's own status, and show the real error.
+if ! git clone --depth 1 --branch "$BRANCH" "https://github.com/${REPO}.git" "$CLONE_DIR" >"$CLONE_LOG" 2>&1; then
     fail "Failed to clone https://github.com/${REPO}.git (branch: ${BRANCH})"
+    tail -20 "$CLONE_LOG"
+    rm -rf "$CLONE_DIR" "$CLONE_LOG"
+    exit 1
+fi
+rm -f "$CLONE_LOG"
+
+# A clone can also exit 0 with a tree that is unusable to `horus run`.
+# horus/Cargo.toml is the exact marker find_horus_source_dir() looks for
+# (run_rust.rs), and horus_core/Cargo.toml is what SRC_VERSION parses below.
+# Both are checked *before* the destructive rm -rf further down, so a bad fetch
+# can never delete a working cached source tree.
+if [ ! -f "${CLONE_DIR}/horus/Cargo.toml" ] || [ ! -f "${CLONE_DIR}/horus_core/Cargo.toml" ]; then
+    fail "Fetched tree for branch '${BRANCH}' is incomplete (no horus/Cargo.toml)"
     rm -rf "$CLONE_DIR"
     exit 1
 fi
 
 # Version the cache dir by the crate version so multiple installs coexist and
-# find_horus_source_dir() can prefer the tree matching the running CLI.
-SRC_VERSION=$(grep -m1 '^version' "${CLONE_DIR}/horus_core/Cargo.toml" 2>/dev/null | sed 's/.*"\(.*\)".*/\1/')
-[ -n "$SRC_VERSION" ] || SRC_VERSION="unknown"
+# find_horus_source_dir() can prefer the tree matching the running CLI. An
+# unparseable version used to fall back to "unknown" and cache the tree anyway;
+# that only hid the failure until the first `horus run`.
+SRC_VERSION=$(grep -m1 '^version' "${CLONE_DIR}/horus_core/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+if [ -z "$SRC_VERSION" ]; then
+    fail "Could not parse version from horus_core/Cargo.toml"
+    rm -rf "$CLONE_DIR"
+    exit 1
+fi
 HORUS_SRC_DIR="${HORUS_CACHE}/horus@${SRC_VERSION}"
 
 mkdir -p "$HORUS_CACHE"
 rm -rf "$HORUS_SRC_DIR"
 mv "$CLONE_DIR" "$HORUS_SRC_DIR"
+CLONE_DIR=""
 ok "Source cached at ~/.horus/cache/horus@${SRC_VERSION}"
 
 TMPDIR=$(mktemp -d)

--- a/scripts/setup-realtime.sh
+++ b/scripts/setup-realtime.sh
@@ -168,10 +168,19 @@ else
     # memlock and nice -20. Any local user can then lock all of RAM, or run a
     # SCHED_FIFO 99 spinner that preempts the kernel's own threads — and on a
     # robot, preempts the very control loops these limits exist to protect.
+    #
+    # The two "Created ..." / "LOG OUT" echoes used to sit *after* this if/else,
+    # so the skip branch — the normal case under cloud-init, Docker, systemd and
+    # Ansible's `become`, all of which leave SUDO_USER empty — reported a limits
+    # file it had not written. RT nodes then came up without SCHED_FIFO on a
+    # machine whose setup script had said "complete!". Report per branch, and
+    # remember the skip so the final summary does not claim success either.
     RT_USER="${SUDO_USER:-}"
     if [ -z "$RT_USER" ] || [ "$RT_USER" = "root" ]; then
+        rt_limits_skipped=true
         echo -e "  ${YELLOW}${WARN}${NC} Could not determine the invoking user (SUDO_USER unset)."
-        echo -e "  ${YELLOW}${WARN}${NC} Skipping RT limits. Re-run as: sudo $0"
+        echo -e "  ${YELLOW}${WARN}${NC} Skipping RT limits — $LIMITS_FILE was NOT written."
+        echo -e "  ${YELLOW}${WARN}${NC} Re-run as: sudo $0"
         echo -e "      Or add these lines to $LIMITS_FILE for the account running HORUS:"
         echo -e "        <user>  -  rtprio   99"
         echo -e "        <user>  -  memlock  unlimited"
@@ -190,9 +199,9 @@ $RT_USER    hard    memlock    unlimited
 $RT_USER    soft    nice       -20
 $RT_USER    hard    nice       -20
 LIMEOF
+        echo -e "  ${GREEN}${OK}${NC} Created $LIMITS_FILE"
+        echo -e "  ${YELLOW}${WARN}${NC} LOG OUT and LOG BACK IN for limits to take effect"
     fi
-    echo -e "  ${GREEN}${OK}${NC} Created $LIMITS_FILE"
-    echo -e "  ${YELLOW}${WARN}${NC} LOG OUT and LOG BACK IN for limits to take effect"
 fi
 
 echo ""
@@ -238,25 +247,35 @@ echo -e "${CYAN}${INFO}${NC} Kernel Parameters"
 SYSCTL_FILE="/etc/sysctl.d/99-horus-realtime.conf"
 
 if $check_only; then
-    shmmax=$(sysctl -n kernel.shmmax 2>/dev/null || echo "0")
     timer_slack=$(sysctl -n kernel.timer_migration 2>/dev/null || echo "unknown")
-    echo "  kernel.shmmax: $shmmax"
+    swappiness=$(sysctl -n vm.swappiness 2>/dev/null || echo "unknown")
     echo "  kernel.timer_migration: $timer_slack"
+    echo "  vm.swappiness: $swappiness"
 else
+    # This file used to set kernel.shmmax = 256 MiB and kernel.shmall = 65536
+    # *pages* under a comment claiming it maximized shared memory. Since Linux
+    # 4.14 both default to effectively unlimited, so the file permanently cut a
+    # system-wide limit by orders of magnitude for every process on the host —
+    # enough to stop PostgreSQL and any other SysV-shm user from starting. It
+    # did nothing for HORUS either: HORUS IPC is POSIX shm on /dev/shm (see
+    # section 3 above), which is bounded by the tmpfs mount size, not by
+    # shmmax/shmall. Both lines are therefore gone rather than raised.
     cat > "$SYSCTL_FILE" << 'SYSEOF'
 # HORUS Real-Time Kernel Parameters
-# Maximize shared memory for high-throughput IPC
-kernel.shmmax = 268435456
-kernel.shmall = 65536
-
 # Disable timer migration for better RT latency
 kernel.timer_migration = 0
 
 # Reduce VM swappiness for robotics workloads
 vm.swappiness = 10
 SYSEOF
-    sysctl -p "$SYSCTL_FILE" 2>/dev/null || true
-    echo -e "  ${GREEN}${OK}${NC} Applied kernel parameters ($SYSCTL_FILE)"
+    # `2>/dev/null || true` announced "Applied" even when the kernel rejected a
+    # parameter. `|| true` has to stay under `set -e`; the status gates the
+    # message instead, and stderr is left visible.
+    if sysctl -p "$SYSCTL_FILE"; then
+        echo -e "  ${GREEN}${OK}${NC} Applied kernel parameters ($SYSCTL_FILE)"
+    else
+        echo -e "  ${YELLOW}${WARN}${NC} Wrote $SYSCTL_FILE but sysctl -p reported errors"
+    fi
 fi
 
 echo ""
@@ -306,6 +325,16 @@ echo -e "${CYAN}═════════════════════�
 
 if $check_only; then
     echo -e "${CYAN}${INFO}${NC} Check complete. Run without --check to apply fixes."
+elif [ "${rt_limits_skipped:-false}" = "true" ]; then
+    # Not "complete": the RT limits file was never written, so ulimit -r stays
+    # at 0 and every RT node will silently fall back to normal priority.
+    echo -e "${YELLOW}${WARN}${NC} Real-time configuration completed WITH WARNINGS."
+    echo -e "${YELLOW}${WARN}${NC} $LIMITS_FILE was not written — RT scheduling is NOT enabled."
+    echo ""
+    echo "  Verify with:"
+    echo -e "    ${CYAN}ulimit -r${NC}    # Shows 0 until the limits file exists"
+    echo ""
+    exit 1
 else
     echo -e "${GREEN}${OK}${NC} Real-time configuration complete!"
     echo ""


### PR DESCRIPTION
Seven workflows were red on main. Each had its own cause, and several were masking the next one behind them.

## What was failing

| Workflow | Cause |
|---|---|
| CI · Check, Clippy | `--all-targets` builds horus_py's lib **test** target, tripping the deliberate `compile_error!` guarding the default `extension-module` feature |
| CI · Test | six deprecated `colored::ColoredString::fgcolor` calls, fatal under main's `-D warnings` |
| CI · Documentation | two broken rustdoc intra-doc links |
| Feature Matrix · Minimal | `BlackBoxEvent` stub drift — 5 × E0559 |
| Feature Matrix · All Features | `create_reference_result` arity + 12 dead bindings |
| Cross-Platform Parity · Cross-Compile | same stub drift |
| Cross-Platform Parity · macOS | zombie detection wrong on macOS |
| Multi-Platform · Windows | path-addressed topic access assumes a file-backed region |
| Integration Tests | test asserting superseded send semantics |
| Docs Contract | "hermetic" tier ran tests that need a docs checkout; pin was stale |
| Safety · ASan, TSan | nightly installed without rustfmt; test-binary detection too narrow |

## Three findings worth reading

**Fixing Check unmasked work rather than finishing it.** Clippy had been aborting before it ever linted `horus_core`, and Documentation before it documented anything past `horus_sys`. Once past the horus_py guard, 13 genuine pre-existing findings appeared. All are fixed here — no `#[allow]` was added anywhere.

**The macOS bug had a matching coverage bug.** `parity_process.rs::a_killed_but_unreaped_process_is_not_alive` — the integration test named for that exact behaviour — detected zombies only through `/proc` and `eprintln!("SKIP")`d on macOS without asserting. The parity suite reported green for as long as the bug existed. Fixed alongside it.

**The stub enum will drift again.** `BlackBoxEvent` has two definitions and construction sites are not feature-gated, so drift is invisible in every default build. Beyond the `severity` field that broke the build, the stub was missing four `Net*` variants and carried a `PodSnapshot` that does not exist in the real enum — both latent breaks for horus_net and horus_manager. Re-synced field-for-field with a comment on the invariant, but the durable fix is to stop forking the enum at all. Left as follow-up.

## Verification

Every job was run locally with `RUSTFLAGS="-D warnings"`, matching main:

```
ci-fmt ✔  ci-check ✔  ci-check-py ✔  ci-clippy ✔  ci-clippy-py ✔  ci-doc ✔
fm-min-core ✔  fm-min-{horus,types,net,sys} ✔  fm-all-features ✔
par-sys-lib ✔  par-process ✔  par-shm ✔
dc-hermetic ✔  dc-live 14/14 ✔  dc-cli 7/7 ✔  dc-manifest 6/6 ✔  dc-scaffold ✔  dc-behavior ✔
it-dx ✔
```

⚠️ **The macOS and Windows fixes are reasoned, not executed** — I have no access to either platform. They are the reason this is a PR: the matrix here is the first real test of them.

## Cross-repo coordination

`DOCS_PINNED_REF` points at **softmata/horus-docs#6** (`f1b9762`), a branch head rather than a commit on main. That is deliberate and temporary — this repo's Docs Contract cannot go green until those docs changes exist somewhere fetchable. **When that PR merges, re-pin to the resulting main commit, and do not delete the branch first**: this pin is the only ref keeping `f1b9762` reachable.

`MANIFEST_SCHEMA_URL` also still named `docs.horus-registry.dev` long after horus-docs made `docs.horusrobotics.dev` canonical — the one URL in this repository that no longer resolved to the docs, and stamped into every `$schema` field `horus schema` writes.

Generated with [Claude Code](https://claude.com/claude-code)