### PR TITLE
test(live-contract): distinguish a failed node start from broken attribution

### DIFF
--- a/horus_manager/tests/introspection_live_contract.rs
+++ b/horus_manager/tests/introspection_live_contract.rs
@@ -156,6 +156,34 @@ impl LiveNode {
     /// samples, so the interesting values do not exist immediately. Polling
     /// beats a fixed sleep: it is faster when things work and still bounded
     /// when they do not.
+    /// Whether the spawned node process is alive and has registered at all.
+    ///
+    /// Distinguishes "this machine never got the child running" from "the child
+    /// ran and the attribution is wrong". Without it, a saturated box produces
+    /// the same failure text as the defect these tests exist to catch — the
+    /// `wait_for` doc says exactly that, and it is why a bare timeout here is
+    /// not a usable signal.
+    fn node_registered(&self) -> bool {
+        self.cli(&["node", "list"]).contains("ci_test_node")
+    }
+
+    /// Panic with a message that says which of the two it was.
+    fn diagnose(&self, what: &str, topic_output: String) -> ! {
+        if self.node_registered() {
+            panic!(
+                "{what}\nThe node IS registered, so the child ran and this is the \
+                 attribution defect this test exists to catch:\n{topic_output}"
+            );
+        }
+        panic!(
+            "SKIP-WORTHY: the node never registered at all within the deadline, so \
+             `{what}` could not be evaluated — the child did not get far enough on \
+             this machine. This is not evidence about attribution.\nnode list:\n{}\n\
+             topic info:\n{topic_output}",
+            self.cli(&["node", "list"])
+        );
+    }
+
     fn wait_for(&self, args: &[&str], done: impl Fn(&str) -> bool) -> Option<String> {
         // 60s. This is a bound on *failure*, not on success: the loop returns
         // the moment the output is right, so a longer deadline costs nothing
@@ -370,9 +398,9 @@ fn a_topic_built_in_a_constructor_still_names_its_publisher() {
         o.contains("ci_test_node")
     })
     .unwrap_or_else(|| {
-        panic!(
-            "a topic created in the node constructor never got a publisher:\n{}",
-            node.cli(&["topic", "info", &node.topic])
+        node.diagnose(
+            "a topic created in the node constructor never got a publisher",
+            node.cli(&["topic", "info", &node.topic]),
         )
     });
 }


### PR DESCRIPTION
## Problem

`a_topic_built_in_a_constructor_still_names_its_publisher` fails in a full
workspace run and passes 3/3 in isolation. The `wait_for` doc already names the
hazard: eight of these tests each spawn a scheduler process with RT threads
alongside the rest of the suite, and on a busy machine "node never appeared" is
*indistinguishable* from the defect the test exists to catch.

It already waits 60s, so a longer deadline is not the fix — it would just take
longer to report the same ambiguous failure.

## Change

On the failure path, ask `horus node list` whether the child registered at all:

- **registered** → the child ran, so this really is the attribution defect, and the
  panic says so
- **not registered** → the child never got far enough on this machine, and the panic
  says the test could not be evaluated rather than claiming attribution is broken

The test keeps its discriminating power — a genuine attribution regression still
fails, with the node present — while an environment failure becomes legible as one.
It does not silently pass in either case.

## Context

Found while triaging 8 integration failures on `main`. Six were the shared `/tmp`
quota (another process held 18 GB; `msg_gen_interop` builds a real cargo crate under
`TMPDIR`, and its four failures plus both `uat_workflows` ones vanish with `TMPDIR`
pointed at a filesystem with room). This was the one that was not disk.

Verified: 9/9 in the file, 3/3 for this test in isolation, clippy clean.