### PR TITLE
ci(coverage): stop instrumenting two tick-rate assertions that measure llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -100,13 +100,22 @@ jobs:
           # Exclude crates with workspace linkage issues
           # Skip flaky tests that depend on shared memory state or timing
           # test_direct_channel_latency_estimation: flaky due to coverage instrumentation affecting timing
+          #
+          # test_high_performance_config and test_auto_derive_tick_rate_from_fastest_node
+          # are the same class: both assert a tick COUNT as a proxy for a rate
+          # (10kHz over 50ms wanting >=10 of ~500; 500Hz over 50ms wanting >=5 of
+          # ~25). llvm-cov instruments every function, so a tick loop that fast
+          # cannot hold its rate here and the count measures the instrumentation
+          # rather than the scheduler -- this job saw 1 tick against a threshold
+          # of 10. Both keep their teeth: integration-tests.yml runs the whole
+          # `--test '*'` set in RELEASE, uninstrumented, and skips neither.
           cargo llvm-cov --workspace \
             --exclude horus_benchmarks \
             --exclude horus \
             --exclude horus_library \
             --exclude horus_py \
             --lcov --output-path lcov.info \
-            -- --test-threads=1 --skip test_robot_performance_metrics --skip test_enhanced_scheduler --skip test_custom_exotic_robot_config --skip test_robotics_autonomous_car_perception --skip topic_cross_thread_1p_multi_c_spmc --skip topic_cross_thread_mpmc_pre_initialized_99_percent --skip topic_cross_thread_multi_p_multi_c_mpmc --skip multithread_nonpod_subscribers_each_get_full_stream --skip hlog_latency_under_contention_4_threads --skip hlog_latency_p99_under_50us --skip dual_write_overhead_acceptable --skip shm_fanout_latency_percentiles_cross_thread --skip stress_rt_1khz_under_cpu_contention --skip stress_rt_1khz_baseline_no_contention --skip stress_rt_multi_rate_under_contention --skip stress_rt_isolation_from_compute_nodes --skip xproc_
+            -- --test-threads=1 --skip test_robot_performance_metrics --skip test_enhanced_scheduler --skip test_custom_exotic_robot_config --skip test_robotics_autonomous_car_perception --skip topic_cross_thread_1p_multi_c_spmc --skip topic_cross_thread_mpmc_pre_initialized_99_percent --skip topic_cross_thread_multi_p_multi_c_mpmc --skip multithread_nonpod_subscribers_each_get_full_stream --skip hlog_latency_under_contention_4_threads --skip hlog_latency_p99_under_50us --skip dual_write_overhead_acceptable --skip shm_fanout_latency_percentiles_cross_thread --skip stress_rt_1khz_under_cpu_contention --skip stress_rt_1khz_baseline_no_contention --skip stress_rt_multi_rate_under_contention --skip stress_rt_isolation_from_compute_nodes --skip test_high_performance_config --skip test_auto_derive_tick_rate_from_fastest_node --skip xproc_
         env:
           RUST_BACKTRACE: 1
 


### PR DESCRIPTION
`test_high_performance_config` and `test_auto_derive_tick_rate_from_fastest_node` fail intermittently in the **Code Coverage** job only. Both assert a tick *count* as a proxy for a *rate*:

| test | rate | window | expected | asserts |
|---|---|---|---|---|
| `test_high_performance_config` | 10kHz | 50ms | ~500 | >= 10 |
| `test_auto_derive_tick_rate_from_fastest_node` | 500Hz | 50ms | ~25 | >= 5 |

`llvm-cov` instruments every function, so a tick loop that fast cannot hold its rate under it. The run on #92 recorded **1 tick against a threshold of 10** — a ~500x shortfall that measures the instrumentation and the shared runner, not the scheduler.

### These keep their teeth

`integration-tests.yml` runs the whole `--test '*'` set in **release**, uninstrumented, and skips neither. The auto-bump property and the high-rate property stay gated where the numbers mean something. Note `ci.yml`'s gate is `--lib` only, so it never ran these — the release integration job is what covers them.

### Anti-vacuity

A `--skip` name that matches nothing silently filters nothing, so I checked: the binary lists **14** tests, **12** with these two flags applied — they match exactly the intended pair. Both pass in release locally in ~1s.

### Not #92's fault

#92 touches one file, `horus_manager/tests/introspection_live_contract.rs`, and cannot reach `horus_core/tests/scheduler_config_test.rs`. The flake just landed on its run.

This follows the precedent already documented in `integration-tests.yml`: *"The stress_rt_* family is the same class and coverage.yml has always skipped all four."`

Evidence is the CI failure plus the mechanism; I could not reproduce locally because this box holds 10kHz even unoptimized, and a local llvm-cov pass would not disprove a 2-vCPU runner result anyway.