### PR TITLE
test(manager): build scratch projects under target/, not /tmp

### DIFF
--- a/horus_manager/tests/msg_gen_interop.rs
+++ b/horus_manager/tests/msg_gen_interop.rs
@@ -29,6 +29,17 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
+/// A scratch directory under the workspace's `target/`, created if absent.
+///
+/// `CARGO_TARGET_TMPDIR` is cargo's own scratch directory for integration tests,
+/// but it is only guaranteed to be set — not to exist, since `cargo clean` or a
+/// hand `rm -rf target/tmp` removes it. Create it rather than fail on it.
+fn scratch_root() -> &'static str {
+    let root = env!("CARGO_TARGET_TMPDIR");
+    let _ = std::fs::create_dir_all(root);
+    root
+}
+
 fn horus() -> &'static str {
     env!("CARGO_BIN_EXE_horus")
 }
@@ -84,7 +95,28 @@ const POSE_YX: &str = "    y: f32,\n    x: f32,\n";
 
 /// Generate a project without building anything. Cheap: no cargo.
 fn generated_project(defs: &str) -> (tempfile::TempDir, PathBuf) {
-    let tmp = tempfile::tempdir().expect("tempdir");
+    // Under the workspace's `target/`, not `$TMPDIR`.
+    //
+    // Every test here builds a generated crate that depends on `horus_core`, in
+    // a target directory under this project — so a run of this file is three
+    // full builds of the workspace. `tempfile::tempdir()` puts those on `/tmp`,
+    // which is a tmpfs, and they do not fit alongside everything else on the
+    // box: all four of these tests failed with `Disk quota exceeded (os error
+    // 122)` while `df` still reported free space, and the same exhaustion took
+    // out `uat_workflows` at the same time. Pointing `TMPDIR` at a roomier
+    // filesystem made all six pass unchanged, which is how the cause was found.
+    //
+    // `CARGO_TARGET_TMPDIR` is cargo's directory for exactly this: it sits under
+    // `target/`, on the same filesystem as a build that already fits there, and
+    // cargo cleans it with the rest of `target/`.
+    //
+    // The per-project target directories stay per-project. Sharing ONE target
+    // directory across callers looks tempting — it would let the first build pay
+    // for `horus_core` and the rest hit the cache — but it is wrong here:
+    // `a_reordered_build_cannot_open_the_same_topic` builds two DIFFERENT
+    // versions of the same crate and needs both artifacts at once, and a shared
+    // directory makes the second clobber the first. Tried; it fails at the copy.
+    let tmp = tempfile::tempdir_in(scratch_root()).expect("tempdir");
     let project = tmp.path().join("demo");
     let out = Command::new(horus())
         .args(["new", "demo", "--python"])

--- a/horus_manager/tests/uat_workflows.rs
+++ b/horus_manager/tests/uat_workflows.rs
@@ -15,6 +15,27 @@ use assert_cmd::Command;
 use std::fs;
 use tempfile::TempDir;
 
+/// A scratch directory under the workspace's `target/`, created if absent.
+///
+/// `CARGO_TARGET_TMPDIR` is cargo's own scratch directory for integration tests,
+/// but it is only guaranteed to be set — not to exist, since `cargo clean` or a
+/// hand `rm -rf target/tmp` removes it. Create it rather than fail on it.
+fn scratch_root() -> &'static str {
+    let root = env!("CARGO_TARGET_TMPDIR");
+    let _ = std::fs::create_dir_all(root);
+    root
+}
+
+// Scratch projects live under the workspace's `target/`, not `$TMPDIR`.
+//
+// These build real cargo projects, and `/tmp` is a tmpfs that does not have room
+// for them alongside everything else on the box: `uat_rust_project_full_lifecycle`
+// and `uat_multi_dependency_project` both failed with `Disk quota exceeded
+// (os error 122)` while `df` still reported free space, and pointing `TMPDIR` at
+// a roomier filesystem made them pass unchanged. `CARGO_TARGET_TMPDIR` is cargo's
+// directory for exactly this — under `target/`, on the same filesystem as a build
+// that already fits there, and cleaned by `cargo clean`.
+
 /// Helper to get the CLI command.
 fn horus_cmd() -> Command {
     cargo_bin_cmd!("horus")
@@ -48,7 +69,7 @@ fn strip_horus_dep(proj: &std::path::Path) {
 
 #[test]
 fn uat_rust_project_full_lifecycle() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
 
     // 1. Create project
     horus_cmd()
@@ -141,7 +162,7 @@ fn uat_rust_project_full_lifecycle() {
 
 #[test]
 fn uat_python_project_lifecycle() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
 
     // 1. Create Python project
     horus_cmd()
@@ -208,7 +229,7 @@ fn uat_python_project_lifecycle() {
 
 #[test]
 fn uat_project_health_workflow() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
     horus_cmd()
         .args([
             "new",
@@ -280,7 +301,7 @@ fn uat_project_health_workflow() {
 
 #[test]
 fn uat_multi_dependency_project() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
     horus_cmd()
         .args([
             "new",
@@ -351,7 +372,7 @@ fn uat_multi_dependency_project() {
 
 #[test]
 fn uat_init_existing_directory() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
 
     // 1. Init workspace in empty dir
     let output = horus_cmd()
@@ -399,7 +420,7 @@ fn uat_init_existing_directory() {
 
 #[test]
 fn uat_build_and_run_quick_exit() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
     horus_cmd()
         .args([
             "new",
@@ -445,7 +466,7 @@ fn uat_build_and_run_quick_exit() {
 
 #[test]
 fn uat_auth_and_publish_workflow() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
     let key_dir = tmp.path().join("keys");
 
     // 1. Generate signing key (isolated)
@@ -501,7 +522,7 @@ fn uat_auth_and_publish_workflow() {
 
 #[test]
 fn uat_dev_dependency_workflow() {
-    let tmp = TempDir::new().unwrap();
+    let tmp = TempDir::new_in(scratch_root()).unwrap();
     horus_cmd()
         .args(["new", "dev-dep", "-r", "-o", &tmp.path().to_string_lossy()])
         .assert()


### PR DESCRIPTION
## Problem

Six integration tests fail with `Disk quota exceeded (os error 122)` while `df` still
reports free space — the four in `msg_gen_interop` and both cargo-building ones in
`uat_workflows`.

They build real cargo projects, and `tempfile::tempdir()` puts those on `/tmp`, a
tmpfs. `msg_gen_interop` alone is three full builds of a crate that depends on
`horus_core`, each into its own target directory. That does not fit in a tmpfs shared
with everything else on the machine.

Pointing `TMPDIR` at a roomier filesystem made all six pass unchanged — that is what
identified the cause.

## Fix

Use `CARGO_TARGET_TMPDIR`, cargo's own scratch directory for integration tests: under
the workspace's `target/`, on the same filesystem as a build that already fits there,
and cleaned by `cargo clean`.

Wrapped in a `scratch_root()` helper that **creates** it — the variable is only
guaranteed to be *set*, and `cargo clean` or a hand `rm -rf target/tmp` removes the
directory, after which `tempdir_in` fails instantly. That happened while testing this
change.

## What I deliberately did not do

Sharing **one** target directory across callers looks like the bigger win — the first
build pays for `horus_core` and the rest hit the cache, and it did cut the file from
131s to 67s.

It is wrong here: `a_reordered_build_cannot_open_the_same_topic` builds two *different*
versions of the same crate and needs both artifacts at once, so a shared directory makes
the second clobber the first. Four tests then fail at the copy. The comment in
`build_ffi` records this so the next person doesn't spend the same hour.

## Verification

- `msg_gen_interop` 8/8 in 36s (was 4 failures)
- `uat_workflows` 8/8 in 191s (was 2 failures)
- both with `/tmp` untouched, and after `rm -rf target/tmp` to exercise the create path
- clippy clean