### PR TITLE
fix(rt): grade against jitter, not against the period itself

### DIFF
--- a/horus_core/src/scheduling/rt_report.rs
+++ b/horus_core/src/scheduling/rt_report.rs
@@ -291,6 +291,25 @@ struct JitterResult {
     actual_hz: f64,
 }
 
+/// Deviation of each observed interval from the target period.
+///
+/// This is what "jitter" means everywhere else in this module: the fields are
+/// named `jitter_*_us`, `RtGrade::Production` documents "Jitter <50us P99", and
+/// the issue text reads "P99 jitter ... exceeds 500us threshold".
+///
+/// The measurement used to return the raw INTERVAL instead -- ~1000us for a 1kHz
+/// loop -- so the grade compared a period against a jitter budget. `p99 < 50.0`
+/// could never hold at any rate, and `p99 < 500.0` could not hold below 2kHz, so
+/// RtGrade::Production and RtGrade::Standard were both unreachable and
+/// `is_production_ready()` returned false on every machine including a correctly
+/// configured PREEMPT_RT one.
+fn jitter_from_intervals(intervals_us: &[f64], period_us: f64) -> Vec<f64> {
+    intervals_us
+        .iter()
+        .map(|interval| (interval - period_us).abs())
+        .collect()
+}
+
 fn measure_jitter(target_hz: u64, duration: Duration) -> JitterResult {
     let period = Duration::from_nanos(1_000_000_000 / target_hz);
     let mut timestamps =
@@ -321,10 +340,12 @@ fn measure_jitter(target_hz: u64, duration: Duration) -> JitterResult {
         };
     }
 
-    let mut deltas_us: Vec<f64> = timestamps
+    let period_us = 1_000_000.0 / target_hz as f64;
+    let intervals_us: Vec<f64> = timestamps
         .windows(2)
         .map(|w| w[1].duration_since(w[0]).as_nanos() as f64 / 1000.0)
         .collect();
+    let mut deltas_us = jitter_from_intervals(&intervals_us, period_us);
     deltas_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
     let n = deltas_us.len();
@@ -375,5 +396,55 @@ fn measure_ipc() -> (f64, f64) {
             (latency_ns, throughput)
         }
         Err(_) => (0.0, 0.0),
+    }
+}
+
+#[cfg(test)]
+mod jitter_tests {
+    use super::*;
+
+    /// A perfectly paced loop has ZERO jitter. Before the fix this returned the
+    /// period itself (1000us at 1kHz), which is what made every RT grade
+    /// unreachable.
+    ///
+    /// GATE: revert `jitter_from_intervals` to returning the interval unchanged
+    /// and this fails with 1000 != 0.
+    #[test]
+    fn a_perfectly_paced_loop_has_no_jitter() {
+        let period_us = 1000.0;
+        let intervals = vec![1000.0; 64];
+        let jitter = jitter_from_intervals(&intervals, period_us);
+        assert!(
+            jitter.iter().all(|j| *j == 0.0),
+            "a loop hitting its period exactly must report zero jitter, got {:?}",
+            &jitter[..4]
+        );
+    }
+
+    /// Jitter is the magnitude of the miss, in either direction: running early
+    /// is as much a deadline violation as running late.
+    #[test]
+    fn jitter_is_absolute_deviation_in_both_directions() {
+        let jitter = jitter_from_intervals(&[1200.0, 800.0, 1000.0], 1000.0);
+        assert_eq!(jitter, vec![200.0, 200.0, 0.0]);
+    }
+
+    /// The grade thresholds must be reachable by a well-behaved 1kHz loop.
+    /// This is the property the bug actually broke.
+    #[test]
+    fn a_good_1khz_loop_can_reach_the_production_jitter_budget() {
+        // 1kHz with +/-10us of scheduling noise: comfortably inside the 50us
+        // Production budget and the 500us Standard budget.
+        let intervals: Vec<f64> = (0..100)
+            .map(|i| if i % 2 == 0 { 1010.0 } else { 990.0 })
+            .collect();
+        let mut jitter = jitter_from_intervals(&intervals, 1000.0);
+        jitter.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let p99 = jitter[(jitter.len() as f64 * 0.99) as usize];
+        assert!(
+            p99 < 50.0,
+            "p99 jitter {p99}us must fit the Production budget (<50us); before \
+             the fix this was ~1000us because the raw period was returned"
+        );
     }
 }

--- a/horus_core/src/scheduling/rt_report.rs
+++ b/horus_core/src/scheduling/rt_report.rs
@@ -340,7 +340,14 @@ fn measure_jitter(target_hz: u64, duration: Duration) -> JitterResult {
         };
     }
 
-    let period_us = 1_000_000.0 / target_hz as f64;
+    // Derived from `period`, not recomputed from `target_hz`. `period` is
+    // integer nanoseconds, so for rates that do not divide 1e9 evenly it is
+    // truncated (7 Hz: 142857142 ns, not 142857142.857), and computing the
+    // jitter baseline independently in floating point would measure against a
+    // period the loop never actually slept for. The gap is at most 0.857 ns
+    // against a 50 us Production threshold, so no grade was ever affected —
+    // this is one source of truth rather than a numeric fix.
+    let period_us = period.as_nanos() as f64 / 1000.0;
     let intervals_us: Vec<f64> = timestamps
         .windows(2)
         .map(|w| w[1].duration_since(w[0]).as_nanos() as f64 / 1000.0)
@@ -414,8 +421,14 @@ mod jitter_tests {
         let period_us = 1000.0;
         let intervals = vec![1000.0; 64];
         let jitter = jitter_from_intervals(&intervals, period_us);
+        // Epsilon rather than `== 0.0`: `period_us` is derived from a Duration
+        // in the caller, so a future rate whose nanosecond period does not
+        // divide evenly can leave sub-nanosecond residue. The gate is unharmed
+        // — reverting `jitter_from_intervals` yields 1000.0, six orders of
+        // magnitude above this bound.
+        const EPS_US: f64 = 1e-6;
         assert!(
-            jitter.iter().all(|j| *j == 0.0),
+            jitter.iter().all(|j| j.abs() <= EPS_US),
             "a loop hitting its period exactly must report zero jitter, got {:?}",
             &jitter[..4]
         );


### PR DESCRIPTION
`measure_jitter` returned the raw **interval** between ticks — ~1000 µs for a 1 kHz loop — and the grade compared that against a *jitter* budget.

```
Production: caps.preempt_rt && ... && jitter.p99 < 50.0    // never true at any rate
Standard:   caps.max_priority > 0 && jitter.p99 < 500.0    // never true below 2 kHz
```

So both grades were unreachable on every machine — including a correctly configured PREEMPT_RT box with SCHED_FIFO and mlockall — and `is_production_ready()` returned `false` unconditionally.

The intent was never ambiguous. The fields are `jitter_*_us`, `RtGrade::Production` documents *"Jitter <50μs P99"*, and the issue text reads *"P99 jitter … exceeds 500μs threshold"*. Only the measurement disagreed.

## Gate

Jitter is now absolute deviation from the target period, in a pure helper so it is testable without timing. Revert that helper to returning the interval unchanged and all three tests fail:

```
a_perfectly_paced_loop_has_no_jitter                    got [1000.0, ...] expected 0
a_good_1khz_loop_can_reach_the_production_jitter_budget p99 1010us vs 50us budget
jitter_is_absolute_deviation_in_both_directions         FAILED
```

That `1010us` is the bug's signature exactly.

Found while assessing HORUS's real-time suitability — the customer-facing readiness grade was reporting "not production ready" on hardware meeting every criterion it claims to test.