### PR TITLE
fix(net): stop silently decimating every replicated topic to the export tick

### DIFF
--- a/horus_net/src/config.rs
+++ b/horus_net/src/config.rs
@@ -21,6 +21,15 @@ pub struct NetConfig {
     pub import: ImportConfig,
     /// Export deny patterns (e.g., ["camera.*", "debug.*"]).
     pub deny_export: Vec<String>,
+    /// Topic patterns exported as a full stream rather than a per-tick sample.
+    ///
+    /// The exporter polls on a timer, so by default a replicated topic leaves
+    /// this machine at the tick rate (~20 Hz) whatever rate it is published at.
+    /// That is right for state — a pose, a battery level — and wrong for a
+    /// measurement stream, where the receiver integrates every sample. List the
+    /// streams here (globs allowed) and every message crosses.
+    /// Env: `HORUS_NET_EXPORT_STREAM=odom,joint_states,lidar.*`.
+    pub export_stream: Vec<String>,
     /// Safety heartbeat settings.
     pub safety: SafetyConfig,
     /// Posture for acting on authenticated remote e-stop packets.
@@ -201,6 +210,11 @@ pub struct TopicNetConfig {
     pub redundant_copies: Option<u8>,
     /// Link-lost action override for this topic.
     pub on_link_lost: Option<String>,
+    /// Export sampling override: "stream" (every message) or "latest" (newest
+    /// sample per export tick). Unrecognised values fall through to
+    /// `export_stream` and then to the default rather than picking a mode for
+    /// the operator.
+    pub export_sampling: Option<String>,
     /// Optimizers enabled for this topic.
     pub optimizers: Option<Vec<String>>,
     /// Spatial radius (for spatial optimizer).
@@ -240,6 +254,7 @@ impl Default for NetConfig {
             // — the guard was permanently `Auto`.
             import: ImportConfig::from_env(),
             deny_export: csv_env("HORUS_NET_DENY_EXPORT"),
+            export_stream: csv_env("HORUS_NET_EXPORT_STREAM"),
             safety: SafetyConfig::default(),
             estop_remote: EstopRemotePolicy::from_env(),
             optimizers: csv_env("HORUS_NET_OPTIMIZERS"),
@@ -287,6 +302,7 @@ impl NetConfig {
             secret: None,
             import: ImportConfig::Auto,
             deny_export: vec![],
+            export_stream: vec![],
             safety: SafetyConfig::default(),
             estop_remote: EstopRemotePolicy::Warn,
             optimizers: vec![],
@@ -307,6 +323,34 @@ impl NetConfig {
             }
         }
         None
+    }
+
+    /// How much of a topic's ring the exporter should take on each poll.
+    ///
+    /// A per-topic override wins; otherwise the topic is a stream if it matches
+    /// any `export_stream` pattern; otherwise it is sampled. The default is the
+    /// sampled one because it is the bandwidth floor — turning a whole fleet
+    /// into full streams without being asked could saturate the link the safety
+    /// heartbeat shares — but a sampled topic that is actually losing messages
+    /// says so on the console (see [`crate::shm_reader::SkipReport`]) instead of
+    /// decimating in silence.
+    pub fn export_sampling(&self, topic_name: &str) -> crate::shm_reader::ExportSampling {
+        if let Some(mode) = self
+            .topic_config(topic_name)
+            .and_then(|c| c.export_sampling.as_deref())
+            .and_then(crate::shm_reader::ExportSampling::parse)
+        {
+            return mode;
+        }
+        if self
+            .export_stream
+            .iter()
+            .any(|p| crate::guard::glob_match_topic(topic_name, p))
+        {
+            crate::shm_reader::ExportSampling::AllSlots
+        } else {
+            crate::shm_reader::ExportSampling::LatestOnly
+        }
     }
 
     /// Compute the secret hash (4 bytes) if a secret is configured.
@@ -414,6 +458,7 @@ mod tests {
             secret: None,
             import: ImportConfig::Auto,
             deny_export: vec![],
+            export_stream: vec![],
             safety: SafetyConfig::default(),
             estop_remote: EstopRemotePolicy::Warn,
             optimizers: vec![],

--- a/horus_net/src/metrics.rs
+++ b/horus_net/src/metrics.rs
@@ -26,6 +26,11 @@ pub struct TopicMetrics {
     pub messages_sent: AtomicU64,
     pub messages_received: AtomicU64,
     pub messages_dropped: AtomicU64,
+    /// Local messages that existed in SHM and never left this machine —
+    /// decimated by latest-only export sampling, or lapped in the ring before
+    /// the exporter reached them. Counted separately from `messages_dropped`,
+    /// which is an import-side refusal: this one is data the LAN never saw.
+    pub messages_skipped: AtomicU64,
     pub bytes_sent: AtomicU64,
     pub bytes_received: AtomicU64,
     pub last_sequence: AtomicU32,
@@ -55,6 +60,9 @@ pub struct TopicSnapshot {
     pub messages_sent: u64,
     pub messages_received: u64,
     pub messages_dropped: u64,
+    /// Local messages that never reached the network. See
+    /// [`TopicMetrics::messages_skipped`].
+    pub messages_skipped: u64,
     pub bytes_sent: u64,
     pub bytes_received: u64,
 }
@@ -120,6 +128,20 @@ impl NetMetrics {
         tm.messages_dropped.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record local messages that were never exported.
+    ///
+    /// The export path polls SHM on a timer and, by default, takes the newest
+    /// slot per tick. Everything else published in that tick is gone — and used
+    /// to be gone with no counter anywhere, so a topic replicating at 20 Hz
+    /// instead of 500 Hz was indistinguishable from a topic published at 20 Hz.
+    pub fn record_topic_skipped(&mut self, topic_hash: u32, count: u64) {
+        if count == 0 {
+            return;
+        }
+        let tm = self.topics.entry(topic_hash).or_default();
+        tm.messages_skipped.fetch_add(count, Ordering::Relaxed);
+    }
+
     /// Take a consistent snapshot for reporting.
     pub fn snapshot(&self) -> MetricsSnapshot {
         let peers = self
@@ -144,6 +166,7 @@ impl NetMetrics {
                 messages_sent: tm.messages_sent.load(Ordering::Relaxed),
                 messages_received: tm.messages_received.load(Ordering::Relaxed),
                 messages_dropped: tm.messages_dropped.load(Ordering::Relaxed),
+                messages_skipped: tm.messages_skipped.load(Ordering::Relaxed),
                 bytes_sent: tm.bytes_sent.load(Ordering::Relaxed),
                 bytes_received: tm.bytes_received.load(Ordering::Relaxed),
             })
@@ -192,6 +215,25 @@ mod tests {
         assert_eq!(snap.topics[0].messages_received, 1);
         assert_eq!(snap.topics[0].messages_dropped, 1);
         assert_eq!(snap.topics[0].bytes_sent, 128);
+    }
+
+    #[test]
+    fn skipped_messages_are_counted_per_topic() {
+        let mut m = NetMetrics::new();
+        m.record_topic_send(100, 64);
+        m.record_topic_skipped(100, 24);
+        m.record_topic_skipped(100, 24);
+        // A zero delta must not conjure a topic row out of nothing.
+        m.record_topic_skipped(200, 0);
+
+        let snap = m.snapshot();
+        assert_eq!(snap.topics.len(), 1);
+        assert_eq!(snap.topics[0].messages_sent, 1);
+        assert_eq!(
+            snap.topics[0].messages_skipped, 48,
+            "the 48 messages this topic published and never exported must be \
+             visible somewhere"
+        );
     }
 
     #[test]

--- a/horus_net/src/replicator.rs
+++ b/horus_net/src/replicator.rs
@@ -46,6 +46,16 @@ const TIMER_INTERVAL: Duration = Duration::from_millis(50);
 /// No-peers diagnostic timeout.
 const NO_PEERS_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Most messages one topic contributes to a single export tick.
+///
+/// Only a streaming topic (`ExportSampling::AllSlots`) can reach it; a sampled
+/// one contributes one. It bounds the work and the burst of a stream topic without
+/// losing anything: `ShmRingReader` resumes from its own cursor, so the
+/// remainder is exported on the next tick rather than dropped. At the 50 ms
+/// timer that is 1280 messages/second/topic sustained, which covers a 1 kHz
+/// joint-state stream with room to catch up after a stall.
+const MAX_EXPORT_BATCH: usize = 64;
+
 /// The Replicator — one per process, started by the Scheduler.
 /// Size of the packet scratch buffers.
 ///
@@ -737,6 +747,10 @@ impl Replicator {
             .collect();
 
         let mut outbox: Vec<wire::OutMessage> = Vec::new();
+        // Collected while the readers are borrowed, applied once the loop ends.
+        let mut skipped: Vec<(u32, u64)> = Vec::new();
+        let mut reports: Vec<String> = Vec::new();
+        let now = Instant::now();
 
         for topic_name in topic_names {
             let reader = match self.readers.get_mut(&topic_name) {
@@ -744,8 +758,29 @@ impl Replicator {
                 None => continue,
             };
 
-            if let Some(raw) = reader.try_read_latest() {
-                let topic_hash = wire::topic_hash(&topic_name);
+            // How much of the ring this topic's mode takes. A stream topic
+            // hands back everything published since the previous tick, bounded
+            // by MAX_EXPORT_BATCH; a sampled topic hands back the newest slot
+            // and counts the rest as skipped.
+            let before_skipped = reader.skipped_total();
+            let batch = reader.read_pending(MAX_EXPORT_BATCH);
+            let topic_hash = wire::topic_hash(&topic_name);
+            skipped.push((
+                topic_hash,
+                reader.skipped_total().saturating_sub(before_skipped),
+            ));
+
+            // Say it out loud, on the topic's own terms and at most once every
+            // SKIP_REPORT_INTERVAL. A replicated topic that is being decimated
+            // has to announce it: from the far end, odometry arriving at 20 Hz
+            // because the exporter sampled it is indistinguishable from odometry
+            // that is published at 20 Hz, and the fleet operator debugging a
+            // drifting position estimate has no thread to pull on.
+            if let Some(report) = reader.due_report(now) {
+                reports.push(report.message());
+            }
+
+            for raw in batch {
                 let priority = Priority::auto_infer(&topic_name, false, raw.data.len());
                 let reliability = Reliability::default_for(priority);
 
@@ -760,6 +795,13 @@ impl Replicator {
                     encoding: raw.encoding,
                 });
             }
+        }
+
+        for (topic_hash, count) in skipped {
+            self.metrics.record_topic_skipped(topic_hash, count);
+        }
+        for line in reports {
+            horus_core::terminal::eprint_line(&line);
         }
 
         if outbox.is_empty() {
@@ -871,11 +913,15 @@ impl Replicator {
         // settled, which is the moment a robot starts doing useful work.
         //
         // Driving it from the timer makes export data-driven at the tick rate
-        // rather than topology-driven. `try_read_latest` takes the newest
-        // sample, so a topic faster than TIMER_INTERVAL is downsampled rather
-        // than backlogged — the right trade for the state-like data that
-        // crosses machines, and the same semantic the latched-message resend
-        // below already relies on.
+        // rather than topology-driven — but the tick rate then becomes the
+        // export rate. `try_read_latest` takes the newest sample and leaves the
+        // rest, so EVERY replicated topic was pinned at ~20 Hz however fast its
+        // publisher ran, and nothing counted or said so: a 500 Hz odometry
+        // stream crossed the LAN at 20 Hz and looked, at the far end, exactly
+        // like a 20 Hz odometry stream. Sampling is right for state and wrong
+        // for a measurement stream, so it is now a per-topic choice
+        // (`export_stream` / `HORUS_NET_EXPORT_STREAM`), and whichever way a
+        // topic is set, what it drops is counted and reported.
         //
         // The eventfd path stays: a newly registered topic is still exported
         // immediately rather than waiting up to TIMER_INTERVAL.
@@ -1205,8 +1251,11 @@ impl Replicator {
 
         for m in &all_matches {
             if m.export && !self.readers.contains_key(&m.topic) {
-                self.readers
-                    .insert(m.topic.clone(), ShmRingReader::new(&m.topic));
+                let sampling = self.config.export_sampling(&m.topic);
+                self.readers.insert(
+                    m.topic.clone(),
+                    ShmRingReader::new(&m.topic).with_sampling(sampling),
+                );
             }
             if m.import && !self.writers.contains_key(&m.topic) {
                 if let Some(writer) = ShmRingWriter::open(&m.topic) {
@@ -1615,6 +1664,193 @@ mod tests {
         assert!(
             !fired.load(Ordering::SeqCst),
             "a later unkeyed e-stop episode must not halt"
+        );
+    }
+
+    // ─── Export sampling: what leaves this machine, and what is admitted lost ──
+    //
+    // These drive the private export path against a real SHM ring and a real
+    // UDP socket standing in for the remote subscriber, because the bug they
+    // pin was invisible at every layer above: the exporter took one slot per
+    // 50 ms tick and dropped the rest with no counter, so a 500 Hz odometry
+    // stream reached the fleet at 20 Hz and looked from there exactly like a
+    // 20 Hz odometry stream.
+
+    /// A replicator that exports `topic` to a peer listening on `sub_addr`.
+    fn exporting_replicator(topic: &str, sub_addr: SocketAddr, stream: bool) -> Replicator {
+        let type_hash = wire::topic_hash(topic);
+        let registry = Arc::new(TopicRegistry::new());
+        registry.register(
+            topic,
+            type_hash,
+            std::mem::size_of::<horus_robotics::CmdVel>() as u32,
+            crate::registry::TopicRole::Publisher,
+            true,
+        );
+
+        let mut config = NetConfig::test_config(0);
+        if stream {
+            config.export_stream = vec![topic.to_string()];
+        }
+        let mut rep = Replicator::new(registry, config).unwrap();
+
+        // A peer that subscribes to the topic, announced from the socket the
+        // test is listening on.
+        let announcement = crate::discovery::PeerAnnouncement {
+            peer_id: [0x5A; 16],
+            data_port: sub_addr.port(),
+            secret_hash: [0u8; 4],
+            has_secret: false,
+            topics: vec![crate::discovery::WireTopicEntry {
+                name: topic.to_string(),
+                type_hash,
+                type_size: std::mem::size_of::<horus_robotics::CmdVel>() as u32,
+                role: 2, // subscriber
+                is_pod: 1,
+                priority: 0,
+            }],
+            source_addr: sub_addr,
+        };
+        rep.peers.update_peer(&announcement);
+        rep.update_matches();
+        assert!(
+            rep.readers.contains_key(topic),
+            "the topic must be matched for export before the test means anything"
+        );
+        rep
+    }
+
+    fn publish_shm(path: &std::path::Path, linear: f32) {
+        let cmd = horus_robotics::CmdVel::new(linear, 0.0);
+        // SAFETY: CmdVel is POD; this is the byte form the ring holds.
+        let bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                &cmd as *const horus_robotics::CmdVel as *const u8,
+                std::mem::size_of::<horus_robotics::CmdVel>(),
+            )
+        };
+        assert!(horus_core::communication::write_topic_slot_bytes(
+            path, bytes
+        ));
+    }
+
+    /// Drain every datagram already queued on `sock` and return the CmdVel
+    /// `linear` field of each message they carry.
+    fn drain_exported(sock: &std::net::UdpSocket) -> Vec<f32> {
+        let mut out = Vec::new();
+        let mut buf = [0u8; 65536];
+        while let Ok((n, _)) = sock.recv_from(&mut buf) {
+            let (_, messages) = match wire::decode_packet(&buf[..n]) {
+                Some(p) => p,
+                None => continue,
+            };
+            for m in messages {
+                assert_eq!(
+                    m.payload.len(),
+                    std::mem::size_of::<horus_robotics::CmdVel>()
+                );
+                // SAFETY: the payload is the CmdVel bytes written into SHM.
+                let cmd: horus_robotics::CmdVel =
+                    unsafe { std::ptr::read_unaligned(m.payload.as_ptr() as *const _) };
+                out.push(cmd.linear);
+            }
+        }
+        out
+    }
+
+    fn export_test_topic(base: &str) -> String {
+        use std::sync::atomic::AtomicU32;
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("exp_{base}_{id}_{}", std::process::id())
+    }
+
+    #[test]
+    fn a_burst_reaches_the_subscriber_intact_when_the_topic_is_a_stream() {
+        let sub = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        sub.set_read_timeout(Some(Duration::from_millis(150)))
+            .unwrap();
+        let sub_addr = sub.local_addr().unwrap();
+
+        let name = export_test_topic("burst");
+        let _topic: horus_core::communication::Topic<horus_robotics::CmdVel> =
+            horus_core::communication::Topic::new(&name).expect("create topic");
+        let path = horus_sys::shm::topic_shm_path(&name);
+
+        let mut rep = exporting_replicator(&name, sub_addr, true);
+
+        // First tick starts the reader at "now".
+        publish_shm(&path, 0.0);
+        rep.handle_export();
+        assert_eq!(drain_exported(&sub), vec![0.0]);
+
+        // 50 messages published between two export ticks — a publisher running
+        // 25x faster than the timer.
+        const BURST: usize = 50;
+        for i in 1..=BURST {
+            publish_shm(&path, i as f32);
+        }
+        rep.handle_export();
+
+        let crossed = drain_exported(&sub);
+        let expected: Vec<f32> = (1..=BURST).map(|i| i as f32).collect();
+        assert_eq!(
+            crossed, expected,
+            "every message published between two ticks must reach the peer, in order"
+        );
+
+        let snap = rep.metrics.snapshot();
+        let topic = snap
+            .topics
+            .iter()
+            .find(|t| t.topic_hash == wire::topic_hash(&name))
+            .expect("the topic must appear in the metrics");
+        assert_eq!(topic.messages_sent, BURST as u64 + 1);
+        assert_eq!(topic.messages_skipped, 0);
+    }
+
+    #[test]
+    fn the_default_still_samples_but_no_longer_hides_what_it_dropped() {
+        let sub = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        sub.set_read_timeout(Some(Duration::from_millis(150)))
+            .unwrap();
+        let sub_addr = sub.local_addr().unwrap();
+
+        let name = export_test_topic("sampled");
+        let _topic: horus_core::communication::Topic<horus_robotics::CmdVel> =
+            horus_core::communication::Topic::new(&name).expect("create topic");
+        let path = horus_sys::shm::topic_shm_path(&name);
+
+        let mut rep = exporting_replicator(&name, sub_addr, false);
+
+        publish_shm(&path, 0.0);
+        rep.handle_export();
+        assert_eq!(drain_exported(&sub), vec![0.0]);
+
+        // One tick of a 500 Hz publisher.
+        for i in 1..=25 {
+            publish_shm(&path, i as f32);
+        }
+        rep.handle_export();
+
+        assert_eq!(
+            drain_exported(&sub),
+            vec![25.0],
+            "the default is unchanged: the freshest sample, once per tick"
+        );
+
+        let snap = rep.metrics.snapshot();
+        let topic = snap
+            .topics
+            .iter()
+            .find(|t| t.topic_hash == wire::topic_hash(&name))
+            .expect("the topic must appear in the metrics");
+        assert_eq!(topic.messages_sent, 2);
+        assert_eq!(
+            topic.messages_skipped, 24,
+            "the 24 samples that never left this machine have to be visible \
+             somewhere, or a 25x downsample is indistinguishable from a slow \
+             publisher"
         );
     }
 }

--- a/horus_net/src/shm_reader.rs
+++ b/horus_net/src/shm_reader.rs
@@ -1,14 +1,74 @@
 //! ShmRingReader — read new data from local SHM topics for network export.
 //!
-//! Wraps `horus_core::communication::topic::read_latest_slot_bytes` to poll
-//! local SHM ring buffers and yield new entries since last read.
+//! Wraps `horus_core::communication::topic::read_latest_slot_bytes` and
+//! `read_slots_since` to poll local SHM ring buffers and yield new entries
+//! since the last read.
+//!
+//! Two things a reader owes its caller: the messages, and an honest account of
+//! the ones it did not hand over. The export path runs on a 50 ms timer, so a
+//! reader that only ever takes the newest slot caps every replicated topic at
+//! ~20 Hz however fast the publisher runs. That is the right trade for state —
+//! a pose, a battery level, a mode flag, where the freshest value is the only
+//! one worth a datagram — and the wrong one for a measurement stream, where the
+//! consumer integrates every sample. Whichever it is, the count of what was
+//! dropped is not optional: a fleet robot whose odometry crosses the LAN at
+//! 20 Hz instead of 500 Hz looks, from the other end, exactly like a robot
+//! whose odometry runs at 20 Hz.
 
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
-use horus_core::communication::topic::read_latest_slot_bytes;
+use horus_core::communication::topic::{read_latest_slot_bytes, read_slots_since, TopicSlotRead};
 use horus_sys::shm::topic_shm_path;
 
 use crate::priority::Encoding;
+
+/// How much of a topic's ring the exporter takes on each poll.
+///
+/// The export loop ticks at a fixed rate, so this is the difference between a
+/// topic being *sampled* onto the network and being *streamed* onto it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExportSampling {
+    /// Newest slot only; everything published since the previous poll is
+    /// dropped, and counted in [`ShmRingReader::skipped_decimated`].
+    ///
+    /// Correct for state-like topics, where a stale sample has no value once a
+    /// fresher one exists. It is the default because it is also the bandwidth
+    /// floor: switching a fleet to full streams without asking could saturate
+    /// the link the safety heartbeat shares.
+    #[default]
+    LatestOnly,
+    /// Every message published since the previous poll, oldest first, up to the
+    /// caller's per-poll bound. Anything beyond the bound is not lost — it is
+    /// returned by the next poll, because the reader resumes from its own
+    /// cursor rather than from the head.
+    AllSlots,
+}
+
+impl ExportSampling {
+    /// Parse a configured mode name. `None` for anything unrecognised, so a
+    /// caller can fall through to its own default rather than guessing.
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "all" | "all_slots" | "stream" | "every" | "full" => Some(Self::AllSlots),
+            "latest" | "latest_only" | "newest" | "sample" | "sampled" => Some(Self::LatestOnly),
+            _ => None,
+        }
+    }
+
+    /// Whether this mode replicates every message.
+    pub fn is_stream(self) -> bool {
+        matches!(self, Self::AllSlots)
+    }
+}
+
+/// How often a topic that is losing messages says so, at most.
+///
+/// The first loss on a topic is reported immediately — an operator should not
+/// have to wait out an interval to learn the fleet is dropping data — and every
+/// report after that is spaced by this, because the alternative on a 1 kHz topic
+/// is a log line per tick that nobody reads.
+pub const SKIP_REPORT_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Raw message read from SHM, ready for network transmission.
 #[derive(Debug, Clone)]
@@ -23,10 +83,81 @@ pub struct RawShmMessage {
     pub encoding: Encoding,
 }
 
+/// An account of what a topic did not put on the wire, ready to be logged.
+///
+/// Covers the window since the previous report for this topic, so the rates it
+/// quotes are the rates an operator would measure over that window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkipReport {
+    /// Topic this is about.
+    pub topic: String,
+    /// Sampling mode in force while the window ran.
+    pub sampling: ExportSampling,
+    /// Messages exported during the window.
+    pub forwarded: u64,
+    /// Messages dropped because latest-only sampling took the newest slot only.
+    pub decimated: u64,
+    /// Messages the publisher overwrote before the exporter reached them.
+    pub lapped: u64,
+    /// Wall time the window covers.
+    pub window: Duration,
+}
+
+impl SkipReport {
+    /// Messages that existed locally during the window, exported or not.
+    pub fn published(&self) -> u64 {
+        self.forwarded
+            .saturating_add(self.decimated)
+            .saturating_add(self.lapped)
+    }
+
+    /// Messages that existed locally and did not leave this machine.
+    pub fn skipped(&self) -> u64 {
+        self.decimated.saturating_add(self.lapped)
+    }
+
+    /// The operator-facing line. Names the topic, the numbers, the cause, and
+    /// the one setting that changes it — a warning that does not say what to do
+    /// about it is just noise on a robot's console.
+    pub fn message(&self) -> String {
+        let secs = self.window.as_secs_f64().max(0.001);
+        let published = self.published();
+        let mut msg = format!(
+            "[horus_net] Topic '{}' exported {} of {} messages in the last {:.1}s \
+             ({:.0} Hz of {:.0} Hz published).",
+            self.topic,
+            self.forwarded,
+            published,
+            secs,
+            self.forwarded as f64 / secs,
+            published as f64 / secs,
+        );
+        if self.decimated > 0 {
+            msg.push_str(&format!(
+                " {} were dropped by latest-only export, which takes one newest sample \
+                 per tick: correct for state (a pose, a battery level), wrong for a \
+                 measurement stream (odometry, joint states, lidar). \
+                 Set HORUS_NET_EXPORT_STREAM='{}' (globs allowed) to replicate every message.",
+                self.decimated, self.topic
+            ));
+        }
+        if self.lapped > 0 {
+            msg.push_str(&format!(
+                " {} were overwritten in the local ring before the exporter reached them — \
+                 the publisher is outrunning the export tick. Give the topic a larger ring \
+                 or publish more slowly.",
+                self.lapped
+            ));
+        }
+        msg
+    }
+}
+
 /// Reader that polls a local SHM topic ring buffer for new data.
 ///
-/// Each reader tracks its last-read position. Calling `try_read_next()`
-/// returns new data or `None` if no new messages since last read.
+/// Each reader tracks its last-read position. Calling `read_pending()` returns
+/// what is new since that position, under the reader's [`ExportSampling`] mode,
+/// and every message it does *not* return is counted.
 pub struct ShmRingReader {
     /// Path to the SHM backing file for this topic.
     shm_path: PathBuf,
@@ -34,6 +165,24 @@ pub struct ShmRingReader {
     last_write_idx: u64,
     /// Topic name (for logging).
     topic_name: String,
+    /// How much of the ring each poll takes.
+    sampling: ExportSampling,
+    // ── What this reader did and did not put on the wire ──
+    /// Messages handed to the export path, for the life of the reader.
+    forwarded: u64,
+    /// Messages that were in the ring and were skipped because latest-only
+    /// sampling takes the newest slot and leaves the rest.
+    skipped_decimated: u64,
+    /// Messages the publisher overwrote before this reader reached them.
+    skipped_lapped: u64,
+    // ── The same three, since the last report ──
+    window_forwarded: u64,
+    window_decimated: u64,
+    window_lapped: u64,
+    /// When the current reporting window opened.
+    window_start: Instant,
+    /// Whether a report has ever been emitted for this reader.
+    reported: bool,
 }
 
 impl ShmRingReader {
@@ -44,20 +193,57 @@ impl ShmRingReader {
         // `horus_` prefix was dropped on 2026-03-29 — so the export side of LAN
         // replication silently read nothing for four months.
         let shm_path = topic_shm_path(topic_name);
-
-        Self {
-            shm_path,
-            last_write_idx: 0,
-            topic_name: topic_name.to_string(),
-        }
+        Self::at(topic_name, shm_path)
     }
 
     /// Create a reader with a custom SHM path (for testing).
     pub fn with_path(topic_name: &str, shm_path: PathBuf) -> Self {
+        Self::at(topic_name, shm_path)
+    }
+
+    fn at(topic_name: &str, shm_path: PathBuf) -> Self {
         Self {
             shm_path,
             last_write_idx: 0,
             topic_name: topic_name.to_string(),
+            sampling: ExportSampling::default(),
+            forwarded: 0,
+            skipped_decimated: 0,
+            skipped_lapped: 0,
+            window_forwarded: 0,
+            window_decimated: 0,
+            window_lapped: 0,
+            window_start: Instant::now(),
+            reported: false,
+        }
+    }
+
+    /// Builder form of [`Self::set_sampling`].
+    pub fn with_sampling(mut self, sampling: ExportSampling) -> Self {
+        self.sampling = sampling;
+        self
+    }
+
+    /// Change how much of the ring each poll takes.
+    pub fn set_sampling(&mut self, sampling: ExportSampling) {
+        self.sampling = sampling;
+    }
+
+    /// Current sampling mode.
+    pub fn sampling(&self) -> ExportSampling {
+        self.sampling
+    }
+
+    /// Read what is new since the last poll, under this reader's sampling mode.
+    ///
+    /// `max` bounds the work of one poll in [`ExportSampling::AllSlots`]; the
+    /// remainder is returned by the next poll rather than dropped. In
+    /// [`ExportSampling::LatestOnly`] the result is at most one message and
+    /// `max` is irrelevant.
+    pub fn read_pending(&mut self, max: usize) -> Vec<RawShmMessage> {
+        match self.sampling {
+            ExportSampling::LatestOnly => self.try_read_latest().into_iter().collect(),
+            ExportSampling::AllSlots => self.try_read_all(max),
         }
     }
 
@@ -70,31 +256,117 @@ impl ShmRingReader {
     pub fn try_read_latest(&mut self) -> Option<RawShmMessage> {
         let slot = read_latest_slot_bytes(&self.shm_path, self.last_write_idx)?;
 
-        // Update tracking
-        let gap = if self.last_write_idx > 0 {
-            slot.write_idx.saturating_sub(self.last_write_idx)
-        } else {
-            1
-        };
-        if gap > 1 {
-            // We missed some messages (ring lapped us or we're slow).
-            // Only the latest is available — this is fine for network replication
-            // since we always want the freshest data.
+        // Everything published between the previous poll and this one was in the
+        // ring and is not going anywhere: this call hands back the newest slot
+        // and nothing else. The gap used to be computed right here and thrown
+        // away inside an empty `if gap > 1 {}` block — that empty block was the
+        // whole of the "downsampling is fine for network replication" argument,
+        // and it is what made a 25x decimation of a robot's odometry invisible
+        // at both ends of the link.
+        //
+        // A first read is not decimation: a reader that has never polled starts
+        // at "now" rather than replaying whatever history the ring holds.
+        if self.last_write_idx > 0 {
+            let skipped = slot
+                .write_idx
+                .saturating_sub(self.last_write_idx)
+                .saturating_sub(1);
+            self.skipped_decimated = self.skipped_decimated.saturating_add(skipped);
+            self.window_decimated = self.window_decimated.saturating_add(skipped);
         }
         self.last_write_idx = slot.write_idx;
+        self.count_forwarded(1);
 
-        let encoding = if slot.is_pod {
-            Encoding::native_pod()
-        } else {
-            Encoding::Bincode
+        Some(Self::to_raw(slot))
+    }
+
+    /// Try to read every message published since the last poll, oldest first.
+    ///
+    /// At most `max` per call; the rest arrive on the next one. Messages the
+    /// publisher overwrote before this reader reached them are counted in
+    /// [`Self::skipped_lapped`] rather than left as a silent hole in the
+    /// sequence numbering the peer sees.
+    pub fn try_read_all(&mut self, max: usize) -> Vec<RawShmMessage> {
+        if max == 0 {
+            return Vec::new();
+        }
+
+        // Probe the head first. `read_slots_since` cannot tell "no new data"
+        // apart from "the ring restarted below our cursor" — both come back as
+        // an empty batch — and the second case would wedge this reader forever:
+        // a publisher process that is replaced, recreating the backing file,
+        // resets the write index to 1 while our cursor sits at, say, 40000, and
+        // the topic would then never export again with nothing said about it.
+        // The latest-only path self-heals from that by construction, so the
+        // streaming path has to as well.
+        let Some(head) = read_latest_slot_bytes(&self.shm_path, self.last_write_idx) else {
+            return Vec::new();
+        };
+        if head.write_idx < self.last_write_idx {
+            self.last_write_idx = 0;
+        }
+
+        // First poll (or a resynchronisation): start at the head rather than
+        // replaying a full ring of history nobody asked for.
+        if self.last_write_idx == 0 {
+            self.last_write_idx = head.write_idx;
+            self.count_forwarded(1);
+            return vec![Self::to_raw(head)];
+        }
+
+        let (slots, lapped) = read_slots_since(&self.shm_path, self.last_write_idx, max);
+        if slots.is_empty() && lapped == 0 {
+            return Vec::new();
+        }
+
+        // `read_slots_since` walks the ordinals `cursor+1 ..= cursor+want`
+        // contiguously and accounts for every one of them: it either returns the
+        // slot or counts it lapped. So the cursor advances by exactly what was
+        // accounted for — which also means a reader that fell an entire ring
+        // behind climbs out instead of re-counting the same unreachable window
+        // on every tick.
+        let accounted = (slots.len() as u64).saturating_add(lapped);
+        self.last_write_idx = self.last_write_idx.saturating_add(accounted);
+
+        if lapped > 0 {
+            self.skipped_lapped = self.skipped_lapped.saturating_add(lapped);
+            self.window_lapped = self.window_lapped.saturating_add(lapped);
+        }
+        self.count_forwarded(slots.len() as u64);
+
+        slots.into_iter().map(Self::to_raw).collect()
+    }
+
+    /// A due account of the messages this topic is not replicating, or `None`
+    /// when there is nothing to report or the previous report is too recent.
+    ///
+    /// `now` is passed in rather than read here so the cadence is testable
+    /// without sleeping.
+    pub fn due_report(&mut self, now: Instant) -> Option<SkipReport> {
+        if self.window_decimated == 0 && self.window_lapped == 0 {
+            return None;
+        }
+        let window = now.saturating_duration_since(self.window_start);
+        if self.reported && window < SKIP_REPORT_INTERVAL {
+            return None;
+        }
+
+        let report = SkipReport {
+            topic: self.topic_name.clone(),
+            sampling: self.sampling,
+            forwarded: self.window_forwarded,
+            decimated: self.window_decimated,
+            lapped: self.window_lapped,
+            window,
         };
 
-        Some(RawShmMessage {
-            data: slot.payload,
-            write_idx: slot.write_idx,
-            is_pod: slot.is_pod,
-            encoding,
-        })
+        self.reported = true;
+        self.window_start = now;
+        self.window_forwarded = 0;
+        self.window_decimated = 0;
+        self.window_lapped = 0;
+
+        Some(report)
     }
 
     /// Check if the SHM file exists (topic has been created locally).
@@ -110,6 +382,46 @@ impl ShmRingReader {
     /// Current write index (0 if never read).
     pub fn last_write_idx(&self) -> u64 {
         self.last_write_idx
+    }
+
+    /// Messages handed to the export path over this reader's life.
+    pub fn forwarded(&self) -> u64 {
+        self.forwarded
+    }
+
+    /// Messages left behind by latest-only sampling over this reader's life.
+    pub fn skipped_decimated(&self) -> u64 {
+        self.skipped_decimated
+    }
+
+    /// Messages the publisher overwrote before this reader reached them.
+    pub fn skipped_lapped(&self) -> u64 {
+        self.skipped_lapped
+    }
+
+    /// Every local message this reader did not put on the wire.
+    pub fn skipped_total(&self) -> u64 {
+        self.skipped_decimated.saturating_add(self.skipped_lapped)
+    }
+
+    fn count_forwarded(&mut self, n: u64) {
+        self.forwarded = self.forwarded.saturating_add(n);
+        self.window_forwarded = self.window_forwarded.saturating_add(n);
+    }
+
+    fn to_raw(slot: TopicSlotRead) -> RawShmMessage {
+        let encoding = if slot.is_pod {
+            Encoding::native_pod()
+        } else {
+            Encoding::Bincode
+        };
+
+        RawShmMessage {
+            data: slot.payload,
+            write_idx: slot.write_idx,
+            is_pod: slot.is_pod,
+            encoding,
+        }
     }
 }
 
@@ -132,6 +444,8 @@ mod tests {
             PathBuf::from("/tmp/nonexistent_shm_file_horus_net_test"),
         );
         assert!(reader.try_read_latest().is_none());
+        assert!(reader.try_read_all(64).is_empty());
+        assert_eq!(reader.skipped_total(), 0);
     }
 
     #[test]
@@ -160,5 +474,119 @@ mod tests {
         let name = "robot.imu";
         let reader = ShmRingReader::new(name);
         assert_eq!(reader.shm_path, topic_shm_path(name));
+    }
+
+    #[test]
+    fn default_sampling_is_latest_only() {
+        let reader = ShmRingReader::new("robot.pose");
+        assert_eq!(reader.sampling(), ExportSampling::LatestOnly);
+        assert!(!reader.sampling().is_stream());
+    }
+
+    #[test]
+    fn sampling_mode_parses_both_spellings_and_rejects_nonsense() {
+        for stream in ["stream", "all", "ALL_SLOTS", " every ", "full"] {
+            assert_eq!(
+                ExportSampling::parse(stream),
+                Some(ExportSampling::AllSlots)
+            );
+        }
+        for latest in ["latest", "latest_only", "Newest", "sample", "sampled"] {
+            assert_eq!(
+                ExportSampling::parse(latest),
+                Some(ExportSampling::LatestOnly)
+            );
+        }
+        // A typo must not silently pick a mode for the operator.
+        assert_eq!(ExportSampling::parse("streem"), None);
+        assert_eq!(ExportSampling::parse(""), None);
+    }
+
+    fn report(decimated: u64, lapped: u64) -> SkipReport {
+        SkipReport {
+            topic: "odom".into(),
+            sampling: if lapped > 0 {
+                ExportSampling::AllSlots
+            } else {
+                ExportSampling::LatestOnly
+            },
+            forwarded: 20,
+            decimated,
+            lapped,
+            window: Duration::from_secs(10),
+        }
+    }
+
+    #[test]
+    fn a_decimation_report_names_the_topic_the_count_and_the_way_out() {
+        let msg = report(480, 0).message();
+        assert!(msg.contains("'odom'"), "{msg}");
+        assert!(msg.contains("exported 20 of 500"), "{msg}");
+        assert!(
+            msg.contains("480 were dropped by latest-only export"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("HORUS_NET_EXPORT_STREAM='odom'"),
+            "a warning with no remedy is noise: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_lapped_report_blames_the_ring_not_the_sampling() {
+        let msg = report(0, 7).message();
+        assert!(
+            msg.contains("7 were overwritten in the local ring"),
+            "{msg}"
+        );
+        assert!(
+            !msg.contains("latest-only export"),
+            "stream mode does not decimate; saying so would send the operator \
+             chasing the wrong setting: {msg}"
+        );
+    }
+
+    #[test]
+    fn report_arithmetic_counts_every_local_message_once() {
+        let r = report(480, 7);
+        assert_eq!(r.published(), 507);
+        assert_eq!(r.skipped(), 487);
+    }
+
+    #[test]
+    fn no_report_while_nothing_is_being_skipped() {
+        let mut reader = ShmRingReader::new("robot.pose");
+        reader.count_forwarded(100);
+        assert!(reader.due_report(Instant::now()).is_none());
+    }
+
+    #[test]
+    fn the_first_skip_is_reported_at_once_then_rate_limited() {
+        let mut reader = ShmRingReader::new("robot.odom");
+        let t0 = Instant::now();
+
+        reader.count_forwarded(1);
+        reader.window_decimated = 24;
+        let first = reader
+            .due_report(t0)
+            .expect("the first loss on a topic must not wait out an interval");
+        assert_eq!(first.decimated, 24);
+        assert_eq!(first.forwarded, 1);
+
+        // Counters reset with the window, so an immediate re-poll says nothing.
+        assert!(reader.due_report(t0).is_none());
+
+        // More loss, but too soon: still silent.
+        reader.window_decimated = 24;
+        assert!(reader.due_report(t0 + Duration::from_secs(3)).is_none());
+
+        // Past the interval it speaks again, and reports the whole backlog —
+        // the losses that accumulated while it was quiet are not forgotten.
+        reader.window_decimated += 100;
+        let second = reader
+            .due_report(t0 + SKIP_REPORT_INTERVAL)
+            .expect("a report is due once the interval has passed");
+        assert_eq!(second.decimated, 124);
+        assert_eq!(second.window, SKIP_REPORT_INTERVAL);
     }
 }

--- a/horus_net/tests/export_sampling.rs
+++ b/horus_net/tests/export_sampling.rs
@@ -1,0 +1,382 @@
+//! Export sampling — what a replicated topic puts on the wire, and what it
+//! admits to leaving behind.
+//!
+//! The export loop polls SHM on a 50 ms timer. Taking only the newest slot on
+//! each poll pins every replicated topic at ~20 Hz however fast its publisher
+//! runs, which is correct for state (a pose, a battery level) and wrong for a
+//! measurement stream (odometry, joint states, lidar). Both modes exist here;
+//! what neither is allowed to do is lose messages quietly.
+//!
+//! These drive the real SHM ring through `write_topic_slot_bytes`, which is the
+//! cross-process contract `ShmRingReader` reads on a robot.
+
+use horus_core::communication::{write_topic_slot_bytes, Topic};
+use horus_net::config::NetConfig;
+use horus_net::shm_reader::{ExportSampling, ShmRingReader};
+use horus_robotics::CmdVel;
+use horus_sys::shm::shm_topics_dir;
+
+/// Ring capacity a `Topic<CmdVel>` gets: 4096-byte page / 16-byte message.
+const RING_CAPACITY: u32 = 256;
+
+fn unique_topic(base: &str) -> String {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("sampling_{base}_{id}_{}", std::process::id())
+}
+
+fn shm_path_for(topic_name: &str) -> std::path::PathBuf {
+    shm_topics_dir().join(topic_name)
+}
+
+fn publish(path: &std::path::Path, linear: f32) {
+    let cmd = CmdVel::new(linear, 0.0);
+    // SAFETY: CmdVel is a POD message; this is the byte form the SHM ring holds.
+    let bytes: &[u8] = unsafe {
+        std::slice::from_raw_parts(
+            &cmd as *const CmdVel as *const u8,
+            std::mem::size_of::<CmdVel>(),
+        )
+    };
+    assert!(
+        write_topic_slot_bytes(path, bytes),
+        "raw SHM publish must succeed"
+    );
+}
+
+fn linear_of(msg: &horus_net::shm_reader::RawShmMessage) -> f32 {
+    assert_eq!(msg.data.len(), std::mem::size_of::<CmdVel>());
+    // SAFETY: the slot holds exactly the CmdVel bytes written above.
+    let cmd: CmdVel = unsafe { std::ptr::read_unaligned(msg.data.as_ptr() as *const CmdVel) };
+    cmd.linear
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The burst must cross intact in stream mode
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_burst_crosses_intact_in_stream_mode() {
+    let name = unique_topic("burst");
+    let _topic: Topic<CmdVel> = Topic::new(&name).expect("create topic");
+    let path = shm_path_for(&name);
+
+    let mut reader = ShmRingReader::new(&name).with_sampling(ExportSampling::AllSlots);
+
+    // The first poll starts the reader at "now" rather than replaying history.
+    publish(&path, 0.0);
+    let first = reader.read_pending(64);
+    assert_eq!(first.len(), 1);
+    assert_eq!(linear_of(&first[0]), 0.0);
+
+    // A publisher running far faster than the export tick: 50 messages between
+    // one poll and the next.
+    const BURST: usize = 50;
+    for i in 1..=BURST {
+        publish(&path, i as f32);
+    }
+
+    let batch = reader.read_pending(64);
+    assert_eq!(
+        batch.len(),
+        BURST,
+        "every message published between two polls must cross, not just the newest"
+    );
+    let seen: Vec<f32> = batch.iter().map(linear_of).collect();
+    let expected: Vec<f32> = (1..=BURST).map(|i| i as f32).collect();
+    assert_eq!(seen, expected, "and in publish order, oldest first");
+
+    // Sequence numbers are the ring's own write indices, so the receiving peer
+    // can tell a gap from a reorder.
+    let idx: Vec<u64> = batch.iter().map(|m| m.write_idx).collect();
+    let expected_idx: Vec<u64> = (2..=(BURST as u64 + 1)).collect();
+    assert_eq!(idx, expected_idx);
+
+    assert_eq!(
+        reader.skipped_total(),
+        0,
+        "nothing was skipped, so nothing may be reported as skipped"
+    );
+    assert_eq!(reader.forwarded(), BURST as u64 + 1);
+    assert!(
+        reader.due_report(std::time::Instant::now()).is_none(),
+        "a topic that lost nothing must not cry wolf"
+    );
+}
+
+#[test]
+fn a_bounded_batch_resumes_on_the_next_poll_rather_than_dropping() {
+    let name = unique_topic("resume");
+    let _topic: Topic<CmdVel> = Topic::new(&name).expect("create topic");
+    let path = shm_path_for(&name);
+
+    let mut reader = ShmRingReader::new(&name).with_sampling(ExportSampling::AllSlots);
+    publish(&path, 0.0);
+    assert_eq!(reader.read_pending(64).len(), 1);
+
+    // More than one poll's worth, but well inside the ring.
+    for i in 1..=200 {
+        publish(&path, i as f32);
+    }
+
+    let mut seen: Vec<f32> = Vec::new();
+    for _ in 0..10 {
+        let batch = reader.read_pending(64);
+        assert!(batch.len() <= 64, "the per-poll bound must be honoured");
+        if batch.is_empty() {
+            break;
+        }
+        seen.extend(batch.iter().map(linear_of));
+    }
+
+    let expected: Vec<f32> = (1..=200).map(|i| i as f32).collect();
+    assert_eq!(
+        seen, expected,
+        "the bound caps a poll's work; it must not lose the remainder"
+    );
+    assert_eq!(reader.skipped_total(), 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The skipped count must be non-zero and correct in latest-only mode
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn latest_only_export_counts_every_sample_it_drops() {
+    let name = unique_topic("decimated");
+    let _topic: Topic<CmdVel> = Topic::new(&name).expect("create topic");
+    let path = shm_path_for(&name);
+
+    // The shipped default: no per-topic configuration at all.
+    let mut reader = ShmRingReader::new(&name);
+    assert_eq!(reader.sampling(), ExportSampling::LatestOnly);
+
+    publish(&path, 0.0);
+    assert_eq!(reader.read_pending(64).len(), 1);
+    assert_eq!(
+        reader.skipped_decimated(),
+        0,
+        "starting at 'now' is not decimation"
+    );
+
+    // One export tick's worth of a 500 Hz publisher: 25 messages per 50 ms.
+    for i in 1..=25 {
+        publish(&path, i as f32);
+    }
+
+    let batch = reader.read_pending(64);
+    assert_eq!(
+        batch.len(),
+        1,
+        "latest-only still takes the newest slot only"
+    );
+    assert_eq!(linear_of(&batch[0]), 25.0, "and it is the freshest one");
+    assert_eq!(
+        reader.skipped_decimated(),
+        24,
+        "the 24 messages this topic published and never exported must be counted"
+    );
+    assert_eq!(reader.skipped_lapped(), 0, "the ring never lapped");
+    assert_eq!(reader.skipped_total(), 24);
+
+    // Again, so the counter is cumulative rather than per-poll.
+    for i in 26..=50 {
+        publish(&path, i as f32);
+    }
+    assert_eq!(reader.read_pending(64).len(), 1);
+    assert_eq!(reader.skipped_decimated(), 48);
+}
+
+#[test]
+fn a_decimated_topic_says_so_on_the_console() {
+    let name = unique_topic("loud");
+    let _topic: Topic<CmdVel> = Topic::new(&name).expect("create topic");
+    let path = shm_path_for(&name);
+
+    let mut reader = ShmRingReader::new(&name);
+    publish(&path, 0.0);
+    reader.read_pending(64);
+    for i in 1..=25 {
+        publish(&path, i as f32);
+    }
+    reader.read_pending(64);
+
+    let report = reader
+        .due_report(std::time::Instant::now())
+        .expect("a topic losing 24 of every 25 messages must not be silent");
+    assert_eq!(report.topic, name);
+    assert_eq!(report.decimated, 24);
+    assert_eq!(report.forwarded, 2);
+    assert_eq!(report.sampling, ExportSampling::LatestOnly);
+
+    let msg = report.message();
+    assert!(msg.contains(&name), "the line must name the topic: {msg}");
+    assert!(msg.contains("24"), "and the count: {msg}");
+    assert!(
+        msg.contains("HORUS_NET_EXPORT_STREAM"),
+        "and the way to stop it: {msg}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A reader that falls a whole ring behind must climb out, and say what it lost
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_stream_reader_lapped_by_the_publisher_counts_the_loss_and_catches_up() {
+    let name = unique_topic("lapped");
+    let _topic: Topic<CmdVel> = Topic::new(&name).expect("create topic");
+    let path = shm_path_for(&name);
+
+    let mut reader = ShmRingReader::new(&name).with_sampling(ExportSampling::AllSlots);
+    publish(&path, 0.0);
+    assert_eq!(reader.read_pending(64).len(), 1);
+
+    // Far more than the ring holds between two polls: the publisher overwrites
+    // slots this reader has not reached. That is a real loss, and the point is
+    // that it is counted rather than silently absent from the peer's stream.
+    let burst = RING_CAPACITY as usize + 144;
+    for i in 1..=burst {
+        publish(&path, i as f32);
+    }
+
+    let mut delivered = 0u64;
+    for _ in 0..64 {
+        let batch = reader.read_pending(64);
+        if batch.is_empty() && reader.last_write_idx() > burst as u64 {
+            break;
+        }
+        delivered += batch.len() as u64;
+    }
+
+    assert!(
+        reader.skipped_lapped() > 0,
+        "the ring demonstrably lapped; the reader must not report a clean run"
+    );
+    assert_eq!(
+        delivered + reader.skipped_lapped(),
+        burst as u64,
+        "every message published is either delivered or counted lost — no third \
+         category, and no silent hole"
+    );
+    assert_eq!(
+        reader.last_write_idx(),
+        burst as u64 + 1,
+        "a reader lapped by a whole ring must catch up to the head, not wedge \
+         re-counting a window it can never reach"
+    );
+
+    let report = reader
+        .due_report(std::time::Instant::now())
+        .expect("a lapped stream must report");
+    assert_eq!(report.decimated, 0, "stream mode does not decimate");
+    assert!(report.lapped > 0);
+    let msg = report.message();
+    assert!(
+        msg.contains("overwritten in the local ring"),
+        "the operator must be pointed at the ring, not at the sampling mode: {msg}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Config selects the mode per topic
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn config_picks_the_mode_per_topic() {
+    let mut config = NetConfig::test_config(0);
+    assert_eq!(
+        config.export_sampling("odom"),
+        ExportSampling::LatestOnly,
+        "the default is unchanged: sampled, and now loud about it"
+    );
+
+    config.export_stream = vec!["odom".into(), "robot.*.scan".into()];
+    assert_eq!(config.export_sampling("odom"), ExportSampling::AllSlots);
+    assert_eq!(
+        config.export_sampling("robot.front_lidar.scan"),
+        ExportSampling::AllSlots
+    );
+    assert_eq!(
+        config.export_sampling("battery"),
+        ExportSampling::LatestOnly,
+        "a pose or a battery level is right to sample"
+    );
+}
+
+#[test]
+fn a_per_topic_override_beats_the_pattern_list() {
+    let mut config = NetConfig::test_config(0);
+    config.export_stream = vec!["*".into()];
+    config.topic_overrides.insert(
+        "battery".into(),
+        horus_net::config::TopicNetConfig {
+            export_sampling: Some("latest".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(config.export_sampling("odom"), ExportSampling::AllSlots);
+    assert_eq!(
+        config.export_sampling("battery"),
+        ExportSampling::LatestOnly
+    );
+
+    // A typo must not quietly choose a mode on the operator's behalf; it falls
+    // through to the pattern list, which here says stream.
+    config.topic_overrides.insert(
+        "imu".into(),
+        horus_net::config::TopicNetConfig {
+            export_sampling: Some("streem".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(config.export_sampling("imu"), ExportSampling::AllSlots);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A publisher that restarts must not silently end the topic's replication
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_stream_reader_resynchronises_when_the_publisher_recreates_the_ring() {
+    // A node restarts, its backing file is recreated, and the write index goes
+    // back to 1 while the exporter's cursor sits well above it. Latest-only
+    // export recovers from that by construction — any index that differs from
+    // the cursor is new data. A streaming reader asks "what came after my
+    // cursor?", and the honest answer is "nothing, ever again": the topic would
+    // stop crossing the LAN with nothing logged and every counter clean, which
+    // is the same silence this whole change exists to remove.
+    let live = unique_topic("resync_live");
+    let fresh = unique_topic("resync_fresh");
+    let _live_topic: Topic<CmdVel> = Topic::new(&live).expect("create topic");
+    let _fresh_topic: Topic<CmdVel> = Topic::new(&fresh).expect("create replacement topic");
+    let live_path = shm_path_for(&live);
+    let fresh_path = shm_path_for(&fresh);
+
+    let mut reader = ShmRingReader::new(&live).with_sampling(ExportSampling::AllSlots);
+    // The first poll starts the reader at "now"; the other 29 stream through.
+    publish(&live_path, 0.0);
+    let mut delivered = reader.read_pending(64).len();
+    for i in 1..30 {
+        publish(&live_path, i as f32);
+    }
+    for _ in 0..4 {
+        delivered += reader.read_pending(64).len();
+    }
+    assert_eq!(delivered, 30);
+    assert_eq!(reader.last_write_idx(), 30);
+
+    // The publisher is replaced: same topic path, brand-new ring at index 0.
+    std::fs::rename(&fresh_path, &live_path).expect("swap in the recreated ring");
+    publish(&live_path, 99.0);
+
+    let batch = reader.read_pending(64);
+    assert_eq!(
+        batch.len(),
+        1,
+        "a recreated ring must be picked up, not waited on forever"
+    );
+    assert_eq!(linear_of(&batch[0]), 99.0);
+    assert_eq!(reader.last_write_idx(), 1);
+}


### PR DESCRIPTION
`handle_export` called `reader.try_read_latest()` once per 50 ms timer tick, and `ShmRingReader::try_read_latest` computed the write-index gap and threw it away inside a **literally empty** `if gap > 1 { /* comment arguing this is fine */ }` block. No counter, no log, no metric. Every replicated topic was pinned at ~20 Hz regardless of publish rate — a fleet robot's odometry, joint states or lidar arriving at 20 Hz, with nothing anywhere saying so.

The default stays `LatestOnly`: streaming every topic by default is a wire-behaviour change that could crowd the link a safety heartbeat shares on a deployed fleet, and decimation is genuinely correct for state (a pose, a battery level). **The silence was the bug, so the silence is what was removed.** A decimated topic now says so:

    [horus_net] Topic 'odom' exported 2 of 26 messages in the last 0.2s (13 Hz of 164 Hz
    published). 24 were dropped by latest-only export, which takes one newest sample per
    tick: correct for state (a pose, a battery level), wrong for a measurement stream
    (odometry, joint states, lidar). Set HORUS_NET_EXPORT_STREAM='odom' to replicate every
    message.

Also adds opt-in `AllSlots` streaming per topic (`HORUS_NET_EXPORT_STREAM`, globs, or per-topic config), bounded at 64 messages/topic/tick. Two correctness details streaming needed: the cursor advances by everything *accounted for* (delivered + lapped) so a reader a whole ring behind climbs out instead of wedging, and an explicit resync when the publisher process is replaced and the ring restarts below the cursor — which `read_slots_since` alone reports as "no new data, forever".

An unrecognised mode string falls through rather than picking a mode on the operator's behalf.

26 new tests including two that drive a real SHM ring and a real UDP subscriber. `cargo test -p horus_net` green.