### PR TITLE
perf(rt): the degradation ladder wrote to stdout from the RT thread

### DIFF
--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -2,6 +2,26 @@
 //!
 //! These are the building blocks that the scheduler composes for different
 //! execution strategies (sequential, parallel, future RT-thread, etc.).
+//!
+//! # Everything above `run_tick` runs on an RT thread
+//!
+//! `honor_safe_state_request` and `apply_degradation_action` are reached only
+//! from `rt_executor` -- the scheduler keeps its own main-thread copy of the
+//! degradation dispatch -- so they execute on a SCHED_FIFO thread, inside the
+//! tick. They therefore report through `rt_diag`, which formats into a
+//! statically allocated ring and never allocates, blocks or enters the kernel,
+//! rather than through `print_line`.
+//!
+//! `print_line` does `isatty` + `tcgetattr`, takes the process-global stdout
+//! lock, then `write` and `flush`. Pointed at a slow consumer -- a serial
+//! console, a pipe nobody is reading -- that write blocks for as long as the
+//! reader takes, on the thread driving an actuator. Two of these sites are the
+//! `Isolate` and `Kill` rungs, which are not even verbose-gated and which safe
+//! or shut down the node in the same breath: the worst possible place to wait
+//! on a terminal.
+//!
+//! The drain half is started by `RtExecutor::start` on the caller's thread
+//! before any RT thread exists, so a line queued from here always has a drainer.
 
 use std::time::{Duration, Instant};
 
