### PR TITLE
security(dependabot): stop auto-merging github-actions bumps unread

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -29,8 +29,18 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # github-actions is excluded deliberately. A patch bump there changes the
+      # code that EXECUTES inside CI, and main requires no pull-request review
+      # (required_pull_request_reviews is null), so an auto-merged action bump
+      # would land unread and then run with repository credentials. A compromised
+      # action publishing a patch release is a well-known supply-chain path, and
+      # it is the one ecosystem here where "patch" does not mean "smaller blast
+      # radius". Every other ecosystem still auto-merges patches as before; these
+      # PRs simply wait for a human to look, which is a handful per month.
       - name: Auto-Merge Patch Updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          steps.metadata.outputs.package-ecosystem != 'github-actions'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
The patch auto-merge rule fired on **every** ecosystem — only the *minor* rule was restricted to cargo.

Combined with `required_pull_request_reviews: null` on main, a `github-actions` patch bump merged with nobody reading it, then ran with repository credentials on the next workflow.

That is the one ecosystem where "patch" does not bound the blast radius: it changes the code that **executes inside CI**, not code the project links against. A compromised action shipping a patch release is a well-known supply-chain path.

| ecosystem | patch | minor |
|---|---|---|
| cargo / npm / pip | auto-merge (unchanged) | cargo only (unchanged) |
| **github-actions** | **now waits for a human** | already manual |

Dependabot's `github-actions` schedule is weekly, so this is a handful of PRs a month.

Found while security-reviewing the autopilot (#101): its convoy job selected PRs on "auto-merge is enabled" and would have kept these current, accelerating the loop. That job is now scoped to human authors — but routing around the policy is not the same as fixing it.