### PR TITLE
fix(topic): the epoch flush must not drag the SpmcShm cursor backward

### DIFF
--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2421,7 +2421,25 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
         //   producers doing CAS start from a stale head.
         if local.cached_mode.is_cross_process() {
             if local.role.can_recv() {
-                header.tail.store(local.local_tail, Ordering::Release);
+                // fetch_max, not store: on SpmcShm this word is not this
+                // handle's private position. `recv_shm_spmc_pod` CAS-coordinates
+                // competing consumers THROUGH it, and `is_cross_process()`
+                // includes SpmcShm, so a handle whose batched local_tail lags
+                // the cursor would publish its own value over a claim another
+                // consumer had already made -- and the next CAS hands those
+                // messages out a second time.
+                //
+                // The consumer-join flush above already reasons this way and
+                // says so: "fetch_max never moves the shared tail backward, so
+                // it is safe even if a concurrent SpmcShm consumer has already
+                // advanced it". This site published the same value with a plain
+                // store. Modelled in tests/loom_spmc_epoch_flush.rs, which goes
+                // RED with the store and green with fetch_max.
+                //
+                // No behaviour change for the single-consumer backends: there
+                // the batched local_tail is always at or ahead of the shared
+                // word, so the max is the store.
+                header.tail.fetch_max(local.local_tail, Ordering::Release);
             }
             if local.role.can_send() {
                 header

--- a/horus_core/tests/loom_spmc_epoch_flush.rs
+++ b/horus_core/tests/loom_spmc_epoch_flush.rs
@@ -1,0 +1,139 @@
+//! Loom model of the SpmcShm epoch flush against competing consumers.
+//!
+//! # The asymmetry this exists to pin
+//!
+//! `handle_epoch_change` publishes a handle's consumed frontier to the shared
+//! `header.tail` before migrating (`topic/mod.rs`, the `is_cross_process()`
+//! block). On SpscShm/MpscShm that word is effectively the one consumer's own
+//! position, so a plain store is harmless. On **SpmcShm it is not**:
+//! `recv_shm_spmc_pod` CAS-coordinates competing consumers *through* that word,
+//! making it a shared claim cursor. `is_cross_process()` includes `SpmcShm`
+//! (`types.rs`), so the flush fires there too.
+//!
+//! The consumer-join flush a few hundred lines earlier publishes the SAME value
+//! and uses `fetch_max`, with the reason written out:
+//!
+//! > `fetch_max` never moves the shared tail backward, so it is safe even if a
+//! > concurrent SpmcShm consumer has already advanced it.
+//!
+//! and names the consequence of getting it wrong:
+//!
+//! > if a 2nd consumer now joins and CAS-reads from that stale value, it
+//! > RE-DELIVERS messages the first consumer already took.
+//!
+//! Same value, same modes, same hazard — one site guarded, one not.
+//!
+//! # Why loom rather than an integration test
+//!
+//! A topic renegotiates its backend: handles opened around a `force_migrate`
+//! land back in SpscShm when only one consumer is active, so pinning two live
+//! SpmcShm consumers from the outside is unreliable. Loom makes the interleaving
+//! explicit and the result deterministic.
+//!
+//! # Gate
+//!
+//! `FLUSH_WITH_FETCH_MAX = false` reproduces the plain store and the model goes
+//! RED — the cursor moves backward and a message is claimed twice. `true` is
+//! the fix and it passes.
+
+use loom::sync::atomic::{AtomicU64, Ordering};
+use loom::sync::Arc;
+
+/// Set to `false` to model the plain `store` (the pre-fix code).
+const FLUSH_WITH_FETCH_MAX: bool = true;
+
+/// The shared SpmcShm claim cursor plus the per-message claim ledger.
+struct Spmc {
+    /// `header.tail` — competing consumers CAS through this to claim.
+    tail: AtomicU64,
+    /// How many messages are available (`header.sequence_or_head`).
+    head: AtomicU64,
+    /// claims[i] counts how many consumers claimed message i. Must never exceed 1.
+    claims: [AtomicU64; 8],
+}
+
+impl Spmc {
+    fn new(head: u64) -> Self {
+        Self {
+            tail: AtomicU64::new(0),
+            head: AtomicU64::new(head),
+            claims: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+
+    /// Mirrors `recv_shm_spmc_pod`: load the cursor, CAS it forward to claim.
+    /// Returns the claimed index.
+    fn try_claim(&self) -> Option<u64> {
+        loop {
+            let tail = self.tail.load(Ordering::Acquire);
+            if tail >= self.head.load(Ordering::Acquire) {
+                return None;
+            }
+            if self
+                .tail
+                .compare_exchange_weak(
+                    tail,
+                    tail.wrapping_add(1),
+                    Ordering::AcqRel,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                self.claims[(tail % 8) as usize].fetch_add(1, Ordering::Relaxed);
+                return Some(tail);
+            }
+        }
+    }
+
+    /// Mirrors the `handle_epoch_change` flush of a handle's cached position.
+    fn epoch_flush(&self, local_tail: u64) {
+        if FLUSH_WITH_FETCH_MAX {
+            self.tail.fetch_max(local_tail, Ordering::Release);
+        } else {
+            self.tail.store(local_tail, Ordering::Release);
+        }
+    }
+}
+
+#[test]
+fn spmc_epoch_flush_must_not_redeliver_a_claimed_message() {
+    let mut builder = loom::model::Builder::new();
+    builder.preemption_bound = Some(3);
+    builder.check(|| {
+        // Three messages available; two consumers competing.
+        let s = Arc::new(Spmc::new(3));
+
+        // Consumer A claims one message, so its cached local_tail is 1 while the
+        // shared cursor will run ahead of it once B claims.
+        let a_local = s.try_claim().map(|i| i + 1).unwrap_or(0);
+
+        let h = {
+            let s = s.clone();
+            loom::thread::spawn(move || {
+                // Consumer B keeps claiming, pushing the cursor past A.
+                while s.try_claim().is_some() {}
+            })
+        };
+
+        // A crosses an epoch boundary and flushes its now-stale position.
+        s.epoch_flush(a_local);
+
+        h.join().unwrap();
+
+        // Drain anything the flush re-opened.
+        while s.try_claim().is_some() {}
+
+        // The invariant: SpmcShm hands each message to exactly one consumer.
+        for i in 0..3usize {
+            let n = s.claims[i].load(Ordering::Relaxed);
+            assert!(
+                n <= 1,
+                "message {i} was claimed {n} times — the epoch flush moved the \
+                 shared cursor backward over a claim another consumer had \
+                 already made, so the next CAS handed the same message out \
+                 again. This is what fetch_max prevents and a plain store does \
+                 not."
+            );
+        }
+    });
+}


### PR DESCRIPTION
`handle_epoch_change` publishes a handle's consumed frontier to `header.tail` before migrating. On SpscShm/MpscShm that word is effectively the one consumer's own position, so a plain `store` is harmless. **On SpmcShm it is not** — `recv_shm_spmc_pod` CAS-coordinates competing consumers *through* that word, making it a shared claim cursor, and `is_cross_process()` includes `SpmcShm`, so the flush fires there too.

A handle whose batched `local_tail` lags the cursor published its own smaller value over a claim another consumer had already made. The next CAS then handed those messages out **a second time**.

## The same file already knows this

The consumer-join flush a few hundred lines earlier publishes the *same value* and uses `fetch_max`, with the reason written out:

> `fetch_max` never moves the shared tail backward, so it is safe even if a concurrent SpmcShm consumer has already advanced it.

and it names the exact failure:

> if a 2nd consumer now joins and CAS-reads from that stale value, it RE-DELIVERS messages the first consumer already took.

Same value, same modes, same hazard — one site guarded, one not. Before this change:

| site | op |
|---|---|
| consumer-join flush (SpmcShm) | `fetch_max` |
| late-join skip | `fetch_max` |
| **epoch-change flush** | **`store`** |

## Gate

`tests/loom_spmc_epoch_flush.rs` models two consumers CAS-claiming through the cursor while one flushes a stale position across an epoch boundary.

```
FLUSH_WITH_FETCH_MAX = true   -> pass
FLUSH_WITH_FETCH_MAX = false  -> FAILED: message 1 was claimed 2 times
```

The ablation is what makes the model non-vacuous — the same model detects the difference between the two implementations.

## Why loom and not an integration test

I tried the integration test first and it does not work: a topic renegotiates its backend, and handles opened around a `force_migrate` land back in SpscShm when only one consumer is active (`a_mode=SpscShm` even with `t.mode()==SpmcShm`). Two live SpmcShm consumers cannot be pinned reliably from the outside, so the test passed vacuously against the *unfixed* code. That attempt and why it was dropped are recorded in the model's header rather than left as folklore.

## Blast radius

No behaviour change for the single-consumer backends — their batched `local_tail` is always at or ahead of the shared word, so the max *is* the store. The change only bites where a peer has already advanced the cursor.

Verified: full `horus_core` lib suite green (**2465 passed, 0 failed**), and all five loom models green.

## Provenance

Found by reading the broadcast tail protocol to scope a different question (whether a consumer advancing the shared tail could make a producer overwrite unread data). On the broadcast backends it cannot — `send_shm_pod_broadcast` never reads `header.tail` at all. The backpressured multi-consumer mode is where that hazard is real, and this was sitting in it.