@@ -54,13 +74,13 @@ pub(crate) fn honor_safe_state_request(
         // latched by the ladder when it raised the request.
         node.is_stopped = true;
         if monitors.verbose {
-            crate::terminal::print_line(&format!(
+            super::rt_executor::rt_diag(format_args!(
                 " Watchdog critical: '{}' PANICKED in enter_safe_state on its executor",
                 node.name
             ));
         }
     } else if monitors.verbose {
-        crate::terminal::print_line(&format!(
+        super::rt_executor::rt_diag(format_args!(
             " Watchdog critical: '{}' entered safe state on its executor",
             node.name
         ));
@@ -96,7 +116,7 @@ pub(crate) fn apply_degradation_action(
         DegradationAction::None => {}
         DegradationAction::Warn(ref name) => {
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Degradation: '{name}' — sustained timing violations, monitoring"
                 ));
             }
@@ -120,7 +140,7 @@ pub(crate) fn apply_degradation_action(
             node.rate_hz = Some(new_rate_hz);
             node.last_tick = Some(Instant::now());
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Degradation: '{name}' — reducing rate to {new_rate_hz:.1} Hz"
                 ));
             }
@@ -135,7 +155,7 @@ pub(crate) fn apply_degradation_action(
             if panicked {
                 node.is_stopped = true;
             }
-            crate::terminal::print_line(&format!(
+            super::rt_executor::rt_diag(format_args!(
                 " Degradation: '{name}' — isolated, entered safe state{}",
                 if panicked {
                     " FAILED (panicked) — node stopped"
@@ -155,7 +175,7 @@ pub(crate) fn apply_degradation_action(
             }))
             .is_err();
             node.is_stopped = true;
-            crate::terminal::print_line(&format!(
+            super::rt_executor::rt_diag(format_args!(
                 " KILL: '{name}' — permanently removed from execution after shutdown(){}",
                 if panicked { " (shutdown panicked)" } else { "" }
             ));
@@ -175,7 +195,7 @@ pub(crate) fn apply_degradation_action(
             node.last_tick = Some(Instant::now());
             set_health(node, NodeHealthState::Healthy);
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Recovery: '{name}' — restored to {original_rate_hz:.1} Hz"
                 ));
             }
@@ -183,7 +203,7 @@ pub(crate) fn apply_degradation_action(
         DegradationAction::Deisolate(ref name) => {
             set_health(node, NodeHealthState::Warning);
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Recovery: '{name}' — de-isolated, resuming at reduced rate"
                 ));
             }

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -4284,6 +4284,50 @@ mod tests {
         );
     }
 
+    /// The degradation ladder reports through the ring, not through stdout.
+    ///
+    /// `apply_degradation_action` is reached only from this executor, i.e. from
+    /// a SCHED_FIFO thread inside the tick, and it used to call
+    /// `print_line(&format!(...))`. `print_line` does `isatty` + `tcgetattr`,
+    /// takes the process-global stdout lock, then writes and flushes: pointed at
+    /// a serial console or a pipe nobody is reading, that blocks for as long as
+    /// the reader takes, on the thread driving an actuator.
+    ///
+    /// `Isolate` and `Kill` are the two rungs that were not even verbose-gated,
+    /// and both safe or shut down the node in the same breath -- the worst place
+    /// in the system to wait on a terminal. This asserts the line is queued
+    /// rather than printed.
+    #[test]
+    fn the_degradation_ladder_reports_through_the_ring_not_stdout() {
+        use super::super::safety_monitor::DegradationAction;
+        use std::sync::atomic::AtomicU64;
+
+        let monitors = test_monitors();
+        let mut node = make_rt_registered("ring_reporter", Arc::new(AtomicU64::new(0)));
+        node.rate_hz = Some(100.0);
+        monitors.node_controls.register("ring_reporter");
+
+        let before = RT_DIAG_HEAD.load(Ordering::Relaxed);
+        super::super::primitives::apply_degradation_action(
+            &mut node,
+            DegradationAction::Isolate("ring_reporter".to_string()),
+            &monitors,
+        );
+        let after = RT_DIAG_HEAD.load(Ordering::Relaxed);
+
+        assert!(
+            after > before,
+            "Isolate queued nothing — it is still going straight to stdout from \
+             the RT thread"
+        );
+        let found = find_queued(before..after, |t| t.contains("ring_reporter"))
+            .expect("the isolate line must be in the ring");
+        assert!(
+            found.contains("isolated"),
+            "queued the wrong line: {found}"
+        );
+    }
+
     /// The ring is BOUNDED and the producer never waits on the consumer.
     ///
     /// That is the whole point: a deadline miss must not be able to block the


### PR DESCRIPTION
`honor_safe_state_request` and `apply_degradation_action` are reached **only** from `rt_executor` — the scheduler keeps a separate main-thread copy of the degradation dispatch — so both run on a SCHED_FIFO thread, inside the tick. Both reported through `print_line(&format!(...))`.

`print_line` calls `isatty` and `tcgetattr`, takes the process-global stdout lock, then writes and flushes. Pointed at a slow consumer — a serial console at 115200 baud, a pipe nobody is reading — that write **blocks for as long as the reader takes**, on the thread driving an actuator. The module already explains this in its own comment about why `rt_diag` exists; these eight call sites were never converted.

Two of them are the `Isolate` and `Kill` rungs, which are **not verbose-gated** and which safe or shut down the node in the same breath. That is the worst place in the system to wait on a terminal: the ladder has just decided a node is in trouble, and the reaction blocks behind whatever is on the far end of stdout. The other six are gated on `monitors.verbose`, which defaults to `true`.

All eight now go through `rt_diag`, which formats with `core::fmt` straight into a statically allocated ring — never allocates, never blocks, never enters the kernel. The drain half is spawned by `RtExecutor::start` on the caller's thread before any RT thread exists, so a queued line always has a drainer. The two remaining `print_line` calls in the file are executor teardown on the caller's thread, where blocking is fine; left alone.

New test `the_degradation_ladder_reports_through_the_ring_not_stdout`. Non-vacuity confirmed by hand: reverting just the `Isolate` site to `print_line` fails it with *"Isolate queued nothing — it is still going straight to stdout from the RT thread"*.

2465 lib tests green in a private `CARGO_TARGET_DIR`. Found by an audit of every RT hot path in `horus_core`.