### PR TITLE
fix(safety): an external safe-state request safed nothing

### DIFF
--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -752,6 +752,14 @@ pub(crate) struct SafetyMonitor {
     degradation_policy: DegradationPolicy,
     /// Per-node degradation state
     degradation_states: Mutex<HashMap<String, NodeDegradationState>>,
+    /// A NEW external safe-state request the tick loop has not acted on yet.
+    ///
+    /// Separate from `state`, which latches `SafetyState::SafeState` as an
+    /// observable CONDITION and must stay set. This is the EDGE: it is raised
+    /// once per external trigger and cleared once the scheduler has driven the
+    /// nodes, so one link loss produces one round of safing rather than a fresh
+    /// request on every tick for the rest of the run.
+    external_safe_state_pending: AtomicBool,
 }
 
 /// A cheap, cloneable handle for feeding node watchdogs from another thread.
@@ -823,6 +831,7 @@ impl SafetyMonitor {
             degrade_activations: AtomicU64::new(0),
             degradation_policy: DegradationPolicy::default(),
             degradation_states: Mutex::new(HashMap::new()),
+            external_safe_state_pending: AtomicBool::new(false),
         }
     }
 
@@ -1297,11 +1306,19 @@ impl SafetyMonitor {
     /// Deliberately does NOT set `emergency_stop`: that flag ends the run loop,
     /// which is exactly the outcome an operator choosing `safe_state` over
     /// `stop` asked to avoid.
-    pub(crate) fn install_safe_state_hook(&self) {
+    pub(crate) fn install_safe_state_hook(self: &Arc<Self>) {
         let state = Arc::clone(&self.state);
+        let pending = Arc::clone(self);
         set_safe_state_hook(move |reason| {
             *state.lock() = SafetyState::SafeState;
+            pending
+                .external_safe_state_pending
+                .store(true, Ordering::Release);
             use std::io::Write;
+            // The claim in this line is now true. The scheduler's tick loop
+            // consumes the state via `take_external_safe_state` and drives every
+            // node to `enter_safe_state()`; until it did, this message was the
+            // only thing that happened.
             let _ = writeln!(
                 std::io::stderr(),
                 " SAFE STATE (external): {reason} — nodes safing, scheduler continues"
@@ -1318,6 +1335,22 @@ impl SafetyMonitor {
             use std::io::Write;
             let _ = writeln!(std::io::stderr(), " EMERGENCY STOP (external): {reason}");
         });
+    }
+
+    /// Consume a pending EXTERNAL safe-state request, if one was raised.
+    ///
+    /// `install_safe_state_hook` used to set `SafetyState::SafeState` and print
+    /// "nodes safing, scheduler continues" -- and nothing anywhere read that
+    /// state. The only write was the hook's own; `grep SafetyState::` outside
+    /// this file returned nothing. So `safety.on_link_lost = "safe_state"` told
+    /// the operator the robot was safing and safed no node: a robot that lost
+    /// its link to the fleet controller kept executing its last command, with a
+    /// reassuring line on stderr.
+    ///
+    /// The state is cleared on read so one link-loss produces one round of
+    /// safing rather than a safing request on every tick forever.
+    pub(crate) fn take_external_safe_state(&self) -> bool {
+        self.external_safe_state_pending.swap(false, Ordering::AcqRel)
     }
 
     /// Get current safety state

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -3315,6 +3315,45 @@ impl Scheduler {
     ///
     /// Returns `true` if the scheduler should stop (emergency stop triggered).
     fn check_safety_monitors(&mut self) -> bool {
+        // An EXTERNAL safe-state request -- a lost network link under
+        // `safety.on_link_lost = "safe_state"` -- reaches the scheduler as a
+        // state written by `install_safe_state_hook`. Consume it here and
+        // actually safe the robot.
+        //
+        // Nothing used to read that state. The hook set it, printed "nodes
+        // safing, scheduler continues", and no node was safed: the operator who
+        // chose per-node safing over a full halt got neither. This is the one
+        // safety path with no node to blame, so every node is driven, by both
+        // routes -- the scheduler owns only BestEffort nodes after the class
+        // partition, and `enter_safe_state()` needs `&mut dyn Node`, so an
+        // executor-owned node is reached through the shared control map and
+        // safed by its owning executor's `honor_safe_state_request`.
+        if self
+            .monitor
+            .safety
+            .as_ref()
+            .is_some_and(|m| m.take_external_safe_state())
+        {
+            if let Some(ref controls) = self.node_controls {
+                controls.request_safe_state_all();
+            }
+            for registered in self.nodes.iter_mut() {
+                if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    registered.node.enter_safe_state()
+                }))
+                .is_err()
+                {
+                    // It did not reach a safe state. Stop it rather than let it
+                    // keep ticking as though it had.
+                    registered.is_stopped = true;
+                    print_line(&format!(
+                        " SAFE STATE: '{}' PANICKED in enter_safe_state; node stopped",
+                        registered.name
+                    ));
+                }
+            }
+        }
+
         if let Some(ref monitor) = self.monitor.safety {
             // Use graduated check for per-node health state transitions
             monitor.check_watchdogs_graduated(&mut self.monitor.watchdog_graduated_buf);

--- a/horus_core/src/scheduling/types.rs
+++ b/horus_core/src/scheduling/types.rs
@@ -864,6 +864,24 @@ impl NodeControlMap {
         }
     }
 
+    /// Ask every registered node's owning executor to safe it.
+    ///
+    /// The fleet-wide counterpart to `request_safe_state`. Used by the external
+    /// safe-state path (a lost network link under
+    /// `safety.on_link_lost = "safe_state"`), which has no single node to blame
+    /// and must safe the whole robot.
+    pub fn request_safe_state_all(&self) {
+        for c in self
+            .inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+        {
+            c.safe_state_requested
+                .store(true, std::sync::atomic::Ordering::Release);
+        }
+    }
+
     /// Consume a pending safing request, returning whether one was set.
     ///
     /// Clears the flag, so a request is honoured exactly once per raise.

--- a/horus_core/tests/external_safe_state.rs
+++ b/horus_core/tests/external_safe_state.rs
@@ -1,0 +1,93 @@
+//! An external safe-state request must actually safe the robot.
+//!
+//! `safety.on_link_lost = "safe_state"` routes a lost network link to
+//! `trigger_external_safe_state`, whose installed hook set
+//! `SafetyState::SafeState` and printed
+//!
+//!     SAFE STATE (external): ... — nodes safing, scheduler continues
+//!
+//! Nothing read that state. The hook's own write was the only reference to the
+//! variant outside its own module, so the operator who deliberately chose
+//! per-node safing over a full halt got neither: the robot kept executing its
+//! last command with a reassuring line on stderr.
+//!
+//! This lives in its own test binary because the safe-state hook is a
+//! process-global installed by a running scheduler; sharing a binary with other
+//! scheduler tests would let their schedulers claim the hook.
+
+use horus_core::core::duration_ext::DurationExt;
+use horus_core::core::node::Node;
+use horus_core::scheduling::Scheduler;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+struct SafeStateRecordingNode {
+    safed: Arc<AtomicU64>,
+    ticks: Arc<AtomicU64>,
+}
+
+impl Node for SafeStateRecordingNode {
+    fn name(&self) -> &str {
+        "actuator"
+    }
+    fn tick(&mut self) {
+        self.ticks.fetch_add(1, Ordering::Relaxed);
+    }
+    fn enter_safe_state(&mut self) {
+        self.safed.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// One test, not two, because the safe-state hook is a PROCESS-GLOBAL installed
+/// by whichever scheduler is running. Two tests in this binary raced for it:
+/// one scheduler claimed the hook and absorbed both triggers while the other
+/// saw none, so the pair failed about half the time for a reason that had
+/// nothing to do with the code under test.
+#[test]
+fn an_external_safe_state_request_safes_the_robot_exactly_once() {
+    let safed = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+
+    let mut scheduler = Scheduler::new().tick_rate(200_u64.hz());
+    scheduler
+        .add(SafeStateRecordingNode {
+            safed: safed.clone(),
+            ticks: ticks.clone(),
+        })
+        .build()
+        .unwrap();
+
+    // Fire the external trigger once the scheduler is running and has installed
+    // its hook. Before it is installed, `trigger_external_safe_state` escalates
+    // to an emergency stop instead, which is a different path.
+    std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        horus_core::scheduling::trigger_external_safe_state("test: peer lost".to_string());
+    });
+
+    scheduler.run_for(600_u64.ms()).unwrap();
+
+    let n = safed.load(Ordering::Relaxed);
+    let t = ticks.load(Ordering::Relaxed);
+
+    assert!(t > 0, "the node never ticked, so this run exercised nothing");
+
+    // The fix: the request is consumed and the node is actually safed.
+    assert!(
+        n > 0,
+        "an external safe-state request was raised and no node was safed. The \
+         hook set SafetyState::SafeState and printed 'nodes safing', and nothing \
+         consumed it — which is what a robot losing its link to the fleet \
+         controller under on_link_lost=safe_state used to get."
+    );
+
+    // And it is an EDGE, not a level: one link loss produces one round of
+    // safing, not a fresh `enter_safe_state()` every tick for the rest of the
+    // run. `SafetyState::SafeState` stays latched as an observable condition,
+    // which is why consuming the state itself would have been the wrong fix.
+    assert!(
+        n < t / 4,
+        "safed {n} times over {t} ticks — the request is being re-consumed every \
+         tick instead of once per raise"
+    );
+}


### PR DESCRIPTION
`safety.on_link_lost = "safe_state"` routes a lost network link through `trigger_external_safe_state` (`horus_net/src/replicator.rs:899`), whose hook set `SafetyState::SafeState` and printed

    SAFE STATE (external): {reason} — nodes safing, scheduler continues

**and that was the entire effect.** Nothing read the state — the hook's own write was the only reference to the variant outside its own module (`grep SafetyState::` across the rest of `horus_core` and `horus_net` returns nothing). The hook's doc comment says it exists to *"let the scheduler's tick loop safe the affected nodes"*, and the tick loop had no idea the request had happened.

So an operator who deliberately configured per-node safing **over** a full halt got neither. A robot that lost its link to the fleet controller kept executing whatever it was last commanded, and said on stderr that it was safing. That is worse than having no safe-state option, because it reads as one that works.

### The fix

The tick loop consumes the request and drives every node by both routes it has to: the scheduler owns only BestEffort nodes after the class partition, and `enter_safe_state()` needs `&mut dyn Node`, so executor-owned nodes are reached through the shared control map and safed by their owning executor's `honor_safe_state_request` — the mechanism the watchdog ladder already uses for exactly this. A node that panics on the way to its safe state is stopped rather than left ticking as though it had reached one.

The pending request is tracked as an **edge**, separately from `state`. `SafetyState::SafeState` is a latched observable *condition* and its own doc says so, so consuming the state itself would have made the scheduler forget it was in a safe-state response. The edge clears once the nodes have been driven, so one link loss produces one round of safing rather than a fresh `enter_safe_state()` every tick forever — pinned by the test.

### Verification

Non-vacuity confirmed by hand: with `take_external_safe_state` stubbed to `false`, the test fails with *"an external safe-state request was raised and no node was safed"*; restored, it passes. Stable over three consecutive runs.

2465 lib tests + `external_safe_state`, `safety_torture`, `watchdog_graduation`, `rt_readiness` all green in a private `CARGO_TARGET_DIR`.

Found by an audit of every safing path in `horus_core`; this was a sixth path none of the earlier passes had named.