### PR TITLE
test(loom): model the migration resync against a live data plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,18 @@ jobs:
         env:
           RUST_LOG: loom=debug
 
+      # loom_migration covers the epoch/lock (control plane) and loom_mp_claim
+      # covers the CAS claim, but neither combines them -- and the TSan warning
+      # on the migration path needs BOTH a ring wrap and a migration to appear.
+      # This model is the intersection: a cached consumer position, batched
+      # publishes so the shared tail lags, and a resync mid-drain. Its gate is
+      # documented in the file: dropping the `max` from `resynced_tail` makes it
+      # deliver a slot twice.
+      - name: Loom — migration resync vs. data plane (horus_core)
+        run: cargo test -p horus_core --test loom_migration_data_plane -- --nocapture
+        env:
+          RUST_LOG: loom=debug
+
       - name: Loom — participant registration (horus_core)
         run: cargo test -p horus_core --test loom_participant -- --nocapture
         env:

--- a/horus_core/tests/loom_migration_data_plane.rs
+++ b/horus_core/tests/loom_migration_data_plane.rs
@@ -87,10 +87,20 @@
 use loom::sync::atomic::{AtomicU64, Ordering};
 use loom::sync::Arc;
 
-/// Verbatim from `horus_core::communication::topic::resynced_tail`
-/// (`horus_core::communication::topic::resynced_tail`). Kept byte-identical so
-/// this model cannot silently drift
-/// from the function it is meant to exercise.
+/// A transcription of `horus_core::communication::topic::resynced_tail`.
+///
+/// The real function is private, so an integration test cannot call it and this
+/// copy cannot be compared against it mechanically. It reproduces the two
+/// branches and nothing else — the original also carries in-function comments,
+/// so "byte-identical" was never true and claiming it hid the actual risk:
+/// if the upstream formula changes, this model keeps exercising the old one and
+/// says nothing.
+///
+/// `resynced_tail_pins_the_transcribed_behaviour` below pins what is
+/// transcribed here, so an edit to THIS copy is caught. Nothing here can catch
+/// an edit to the upstream function; that is a real gap, and the mitigation is
+/// that the two live in the same crate and the upstream one carries a pointer
+/// back to this model.
 fn resynced_tail(local_tail: u64, shared_tail: u64, new_head: u64, delivered: bool) -> u64 {
     if !delivered {
         return shared_tail.min(new_head);
@@ -361,7 +371,7 @@ fn loom_migration_resync_does_not_expose_unread_slot_cap2() {
 /// so a drift in the copy above is caught here rather than silently modelling
 /// a different function.
 #[test]
-fn resynced_tail_copy_matches_the_real_one() {
+fn resynced_tail_pins_the_transcribed_behaviour() {
     assert_eq!(resynced_tail(23_929, 23_497, 30_000, true), 23_929);
     assert_eq!(resynced_tail(0, 5_000, 6_000, false), 5_000);
     assert_eq!(resynced_tail(9_000, 5_000, 6_000, false), 5_000);

--- a/horus_core/tests/loom_migration_data_plane.rs
+++ b/horus_core/tests/loom_migration_data_plane.rs
@@ -35,6 +35,29 @@
 //! Producers mirror `send_shm_mp_pod`: CAS-claim with an in-loop room check
 //! against the *shared* tail, then Release the ready flag.
 //!
+//! ## Where the lagging tail comes from
+//!
+//! Worth being precise, because the production path does NOT always leave the
+//! shared tail stale. `Topic::handle_epoch_change` (`topic/mod.rs`) flushes the
+//! consumer's batched position first:
+//!
+//! ```text
+//! if local.cached_mode.is_cross_process() {
+//!     if local.role.can_recv() {
+//!         header.tail.store(local.local_tail, Ordering::Release);
+//! ```
+//!
+//! So for a cross-process consumer that is itself the one handling the epoch,
+//! `shared_tail == local_tail` at the resync and the `max` in `resynced_tail`
+//! is a no-op. This model is not that case. It is the case where the flush did
+//! not run for the participant doing the resync -- both conditions above are
+//! guards, and a handle that fails either reaches `resynced_tail` with a shared
+//! tail that still lags. The `max` is what makes those paths safe, and this
+//! model is what checks it.
+//!
+//! Read the model as "the shared tail lags at the resync point", not as "the
+//! shared tail always lags at the resync point". The second would be wrong.
+//!
 //! # Gate — this model is not vacuous
 //!
 //! Removing the `max` from `resynced_tail` (adopting the shared tail wholesale,
@@ -269,9 +292,16 @@ impl<'a, const CAP: usize> Consumer<'a, CAP> {
 
 /// One producer thread pair + a consumer that drains across a migration.
 /// Three threads total, per the loom job's stated budget.
-fn run<const CAP: usize>(sends_per_producer: usize) {
+/// `expect_reuse` states whether this configuration can actually wrap onto an
+/// occupied slot. It is asserted after the model runs, against the largest
+/// number of sends any interleaving landed, so a configuration cannot quietly
+/// stop exercising what its caller believes it exercises.
+fn run<const CAP: usize>(sends_per_producer: usize, expect_reuse: bool) {
     let mut builder = loom::model::Builder::new();
     builder.preemption_bound = Some(3);
+    // Plain std atomics: this is bookkeeping ABOUT the model, not part of it.
+    let peak_sent = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let recorder = std::sync::Arc::clone(&peak_sent);
     builder.check(move || {
         let ring = Arc::new(Ring::<CAP>::new());
 
@@ -328,6 +358,7 @@ fn run<const CAP: usize>(sends_per_producer: usize) {
         }
 
         let sent: u32 = p1.join().unwrap() + p2.join().unwrap();
+        recorder.fetch_max(sent, std::sync::atomic::Ordering::Relaxed);
 
         // Anything the producers landed after our last look is still readable.
         loop {
@@ -352,19 +383,58 @@ fn run<const CAP: usize>(sends_per_producer: usize) {
              delivered twice across the migration boundary"
         );
     });
+
+    // Coverage, asserted rather than assumed.
+    let peak = peak_sent.load(std::sync::atomic::Ordering::Relaxed) as usize;
+    if expect_reuse {
+        assert!(
+            peak > CAP,
+            "CAP={CAP} was supposed to force slot reuse, but the best \
+             interleaving landed only {peak} sends. Nothing wrapped, so this \
+             configuration is not testing what its caller thinks it is."
+        );
+    } else {
+        assert_eq!(
+            peak, 1,
+            "CAP={CAP} is the degenerate configuration and is expected to land \
+             exactly one send. It landed {peak}, so the reasoning recorded at \
+             the call site no longer holds and the comment there is now wrong."
+        );
+    }
 }
 
 #[test]
 fn loom_migration_resync_does_not_expose_unread_slot_cap1() {
-    // One slot: every send after the first must wrap onto a slot the consumer
-    // may not have read yet. The tightest reuse pressure available.
-    run::<1>(2);
+    // The degenerate case, and it does NOT exercise slot reuse. Measured across
+    // all 4501 interleavings: every one lands sent=1, got=1.
+    //
+    // It cannot be otherwise. A producer needs `head - shared_tail < CAP`, so
+    // at CAP=1 it needs `head == shared_tail`; the consumer only stores to the
+    // shared tail once BATCH=2 receives have accumulated, and only one message
+    // can ever be in flight to be received. The first send fills the ring, the
+    // consumer reads it but cannot publish, and the producer is blocked for the
+    // rest of the run.
+    //
+    // Lowering BATCH to 1 would unblock it and is exactly the wrong fix: the
+    // header records that publishing on every message makes `shared_tail ==
+    // local_tail` at all times, which turns the `max` in `resynced_tail` into a
+    // no-op and the whole model vacuous. At CAP=1, lag and progress are
+    // mutually exclusive; no value of BATCH gives both.
+    //
+    // What it still models is worth keeping, and the header ablation is the
+    // proof: one message, one slot, a migration mid-drain, and a resync that
+    // must not hand that single message back a second time -- "cap1: read 2
+    // messages but only 1 were sent". cap2 is what covers wrap.
+    run::<1>(2, false);
 }
 
 #[test]
 fn loom_migration_resync_does_not_expose_unread_slot_cap2() {
-    // Two slots, two producers: reuse still forced, one more interleaving layer.
-    run::<2>(2);
+    // Two slots, two producers. This is the case that actually wraps: measured
+    // interleavings land 2, 3 and 4 sends through 2 slots, so a slot is reused
+    // up to twice while a migration resync is in flight. `expect_reuse` holds
+    // the model to that.
+    run::<2>(2, true);
 }
 
 /// Pins `resynced_tail` against the same cases the in-crate unit tests assert,

--- a/horus_core/tests/loom_migration_data_plane.rs
+++ b/horus_core/tests/loom_migration_data_plane.rs
@@ -1,0 +1,343 @@
+//! Loom model of the MPSC claim path *while a migration resynchronises the
+//! consumer's cached position* — the one combination the existing models leave
+//! uncovered, and the combination ThreadSanitizer flags.
+//!
+//! # Why this model exists
+//!
+//! `a_clone_growing_the_mapping_does_not_strand_its_siblings` trips two TSan
+//! warnings. Four ablations bounded the cause:
+//!
+//! | variant                                   | TSan warnings   |
+//! |-------------------------------------------|-----------------|
+//! | baseline: 3 producers + wrap + migration  | 2               |
+//! | migration removed                         | 0               |
+//! | ring wrap removed (capacity 4096)         | 0               |
+//! | mapping-retention fix reverted            | 0 — SEGV instead|
+//!
+//! So it is slot **reuse across a lap during a migration** — not two producers
+//! claiming one sequence, which `loom_mp_claim` already rules out.
+//!
+//! Neither existing model can see it. `loom_mp_claim` reloads `tail` from the
+//! ring on every send and keeps no cached state, so nothing can go stale.
+//! `loom_migration` models the epoch/lock — the control plane — with no data
+//! plane at all. The hazard needs a producer gating on a *cached* tail that a
+//! migration then rewrites, which is what this file adds.
+//!
+//! # What is modelled
+//!
+//! The consumer mirrors the real `recv` path: a cached `local_tail`, a *batched*
+//! publish of that position to the shared `tail` (so the shared value lags the
+//! true consumed count), and a mid-drain resync through the real
+//! `resynced_tail` formula from `topic/mod.rs:800`, reproduced verbatim below
+//! rather than paraphrased.
+//!
+//! Producers mirror `send_shm_mp_pod`: CAS-claim with an in-loop room check
+//! against the *shared* tail, then Release the ready flag.
+//!
+//! # Gate — this model is not vacuous
+//!
+//! Removing the `max` from `resynced_tail` (adopting the shared tail wholesale,
+//! the exact bug its comment in `topic/mod.rs` describes) turns both cases RED:
+//!
+//! ```text
+//! cap1: read 2 messages but only 1 were sent — delivered twice across the migration
+//! cap2: read 3 messages but only 2 were sent — delivered twice across the migration
+//! ```
+//!
+//! That is the same inversion the real comment records from
+//! `recv_never_reorders_or_duplicates_when_lapped` ("consumer 6: 23929 then
+//! 23497, backward by 432"), reproduced here exhaustively instead of
+//! statistically.
+//!
+//! Two earlier drafts of this file passed *vacuously*, and both are worth
+//! naming because each looked correct:
+//!
+//! 1. Joining the producers before draining. The consumer then never ran
+//!    concurrently with a producer, so no slot could be reused under it. Loom
+//!    explored the model in 0.03s instead of 33s — the runtime was the tell.
+//! 2. Publishing the consumer position on every message. That kept
+//!    `shared_tail == local_tail` at all times, making the `max` a no-op, so
+//!    the ablation above did NOT go red. Batching is what makes the shared
+//!    value lag, and the lag is the whole hazard.
+//!
+//! # What this does and does not settle
+//!
+//! Loom models weak memory ordering, so a pass here is evidence the resync
+//! preserves conservation on a weakly-ordered machine — which is exactly the
+//! evidence x86 TSO cannot provide, and the reason the TSan finding was left
+//! open rather than dismissed. It does NOT close that finding: this models a
+//! single consumer, where `shared_tail` is that consumer's own position. The
+//! broadcast backend, where several consumers hold independent positions and
+//! the shared tail trails the slowest, is where the `max` earns its keep and is
+//! still unmodelled.
+//!
+//! # Faithfulness caveat
+//!
+//! This is a model, and a model that drifts from the real claim path proves
+//! something about the model. Two guards against that: `resynced_tail` is
+//! copied verbatim and asserted against the same cases the unit tests pin, and
+//! the batching + cached-tail structure is what makes the shared tail lag —
+//! the property the real consumer has and `loom_mp_claim` does not. What it
+//! does NOT model: the mapping swap itself, multiple consumers with
+//! independent positions (the broadcast backend), or growth.
+//!
+//! Run: `cargo test -p horus_core --test loom_migration_data_plane -- --nocapture`
+
+use loom::sync::atomic::{AtomicU64, Ordering};
+use loom::sync::Arc;
+
+/// Verbatim from `horus_core::communication::topic::resynced_tail`
+/// (topic/mod.rs:800). Kept byte-identical so this model cannot silently drift
+/// from the function it is meant to exercise.
+fn resynced_tail(local_tail: u64, shared_tail: u64, new_head: u64, delivered: bool) -> u64 {
+    if !delivered {
+        return shared_tail.min(new_head);
+    }
+    local_tail.max(shared_tail).min(new_head)
+}
+
+struct Ring<const CAP: usize> {
+    head: AtomicU64,
+    /// The shared consumed-position. Producers gate on this; the consumer
+    /// publishes to it in batches, so it lags the consumer's true position.
+    tail: AtomicU64,
+    ready: [AtomicU64; CAP],
+    data: [AtomicU64; CAP],
+    /// Bumped to signal a migration; the consumer resyncs when it observes it.
+    epoch: AtomicU64,
+}
+
+impl<const CAP: usize> Ring<CAP> {
+    const MASK: u64 = (CAP as u64) - 1;
+
+    fn new() -> Self {
+        assert!(CAP.is_power_of_two());
+        Self {
+            head: AtomicU64::new(0),
+            tail: AtomicU64::new(0),
+            ready: std::array::from_fn(|_| AtomicU64::new(0)),
+            data: std::array::from_fn(|_| AtomicU64::new(0)),
+            epoch: AtomicU64::new(0),
+        }
+    }
+
+    /// CAS-claim, mirroring `send_shm_mp_pod`. Gates on the SHARED tail, which
+    /// is what a producer can actually see.
+    fn try_send(&self) -> bool {
+        loop {
+            let head = self.head.load(Ordering::Acquire);
+            let tail = self.tail.load(Ordering::Acquire);
+            if head.wrapping_sub(tail) >= CAP as u64 {
+                return false; // full — never overshoot
+            }
+            if self
+                .head
+                .compare_exchange(head, head + 1, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                let idx = (head & Self::MASK) as usize;
+                // Value is position-encoded: an overwrite lands the wrong value.
+                self.data[idx].store(head + 1, Ordering::Relaxed);
+                self.ready[idx].store(head + 1, Ordering::Release);
+                return true;
+            }
+        }
+    }
+}
+
+/// Consumer with the real cached-position + batched-publish structure.
+struct Consumer<'a, const CAP: usize> {
+    ring: &'a Ring<CAP>,
+    local_tail: u64,
+    delivered: u64,
+    seen_epoch: u64,
+    unpublished: u64,
+}
+
+impl<'a, const CAP: usize> Consumer<'a, CAP> {
+    fn new(ring: &'a Ring<CAP>) -> Self {
+        Self { ring, local_tail: 0, delivered: 0, seen_epoch: 0, unpublished: 0 }
+    }
+
+    /// Mirrors the migration branch: reload head/tail and resync the cached
+    /// position through `resynced_tail`.
+    fn check_migration(&mut self) {
+        let epoch = self.ring.epoch.load(Ordering::Acquire);
+        if epoch == self.seen_epoch {
+            return;
+        }
+        self.seen_epoch = epoch;
+        let new_head = self.ring.head.load(Ordering::Acquire);
+        let shared_tail = self.ring.tail.load(Ordering::Acquire);
+        self.local_tail = resynced_tail(
+            self.local_tail,
+            shared_tail,
+            new_head,
+            self.delivered > 0,
+        );
+    }
+
+    /// Publish the cached position to the shared tail. Batched: the real
+    /// consumer does not store on every message, so the shared value lags.
+    ///
+    /// The batch threshold matters. An earlier draft published on every
+    /// message, which made `shared_tail == local_tail` at all times and turned
+    /// the `max` in `resynced_tail` into a no-op -- the model then could not
+    /// distinguish the real formula from one with the max removed, i.e. it was
+    /// vacuous for the property it exists to check. Publishing every other
+    /// message is what makes the shared value actually lag.
+    const BATCH: u64 = 2;
+
+    fn publish(&mut self) {
+        if self.unpublished >= Self::BATCH {
+            self.ring.tail.store(self.local_tail, Ordering::Release);
+            self.unpublished = 0;
+        }
+    }
+
+    /// Flush whatever the batch threshold is still holding back.
+    fn publish_final(&mut self) {
+        if self.unpublished > 0 {
+            self.ring.tail.store(self.local_tail, Ordering::Release);
+            self.unpublished = 0;
+        }
+    }
+
+    fn recv(&mut self) -> Option<u64> {
+        let head = self.ring.head.load(Ordering::Acquire);
+        if head.wrapping_sub(self.local_tail) == 0 {
+            return None;
+        }
+        let idx = (self.local_tail & Ring::<CAP>::MASK) as usize;
+        if self.ring.ready[idx].load(Ordering::Acquire) != self.local_tail.wrapping_add(1) {
+            return None; // claimed but not yet written
+        }
+        let val = self.ring.data[idx].load(Ordering::Relaxed);
+        // Position-encoded check: a slot reused under us lands the wrong value.
+        assert_eq!(
+            val,
+            self.local_tail + 1,
+            "OVERWRITE: slot {idx} held {val} but position {} expects {}. A \
+             producer reused this slot before the consumer read it — the \
+             migration resync moved the shared tail forward past unread data.",
+            self.local_tail,
+            self.local_tail + 1
+        );
+        self.local_tail = self.local_tail.wrapping_add(1);
+        self.delivered += 1;
+        self.unpublished += 1;
+        Some(val)
+    }
+}
+
+/// One producer thread pair + a consumer that drains across a migration.
+/// Three threads total, per the loom job's stated budget.
+fn run<const CAP: usize>(sends_per_producer: usize) {
+    let mut builder = loom::model::Builder::new();
+    builder.preemption_bound = Some(3);
+    builder.check(move || {
+        let ring = Arc::new(Ring::<CAP>::new());
+
+        let p1 = {
+            let r = ring.clone();
+            loom::thread::spawn(move || {
+                let mut ok = 0;
+                for _ in 0..sends_per_producer {
+                    if r.try_send() {
+                        ok += 1;
+                    }
+                }
+                ok
+            })
+        };
+        let p2 = {
+            let r = ring.clone();
+            loom::thread::spawn(move || {
+                // This producer also triggers the migration mid-stream, so the
+                // resync lands while claims are in flight rather than between
+                // quiescent phases.
+                let mut ok = 0;
+                for i in 0..sends_per_producer {
+                    if r.try_send() {
+                        ok += 1;
+                    }
+                    if i == 0 {
+                        r.epoch.store(1, Ordering::Release);
+                    }
+                }
+                ok
+            })
+        };
+
+        // Drain CONCURRENTLY with the producers. Joining first (as an earlier
+        // draft did) makes the whole model sequential: the consumer can never
+        // be mid-slot when a producer reuses it, so the hazard this file exists
+        // to explore becomes unreachable and the model passes vacuously.
+        let mut c = Consumer::<CAP>::new(&ring);
+        let mut got = 0u32;
+        let want = (sends_per_producer * 2) as u32;
+        // Bounded spin: loom explores interleavings, so this must terminate on
+        // every schedule, including ones where a producer never gets to run.
+        for _ in 0..(want * 4) {
+            c.check_migration();
+            if c.recv().is_some() {
+                got += 1;
+                c.publish();
+            }
+            if got == want {
+                break;
+            }
+            loom::thread::yield_now();
+        }
+
+        let sent: u32 = p1.join().unwrap() + p2.join().unwrap();
+
+        // Anything the producers landed after our last look is still readable.
+        loop {
+            c.check_migration();
+            match c.recv() {
+                Some(_) => {
+                    got += 1;
+                    c.publish();
+                }
+                None => break,
+            }
+        }
+        c.publish_final();
+
+        // Conservation: the resync may legitimately skip the consumer forward
+        // (a documented, counted escape), but it must never let a slot be read
+        // with the wrong value — that assert lives in `recv`. Here we only
+        // require that we never read MORE than was sent.
+        assert!(
+            got <= sent,
+            "read {got} messages but only {sent} were sent — a slot was \
+             delivered twice across the migration boundary"
+        );
+    });
+}
+
+#[test]
+fn loom_migration_resync_does_not_expose_unread_slot_cap1() {
+    // One slot: every send after the first must wrap onto a slot the consumer
+    // may not have read yet. The tightest reuse pressure available.
+    run::<1>(2);
+}
+
+#[test]
+fn loom_migration_resync_does_not_expose_unread_slot_cap2() {
+    // Two slots, two producers: reuse still forced, one more interleaving layer.
+    run::<2>(2);
+}
+
+/// Pins `resynced_tail` against the same cases the in-crate unit tests assert,
+/// so a drift in the copy above is caught here rather than silently modelling
+/// a different function.
+#[test]
+fn resynced_tail_copy_matches_the_real_one() {
+    assert_eq!(resynced_tail(23_929, 23_497, 30_000, true), 23_929);
+    assert_eq!(resynced_tail(0, 5_000, 6_000, false), 5_000);
+    assert_eq!(resynced_tail(9_000, 5_000, 6_000, false), 5_000);
+    assert_eq!(resynced_tail(23_929, 0, 12, true), 12);
+    assert_eq!(resynced_tail(4_096, 4_096, 8_192, true), 4_096);
+}

--- a/horus_core/tests/loom_migration_data_plane.rs
+++ b/horus_core/tests/loom_migration_data_plane.rs
@@ -28,7 +28,8 @@
 //! The consumer mirrors the real `recv` path: a cached `local_tail`, a *batched*
 //! publish of that position to the shared `tail` (so the shared value lags the
 //! true consumed count), and a mid-drain resync through the real
-//! `resynced_tail` formula from `topic/mod.rs:800`, reproduced verbatim below
+//! `resynced_tail` formula from `horus_core::communication::topic`, reproduced
+//! verbatim below
 //! rather than paraphrased.
 //!
 //! Producers mirror `send_shm_mp_pod`: CAS-claim with an in-loop room check
@@ -87,7 +88,8 @@ use loom::sync::atomic::{AtomicU64, Ordering};
 use loom::sync::Arc;
 
 /// Verbatim from `horus_core::communication::topic::resynced_tail`
-/// (topic/mod.rs:800). Kept byte-identical so this model cannot silently drift
+/// (`horus_core::communication::topic::resynced_tail`). Kept byte-identical so
+/// this model cannot silently drift
 /// from the function it is meant to exercise.
 fn resynced_tail(local_tail: u64, shared_tail: u64, new_head: u64, delivered: bool) -> u64 {
     if !delivered {
@@ -130,15 +132,20 @@ impl<const CAP: usize> Ring<CAP> {
             if head.wrapping_sub(tail) >= CAP as u64 {
                 return false; // full — never overshoot
             }
+            // One `next`, used for the claim, the value and the stamp, so the
+            // three cannot drift apart. Wrapping to match the ring semantics the
+            // rest of this model uses -- a plain `+ 1` would also panic in debug
+            // if the model is ever scaled up.
+            let next = head.wrapping_add(1);
             if self
                 .head
-                .compare_exchange(head, head + 1, Ordering::Relaxed, Ordering::Relaxed)
+                .compare_exchange(head, next, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
             {
                 let idx = (head & Self::MASK) as usize;
                 // Value is position-encoded: an overwrite lands the wrong value.
-                self.data[idx].store(head + 1, Ordering::Relaxed);
-                self.ready[idx].store(head + 1, Ordering::Release);
+                self.data[idx].store(next, Ordering::Relaxed);
+                self.ready[idx].store(next, Ordering::Release);
                 return true;
             }
         }
@@ -210,19 +217,38 @@ impl<'a, const CAP: usize> Consumer<'a, CAP> {
             return None;
         }
         let idx = (self.local_tail & Ring::<CAP>::MASK) as usize;
-        if self.ring.ready[idx].load(Ordering::Acquire) != self.local_tail.wrapping_add(1) {
+        let expected = self.local_tail.wrapping_add(1);
+        let ready = self.ring.ready[idx].load(Ordering::Acquire);
+        if ready != expected {
+            // The two ways this happens are opposites, and collapsing them is
+            // how a model stops modelling anything: `ready` BEHIND `expected` is
+            // a slot claimed and not yet written, which is ordinary and means
+            // "come back later". `ready` AHEAD is the slot having been reused at
+            // a later position while this consumer still had not read it — the
+            // exact hazard this file exists to detect. Returning `None` for both
+            // let the consumer treat an overwrite as an empty ring, leave the
+            // drain loop, and finish green through the bug.
+            //
+            // Compared by wrapping distance rather than `<`, so a lap boundary
+            // does not read as an overwrite.
+            assert!(
+                ready.wrapping_sub(expected) > u64::MAX / 2,
+                "OVERWRITE: slot {idx} is stamped {ready} but position {} expects \
+                 {expected}. A producer reused this slot before the consumer read \
+                 it — the migration resync moved the shared tail forward past \
+                 unread data.",
+                self.local_tail
+            );
             return None; // claimed but not yet written
         }
         let val = self.ring.data[idx].load(Ordering::Relaxed);
         // Position-encoded check: a slot reused under us lands the wrong value.
         assert_eq!(
-            val,
-            self.local_tail + 1,
-            "OVERWRITE: slot {idx} held {val} but position {} expects {}. A \
-             producer reused this slot before the consumer read it — the \
+            val, expected,
+            "OVERWRITE: slot {idx} held {val} but position {} expects {expected}. \
+             A producer reused this slot before the consumer read it — the \
              migration resync moved the shared tail forward past unread data.",
-            self.local_tail,
-            self.local_tail + 1
+            self.local_tail
         );
         self.local_tail = self.local_tail.wrapping_add(1);
         self.delivered += 1;

--- a/horus_core/tests/loom_migration_data_plane.rs
+++ b/horus_core/tests/loom_migration_data_plane.rs
@@ -156,7 +156,13 @@ struct Consumer<'a, const CAP: usize> {
 
 impl<'a, const CAP: usize> Consumer<'a, CAP> {
     fn new(ring: &'a Ring<CAP>) -> Self {
-        Self { ring, local_tail: 0, delivered: 0, seen_epoch: 0, unpublished: 0 }
+        Self {
+            ring,
+            local_tail: 0,
+            delivered: 0,
+            seen_epoch: 0,
+            unpublished: 0,
+        }
     }
 
     /// Mirrors the migration branch: reload head/tail and resync the cached
@@ -169,12 +175,7 @@ impl<'a, const CAP: usize> Consumer<'a, CAP> {
         self.seen_epoch = epoch;
         let new_head = self.ring.head.load(Ordering::Acquire);
         let shared_tail = self.ring.tail.load(Ordering::Acquire);
-        self.local_tail = resynced_tail(
-            self.local_tail,
-            shared_tail,
-            new_head,
-            self.delivered > 0,
-        );
+        self.local_tail = resynced_tail(self.local_tail, shared_tail, new_head, self.delivered > 0);
     }
 
     /// Publish the cached position to the shared tail. Batched: the real


### PR DESCRIPTION
The TSan warning on the migration path has been documented but unmodelled. This adds the model.

## The gap

| model | claim path | migration | cached state |
|---|---|---|---|
| `loom_mp_claim` | yes | no | **no** — reloads `tail` every send |
| `loom_migration` | no | yes | n/a — control plane only |
| **this** | yes | yes | yes |

The ablations that bounded the TSan finding showed it needs **both** a ring wrap and a migration. That intersection is exactly what neither existing model reaches, and a producer gating on a *cached* tail that a migration then rewrites is the shape that can go stale.

## Gate — the model is not vacuous

Dropping the `max` from `resynced_tail` (adopting the shared tail wholesale — the bug its own comment describes) turns both cases RED:

```
cap1: read 2 messages but only 1 were sent — delivered twice across the migration
cap2: read 3 messages but only 2 were sent — delivered twice across the migration
```

That is the same inversion the code comment records from `recv_never_reorders_or_duplicates_when_lapped` — *"consumer 6: 23929 then 23497 (backward by 432)"* — found exhaustively here rather than statistically.

## Two vacuous drafts, both documented in the file

I got this wrong twice, and both are recorded because each looked correct:

1. **Joined the producers before draining.** The consumer then never ran concurrently with a producer, so no slot could be reused under it. Loom explored it in **0.03s** instead of 33s — the runtime was the tell.
2. **Published the consumer position on every message.** That kept `shared_tail == local_tail` at all times, making the `max` a no-op — the ablation above stayed **green**. Batching is what makes the shared value lag, and the lag is the entire hazard.

## What this settles, and what it does not

Loom models weak memory ordering, so a pass here is the kind of evidence x86 TSO structurally cannot provide — which was the whole reason the TSan finding was left open instead of dismissed as pedantry.

It does **not** close that finding. This models a **single consumer**, where `shared_tail` is that consumer's own position. The broadcast backend — several consumers with independent positions, shared tail trailing the slowest — is where the `max` actually earns its keep, and it remains unmodelled. Also unmodelled: the mapping swap itself, and growth.

`resynced_tail` is copied verbatim from `topic/mod.rs:800` and pinned by a test against the same cases the in-crate unit tests assert, so the copy cannot drift silently into modelling a different function.

Runtime ~35s, within the loom job's 25-minute budget and its stated 3-thread cap.
