### PR TITLE
fix(rt,safety): five real-time and safety defects in horus_core

### DIFF
--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -2,6 +2,26 @@
 //!
 //! These are the building blocks that the scheduler composes for different
 //! execution strategies (sequential, parallel, future RT-thread, etc.).
+//!
+//! # Everything above `run_tick` runs on an RT thread
+//!
+//! `honor_safe_state_request` and `apply_degradation_action` are reached only
+//! from `rt_executor` -- the scheduler keeps its own main-thread copy of the
+//! degradation dispatch -- so they execute on a SCHED_FIFO thread, inside the
+//! tick. They therefore report through `rt_diag`, which formats into a
+//! statically allocated ring and never allocates, blocks or enters the kernel,
+//! rather than through `print_line`.
+//!
+//! `print_line` does `isatty` + `tcgetattr`, takes the process-global stdout
+//! lock, then `write` and `flush`. Pointed at a slow consumer -- a serial
+//! console, a pipe nobody is reading -- that write blocks for as long as the
+//! reader takes, on the thread driving an actuator. Two of these sites are the
+//! `Isolate` and `Kill` rungs, which are not even verbose-gated and which safe
+//! or shut down the node in the same breath: the worst possible place to wait
+//! on a terminal.
+//!
+//! The drain half is started by `RtExecutor::start` on the caller's thread
+//! before any RT thread exists, so a line queued from here always has a drainer.
 
 use std::time::{Duration, Instant};
 
@@ -54,13 +74,13 @@ pub(crate) fn honor_safe_state_request(
         // latched by the ladder when it raised the request.
         node.is_stopped = true;
         if monitors.verbose {
-            crate::terminal::print_line(&format!(
+            super::rt_executor::rt_diag(format_args!(
                 " Watchdog critical: '{}' PANICKED in enter_safe_state on its executor",
                 node.name
             ));
         }
     } else if monitors.verbose {
-        crate::terminal::print_line(&format!(
+        super::rt_executor::rt_diag(format_args!(
             " Watchdog critical: '{}' entered safe state on its executor",
             node.name
         ));
@@ -96,7 +116,7 @@ pub(crate) fn apply_degradation_action(
         DegradationAction::None => {}
         DegradationAction::Warn(ref name) => {
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Degradation: '{name}' — sustained timing violations, monitoring"
                 ));
             }
@@ -120,7 +140,7 @@ pub(crate) fn apply_degradation_action(
             node.rate_hz = Some(new_rate_hz);
             node.last_tick = Some(Instant::now());
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Degradation: '{name}' — reducing rate to {new_rate_hz:.1} Hz"
                 ));
             }
@@ -135,7 +155,7 @@ pub(crate) fn apply_degradation_action(
             if panicked {
                 node.is_stopped = true;
             }
-            crate::terminal::print_line(&format!(
+            super::rt_executor::rt_diag(format_args!(
                 " Degradation: '{name}' — isolated, entered safe state{}",
                 if panicked {
                     " FAILED (panicked) — node stopped"
@@ -155,7 +175,7 @@ pub(crate) fn apply_degradation_action(
             }))
             .is_err();
             node.is_stopped = true;
-            crate::terminal::print_line(&format!(
+            super::rt_executor::rt_diag(format_args!(
                 " KILL: '{name}' — permanently removed from execution after shutdown(){}",
                 if panicked { " (shutdown panicked)" } else { "" }
             ));
@@ -175,7 +195,7 @@ pub(crate) fn apply_degradation_action(
             node.last_tick = Some(Instant::now());
             set_health(node, NodeHealthState::Healthy);
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Recovery: '{name}' — restored to {original_rate_hz:.1} Hz"
                 ));
             }
@@ -183,7 +203,7 @@ pub(crate) fn apply_degradation_action(
         DegradationAction::Deisolate(ref name) => {
             set_health(node, NodeHealthState::Warning);
             if monitors.verbose {
-                crate::terminal::print_line(&format!(
+                super::rt_executor::rt_diag(format_args!(
                     " Recovery: '{name}' — de-isolated, resuming at reduced rate"
                 ));
             }

--- a/horus_core/src/scheduling/profiler.rs
+++ b/horus_core/src/scheduling/profiler.rs
@@ -112,10 +112,24 @@ impl RuntimeProfiler {
 
         let duration_us = duration.as_micros() as f64;
 
-        self.node_stats
-            .entry(node_name.to_string())
-            .or_default()
-            .update(duration_us);
+        // `entry()` takes an owned key, so it allocates on EVERY call --
+        // including the hit path, where the key already exists and the String is
+        // built only to be dropped again. This runs on the RT thread, once per
+        // node per tick, from `rt_executor`'s `try_lock` on the profiler, with
+        // `enabled` defaulting to true. `malloc` has no WCET bound: arena
+        // contention takes it to `brk`/`mmap` and a page fault, inside the tick.
+        //
+        // The steady state is a hit -- a node's name is inserted on its first
+        // tick and never again -- so look up by borrow first and only pay for
+        // the key on the one tick that actually needs it.
+        if let Some(stats) = self.node_stats.get_mut(node_name) {
+            stats.update(duration_us);
+        } else {
+            self.node_stats
+                .entry(node_name.to_string())
+                .or_default()
+                .update(duration_us);
+        }
     }
 
     /// Record a failure for a node
@@ -124,10 +138,16 @@ impl RuntimeProfiler {
             return;
         }
 
-        self.node_stats
-            .entry(node_name.to_string())
-            .or_default()
-            .record_failure();
+        // Same reasoning as `record` above: this one is reached from the RT
+        // thread's panic path, where an unbounded `malloc` is worse still.
+        if let Some(stats) = self.node_stats.get_mut(node_name) {
+            stats.record_failure();
+        } else {
+            self.node_stats
+                .entry(node_name.to_string())
+                .or_default()
+                .record_failure();
+        }
     }
 }
 

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -4284,6 +4284,50 @@ mod tests {
         );
     }
 
+    /// The degradation ladder reports through the ring, not through stdout.
+    ///
+    /// `apply_degradation_action` is reached only from this executor, i.e. from
+    /// a SCHED_FIFO thread inside the tick, and it used to call
+    /// `print_line(&format!(...))`. `print_line` does `isatty` + `tcgetattr`,
+    /// takes the process-global stdout lock, then writes and flushes: pointed at
+    /// a serial console or a pipe nobody is reading, that blocks for as long as
+    /// the reader takes, on the thread driving an actuator.
+    ///
+    /// `Isolate` and `Kill` are the two rungs that were not even verbose-gated,
+    /// and both safe or shut down the node in the same breath -- the worst place
+    /// in the system to wait on a terminal. This asserts the line is queued
+    /// rather than printed.
+    #[test]
+    fn the_degradation_ladder_reports_through_the_ring_not_stdout() {
+        use super::super::safety_monitor::DegradationAction;
+        use std::sync::atomic::AtomicU64;
+
+        let monitors = test_monitors();
+        let mut node = make_rt_registered("ring_reporter", Arc::new(AtomicU64::new(0)));
+        node.rate_hz = Some(100.0);
+        monitors.node_controls.register("ring_reporter");
+
+        let before = RT_DIAG_HEAD.load(Ordering::Relaxed);
+        super::super::primitives::apply_degradation_action(
+            &mut node,
+            DegradationAction::Isolate("ring_reporter".to_string()),
+            &monitors,
+        );
+        let after = RT_DIAG_HEAD.load(Ordering::Relaxed);
+
+        assert!(
+            after > before,
+            "Isolate queued nothing — it is still going straight to stdout from \
+             the RT thread"
+        );
+        let found = find_queued(before..after, |t| t.contains("ring_reporter"))
+            .expect("the isolate line must be in the ring");
+        assert!(
+            found.contains("isolated"),
+            "queued the wrong line: {found}"
+        );
+    }
+
     /// The ring is BOUNDED and the producer never waits on the consumer.
     ///
     /// That is the whole point: a deadline miss must not be able to block the

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -4322,10 +4322,7 @@ mod tests {
         );
         let found = find_queued(before..after, |t| t.contains("ring_reporter"))
             .expect("the isolate line must be in the ring");
-        assert!(
-            found.contains("isolated"),
-            "queued the wrong line: {found}"
-        );
+        assert!(found.contains("isolated"), "queued the wrong line: {found}");
     }
 
     /// The ring is BOUNDED and the producer never waits on the consumer.

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -752,6 +752,14 @@ pub(crate) struct SafetyMonitor {
     degradation_policy: DegradationPolicy,
     /// Per-node degradation state
     degradation_states: Mutex<HashMap<String, NodeDegradationState>>,
+    /// A NEW external safe-state request the tick loop has not acted on yet.
+    ///
+    /// Separate from `state`, which latches `SafetyState::SafeState` as an
+    /// observable CONDITION and must stay set. This is the EDGE: it is raised
+    /// once per external trigger and cleared once the scheduler has driven the
+    /// nodes, so one link loss produces one round of safing rather than a fresh
+    /// request on every tick for the rest of the run.
+    external_safe_state_pending: AtomicBool,
 }
 
 /// A cheap, cloneable handle for feeding node watchdogs from another thread.
@@ -823,6 +831,7 @@ impl SafetyMonitor {
             degrade_activations: AtomicU64::new(0),
             degradation_policy: DegradationPolicy::default(),
             degradation_states: Mutex::new(HashMap::new()),
+            external_safe_state_pending: AtomicBool::new(false),
         }
     }
 
@@ -1297,11 +1306,19 @@ impl SafetyMonitor {
     /// Deliberately does NOT set `emergency_stop`: that flag ends the run loop,
     /// which is exactly the outcome an operator choosing `safe_state` over
     /// `stop` asked to avoid.
-    pub(crate) fn install_safe_state_hook(&self) {
+    pub(crate) fn install_safe_state_hook(self: &Arc<Self>) {
         let state = Arc::clone(&self.state);
+        let pending = Arc::clone(self);
         set_safe_state_hook(move |reason| {
             *state.lock() = SafetyState::SafeState;
+            pending
+                .external_safe_state_pending
+                .store(true, Ordering::Release);
             use std::io::Write;
+            // The claim in this line is now true. The scheduler's tick loop
+            // consumes the state via `take_external_safe_state` and drives every
+            // node to `enter_safe_state()`; until it did, this message was the
+            // only thing that happened.
             let _ = writeln!(
                 std::io::stderr(),
                 " SAFE STATE (external): {reason} — nodes safing, scheduler continues"
@@ -1318,6 +1335,22 @@ impl SafetyMonitor {
             use std::io::Write;
             let _ = writeln!(std::io::stderr(), " EMERGENCY STOP (external): {reason}");
         });
+    }
+
+    /// Consume a pending EXTERNAL safe-state request, if one was raised.
+    ///
+    /// `install_safe_state_hook` used to set `SafetyState::SafeState` and print
+    /// "nodes safing, scheduler continues" -- and nothing anywhere read that
+    /// state. The only write was the hook's own; `grep SafetyState::` outside
+    /// this file returned nothing. So `safety.on_link_lost = "safe_state"` told
+    /// the operator the robot was safing and safed no node: a robot that lost
+    /// its link to the fleet controller kept executing its last command, with a
+    /// reassuring line on stderr.
+    ///
+    /// The state is cleared on read so one link-loss produces one round of
+    /// safing rather than a safing request on every tick forever.
+    pub(crate) fn take_external_safe_state(&self) -> bool {
+        self.external_safe_state_pending.swap(false, Ordering::AcqRel)
     }
 
     /// Get current safety state

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -1395,7 +1395,8 @@ impl SafetyMonitor {
     /// The state is cleared on read so one link-loss produces one round of
     /// safing rather than a safing request on every tick forever.
     pub(crate) fn take_external_safe_state(&self) -> bool {
-        self.external_safe_state_pending.swap(false, Ordering::AcqRel)
+        self.external_safe_state_pending
+            .swap(false, Ordering::AcqRel)
     }
 
     /// Get current safety state

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -99,6 +99,27 @@ pub fn trigger_external_safe_state(reason: String) {
 /// on the safety path — never an unwrap-panic.
 static PENDING_LOCAL_ESTOP: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
+/// Serialises the tests that latch an emergency stop.
+///
+/// `PENDING_LOCAL_ESTOP` is a single process-global slot and `take()` empties
+/// it, but cargo runs this file's tests concurrently in one binary. Every test
+/// that latches a local e-stop writes its reason there on the rising edge, so a
+/// neighbour could overwrite the reason a test had just queued, or drain it
+/// before that test looked. `trigger_queues_the_fleet_broadcast_on_the_rising_edge`
+/// failed intermittently on `main` for exactly that reason -- nothing to do with
+/// the invariant it was written to check.
+///
+/// Every test that reaches `trigger_emergency_stop`, by any route, must hold
+/// this. It is not about thread-safety of the code under test, which is fine;
+/// it is about two tests sharing one mailbox.
+#[cfg(test)]
+static ESTOP_QUEUE_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+fn estop_queue_guard() -> std::sync::MutexGuard<'static, ()> {
+    ESTOP_QUEUE_SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Drain the pending LOCAL-origin e-stop reason (if any) for network broadcast.
 ///
 /// Called by horus_net's replicator tick. Returns `Some(reason)` exactly once per
@@ -1102,15 +1123,39 @@ impl SafetyMonitor {
     /// dispatch and `evaluate_degradation`; only the `max_deadline_misses`
     /// ceiling — an explicitly configured number — stops the robot here.
     pub(crate) fn record_deadline_miss_with_severity(&self, node_name: &str, severity_us: u64) {
-        let misses = self.deadline_misses.fetch_add(1, Ordering::SeqCst) + 1;
+        // Process-wide total, kept for the timing report only. It used to be
+        // the e-stop trigger, and as a LIFETIME count across EVERY node that
+        // was indefensible on a real robot: `max_deadline_misses` defaults to
+        // 100, so a 1 kHz arm that missed its deadline once every few minutes
+        // and recovered immediately each time -- 0.0028% of its ticks over an
+        // hour, an exceptionally healthy control loop -- accumulated its way to
+        // a full emergency stop. Nothing reset it, so a long enough run halted
+        // regardless of health, and one badly tuned node spent the whole
+        // robot's budget.
+        self.deadline_misses.fetch_add(1, Ordering::SeqCst);
 
-        // Track per-node deadline miss data
-        self.budget_enforcer
-            .lock()
-            .record_deadline_miss(node_name, severity_us);
+        // The ceiling is now per node and CONSECUTIVE, which is the thing an
+        // operator setting a "maximum deadline misses" actually means: this node
+        // is not keeping up right now. A run of misses is a node in trouble; a
+        // scattered few that each recover are jitter, and jitter on a stock
+        // kernel is not a reason to stop a robot. `consecutive_misses` is reset
+        // by `check_budget` on any tick that did not violate, so recovery
+        // genuinely clears the count.
+        let consecutive = {
+            let mut enforcer = self.budget_enforcer.lock();
+            enforcer.record_deadline_miss(node_name, severity_us);
+            enforcer
+                .node_timing
+                .get(node_name)
+                .map(|s| s.consecutive_misses)
+                .unwrap_or(0)
+        };
 
-        if misses >= self.max_deadline_misses {
-            self.trigger_emergency_stop(format!("Too many deadline misses: {}", misses));
+        if consecutive >= self.max_deadline_misses {
+            self.trigger_emergency_stop(format!(
+                "node '{}' missed its deadline {} times consecutively (limit {})",
+                node_name, consecutive, self.max_deadline_misses
+            ));
         }
     }
 
@@ -1454,6 +1499,7 @@ mod tests {
     /// Verify that feeding a watchdog resets the expiry flag.
     #[test]
     fn test_watchdog_feed_clears_expired() {
+        let _estop_serial = super::estop_queue_guard();
         use std::thread;
 
         let wd = Watchdog::new(10_u64.ms());
@@ -1484,6 +1530,7 @@ mod tests {
     /// (double panic); post-fix it latches, ignores the write error, and exits 0.
     #[test]
     fn emergency_stop_latches_even_when_stderr_write_fails() {
+        let _estop_serial = super::estop_queue_guard();
         // Child branch: parent redirected our stderr to /dev/full before exec.
         if std::env::var("HORUS_ESTOP_STDERR_CHILD").is_ok() {
             let monitor = SafetyMonitor::new(100);
@@ -1597,6 +1644,7 @@ mod tests {
     /// ceiling.
     #[test]
     fn test_critical_node_deadline_miss_does_not_trigger_emergency_stop() {
+        let _estop_serial = super::estop_queue_guard();
         let monitor = SafetyMonitor::new(100);
         monitor.add_critical_node("critical".to_string(), 1_u64.secs());
 
@@ -2552,6 +2600,7 @@ mod tests {
 
     #[test]
     fn test_emergency_stop_sets_flag_and_state() {
+        let _estop_serial = super::estop_queue_guard();
         let monitor = SafetyMonitor::new(100);
         assert!(!monitor.is_emergency_stop());
 
@@ -2560,23 +2609,72 @@ mod tests {
         assert!(monitor.is_emergency_stop());
     }
 
-    /// Inverted alongside `test_critical_node_deadline_miss_does_not_trigger_emergency_stop`:
-    /// watchdog membership is no longer an escalation trigger, so neither a
-    /// watchdogged nor a plain node e-stops on a single miss. The e-stop now
-    /// comes from the explicitly configured `max_deadline_misses` ceiling.
+    /// The defect this change exists for: a healthy robot must not e-stop just
+    /// for running a long time.
+    ///
+    /// `deadline_misses` was a process-wide count that NOTHING ever reset, and
+    /// `max_deadline_misses` defaults to 100. So a 1 kHz arm that missed its
+    /// deadline once every few minutes and recovered immediately -- 0.0028% of
+    /// its ticks over an hour, an exceptionally healthy control loop -- ground
+    /// its way to a full emergency stop, and a longer run would always get
+    /// there eventually whatever its health. That is a timer wearing a safety
+    /// threshold's name.
+    ///
+    /// Here one node misses ten times the ceiling, recovering between each. It
+    /// must not stop the robot.
+    #[test]
+    fn a_node_that_recovers_between_misses_never_reaches_the_ceiling() {
+        let _estop_serial = super::estop_queue_guard();
+        let ceiling = 5u64;
+        let monitor = SafetyMonitor::new(ceiling);
+        monitor.set_tick_budget("wheel_controller".to_string(), Duration::from_millis(1));
+
+        for _ in 0..(ceiling * 10) {
+            monitor.record_deadline_miss("wheel_controller");
+            // A tick inside budget: `check_budget` clears the consecutive run.
+            let _ = monitor.check_tick_budget("wheel_controller", Duration::from_micros(100));
+        }
+
+        assert!(
+            !monitor.is_emergency_stop(),
+            "{} misses, each immediately recovered, must not e-stop a robot \
+             whose ceiling is {} consecutive",
+            ceiling * 10,
+            ceiling
+        );
+    }
+
+    /// Watchdog membership is not an escalation trigger, so neither a
+    /// watchdogged nor a plain node e-stops on a single miss. The e-stop comes
+    /// from the configured `max_deadline_misses` ceiling — reached by ONE node,
+    /// consecutively.
+    ///
+    /// The earlier version of this test summed a miss on `arm_controller` with
+    /// two on `balance_controller` to reach a ceiling of 3. That is the
+    /// process-wide reading: one node's misses spent another node's safety
+    /// budget, so a chatty logger could halt an arm.
     #[test]
     fn test_deadline_misses_estop_only_at_the_configured_ceiling() {
+        let _estop_serial = super::estop_queue_guard();
         let monitor = SafetyMonitor::new(3);
         monitor.add_critical_node("balance_controller".to_string(), Duration::from_millis(100));
 
         monitor.record_deadline_miss("arm_controller");
         assert!(!monitor.is_emergency_stop());
 
-        // A watchdogged node missing once is no longer fatal either.
+        // A watchdogged node missing once is not fatal either.
         monitor.record_deadline_miss("balance_controller");
         assert!(!monitor.is_emergency_stop());
 
-        // Third miss reaches max_deadline_misses = 3 — that is what stops us.
+        // A second consecutive miss on it is still under the ceiling of 3 — and
+        // the unrelated `arm_controller` miss does not count toward it.
+        monitor.record_deadline_miss("balance_controller");
+        assert!(
+            !monitor.is_emergency_stop(),
+            "arm_controller's miss must not count toward balance_controller's ceiling"
+        );
+
+        // Its third consecutive miss reaches the ceiling.
         monitor.record_deadline_miss("balance_controller");
         assert!(monitor.is_emergency_stop());
     }
@@ -3075,26 +3173,47 @@ mod tests {
         assert_eq!(enforcer.get_overrun_count(), 1099);
     }
 
-    /// Multiple deadline misses just under max should not trigger emergency stop,
-    /// but the Nth miss (at max) should trigger it.
+    /// The ceiling is per node and consecutive, so misses spread across
+    /// DIFFERENT nodes never reach it.
+    ///
+    /// This test used to record one miss each on ten different nodes and expect
+    /// an e-stop, which is the behaviour that made `max_deadline_misses` a
+    /// lifetime process-wide total: ten unrelated nodes each hiccuping once
+    /// halted the robot, and nothing ever reset the count, so a long enough run
+    /// halted whatever its health. Now one node has to miss `max` times in a row
+    /// -- it is not keeping up, right now -- which is what the setting reads as.
     #[test]
     fn test_deadline_miss_threshold_exact() {
+        let _estop_serial = super::estop_queue_guard();
         let max_misses = 10u64;
         let monitor = SafetyMonitor::new(max_misses);
 
-        // Record max_misses - 1 misses on non-critical nodes
-        for i in 0..(max_misses - 1) {
+        // Misses scattered across many nodes must NOT reach the ceiling, however
+        // many there are in total.
+        for i in 0..(max_misses * 3) {
             monitor.record_deadline_miss(&format!("node_{}", i));
+        }
+        assert!(
+            !monitor.is_emergency_stop(),
+            "{} misses spread over {} different nodes must not e-stop: none of \
+             them missed twice in a row",
+            max_misses * 3,
+            max_misses * 3
+        );
+
+        // But one node missing max_misses - 1 times consecutively still must not.
+        for i in 0..(max_misses - 1) {
+            monitor.record_deadline_miss("one_bad_node");
             assert!(
                 !monitor.is_emergency_stop(),
-                "should not estop at miss {} / {}",
+                "should not estop at consecutive miss {} / {}",
                 i + 1,
                 max_misses
             );
         }
 
-        // The Nth miss triggers emergency stop
-        monitor.record_deadline_miss("final_node");
+        // The Nth CONSECUTIVE miss on that same node triggers emergency stop.
+        monitor.record_deadline_miss("one_bad_node");
         assert!(
             monitor.is_emergency_stop(),
             "should estop at miss {}/{}",
@@ -3342,6 +3461,7 @@ mod tests {
     /// Multiple emergency stop triggers: idempotent — state stays EmergencyStop.
     #[test]
     fn test_multiple_emergency_stops_idempotent() {
+        let _estop_serial = super::estop_queue_guard();
         let monitor = SafetyMonitor::new(100);
 
         monitor.trigger_emergency_stop("first".to_string());
@@ -3371,6 +3491,7 @@ mod tests {
     /// set unconditional.
     #[test]
     fn test_rising_edge_queues_pending_only_on_edge() {
+        let _estop_serial = super::estop_queue_guard();
         // Global slot — drain any residue left by other tests first.
         let _ = take_pending_local_estop();
 
@@ -3404,6 +3525,7 @@ mod tests {
     /// Proven RED→GREEN by forcing the set unconditional.
     #[test]
     fn test_antistorm_remote_estop_not_rebroadcast() {
+        let _estop_serial = super::estop_queue_guard();
         // Global slot — drain any residue left by other tests first.
         let _ = take_pending_local_estop();
 
@@ -3580,6 +3702,7 @@ mod estop_trigger_tests {
     /// reporting Normal and queued nothing for the fleet broadcast.
     #[test]
     fn trigger_from_a_handle_latches_state_like_the_monitor() {
+        let _estop_serial = super::estop_queue_guard();
         let monitor = SafetyMonitor::new(10);
         let trigger = monitor.estop_trigger();
 
@@ -3600,6 +3723,7 @@ mod estop_trigger_tests {
     /// told this one stopped.
     #[test]
     fn trigger_queues_the_fleet_broadcast_on_the_rising_edge() {
+        let _guard = estop_queue_guard();
         let _ = take_pending_local_estop(); // clear any prior test's edge
         let monitor = SafetyMonitor::new(10);
         let trigger = monitor.estop_trigger();
@@ -3617,6 +3741,7 @@ mod estop_trigger_tests {
     /// halting gets a broadcast per tick.
     #[test]
     fn a_second_trigger_does_not_requeue_a_broadcast() {
+        let _guard = estop_queue_guard();
         let _ = take_pending_local_estop();
         let monitor = SafetyMonitor::new(10);
         let trigger = monitor.estop_trigger();

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -201,10 +201,46 @@ pub(crate) struct RtState {
 }
 
 /// Tick-loop timing state.
+/// One step of the tick cadence grid: how long to sleep, where the next grid
+/// point is, and whether this tick overran its whole period.
+///
+/// Split out as a pure function of (deadline, now, period) so the arithmetic can
+/// be tested without racing a real clock -- the behaviour it encodes is a timing
+/// property, and a test that measured it by sleeping would be exactly the kind
+/// of load-sensitive test this repo already loses to CPU starvation.
+///
+/// Returns `(sleep, next_deadline, overran)`.
+pub(crate) fn tick_grid_step(
+    deadline: Instant,
+    now: Instant,
+    period: Duration,
+) -> (Duration, Instant, bool) {
+    let sleep = deadline.saturating_duration_since(now);
+    let next = deadline + period;
+    if next <= now {
+        // A whole period (or more) was consumed by the work. Re-anchor instead
+        // of returning a next_deadline already in the past, which would fire a
+        // run of zero-length catch-up ticks.
+        (sleep, now + period, true)
+    } else {
+        (sleep, next, false)
+    }
+}
+
 pub(crate) struct TickState {
     pub period: Duration,
     pub current: u64,
     pub last_instant: Instant,
+    /// The instant the CURRENT tick is supposed to end.
+    ///
+    /// The loop sleeps until this and then advances it by exactly one period,
+    /// rather than sleeping a whole period after the work. See
+    /// `compute_tick_sleep` for why that distinction is the difference between
+    /// a 100 Hz scheduler and a 77 Hz one.
+    pub next_deadline: Instant,
+    /// Ticks whose work overran the whole period, so the grid had to be
+    /// re-anchored. Non-zero means the configured rate is not being achieved.
+    pub overruns: u64,
 }
 
 /// Monitoring features: safety, blackbox flight recorder, telemetry, profiling.
@@ -521,6 +557,8 @@ impl Scheduler {
                 period,
                 current: 0,
                 last_instant: now,
+                next_deadline: now,
+                overruns: 0,
             },
             clock: Arc::new(crate::core::clock::WallClock::new()),
             dependency_graph: None,
@@ -2281,11 +2319,6 @@ impl Scheduler {
                         ));
                     }
                 }
-                // Advance SimClock in deterministic mode
-                if self.pending_config.timing.deterministic_order {
-                    let dt = self.tick.period;
-                    self.clock.advance(dt);
-                }
             }
         } else {
             // No graph — sequential by priority
@@ -2298,6 +2331,25 @@ impl Scheduler {
                     ));
                 }
             }
+        }
+
+        // Advance SimClock once per TICK, on both paths.
+        //
+        // This used to sit inside the `for step in &steps` loop, so simulated
+        // time ran forward by one period per dependency-graph *step*: a graph
+        // with three steps advanced the clock three periods every tick, and a
+        // node reading `horus::now()` saw time moving at 3x rate. The no-graph
+        // fallback below never advanced it at all, so the same program's clock
+        // stopped entirely the moment its dependency graph went away. A policy
+        // trained against one of those timebases and deployed against the other
+        // is reading a different robot.
+        //
+        // The step loop is the wrong place structurally as well as numerically:
+        // steps are a parallelism/ordering decomposition of a single tick, not
+        // a sequence of instants.
+        if self.pending_config.timing.deterministic_order {
+            let dt = self.tick.period;
+            self.clock.advance(dt);
         }
 
         if !self.first_tick_done {
@@ -2924,6 +2976,11 @@ impl Scheduler {
                     ));
                 }
             }
+
+            // Anchor the cadence grid before the first tick, so the first
+            // sleep is measured from here rather than from a stale construction
+            // -time instant.
+            self.tick.next_deadline = Instant::now() + self.tick.period;
 
             // Main tick loop
             while self.is_running() {
@@ -3582,9 +3639,28 @@ impl Scheduler {
         }
     }
 
-    /// Compute the tick sleep duration.
-    fn compute_tick_sleep(&self) -> Option<Duration> {
-        let sleep_duration = if let Some(ref replay) = self.replay {
+    /// Sleep until the end of the current tick, on a phase-locked grid.
+    ///
+    /// This used to return the full period unconditionally, and the caller
+    /// sleeps AFTER running every node. So the realised cycle was
+    /// `work + period`, not `period`: a scheduler configured for 100 Hz whose
+    /// nodes took 3 ms ran at 1/(10 ms + 3 ms) = 77 Hz, and nothing said so.
+    /// Every rate in the system was a ceiling the scheduler quietly missed by
+    /// however long the work happened to take -- which is load-dependent, so
+    /// the error moved around as the robot did.
+    ///
+    /// Now the deadline is absolute and advances by exactly one period per
+    /// tick, which is what the RT executor already does. Subtracting the
+    /// elapsed work from the sleep would fix the gross error but still let the
+    /// sleep's own overshoot accumulate tick over tick; anchoring to a grid
+    /// absorbs it.
+    ///
+    /// On an overrun -- work that took a whole period or more -- the grid is
+    /// re-anchored to now rather than firing a burst of zero-length catch-up
+    /// ticks. A robot wants the next command on the grid, not five of them back
+    /// to back into an actuator.
+    fn compute_tick_sleep(&mut self) -> Option<Duration> {
+        let period = if let Some(ref replay) = self.replay {
             if replay.speed != 1.0 {
                 Duration::from_nanos((self.tick.period.as_nanos() as f64 / replay.speed) as u64)
             } else {
@@ -3594,7 +3670,23 @@ impl Scheduler {
             self.tick.period
         };
 
-        Some(sleep_duration)
+        let (sleep, next, overran) = tick_grid_step(self.tick.next_deadline, Instant::now(), period);
+        if overran {
+            self.tick.overruns += 1;
+        }
+        self.tick.next_deadline = next;
+
+        Some(sleep)
+    }
+
+    /// Ticks whose work overran the whole configured period.
+    ///
+    /// Non-zero means the scheduler is not achieving its configured rate. This
+    /// is the number a control loop needs and had no way to obtain: before the
+    /// cadence fix an overrun was indistinguishable from a normal tick, because
+    /// the loop simply slept a full period afterwards either way.
+    pub fn tick_overruns(&self) -> u64 {
+        self.tick.overruns
     }
 
     /// Increment tick counter.
@@ -5192,7 +5284,7 @@ impl Scheduler {
     ///
     /// Execution strategy depends on mode:
     ///   - Default: ready-dispatch (parallel, per-node dependency tracking)
-    ///   - Deterministic: sequential within steps, SimClock advances between steps
+    ///   - Deterministic: sequential within steps; SimClock advances once per TICK
     ///   - No graph: sequential by .order() priority (fallback)
     async fn execute_nodes(&mut self, node_filter: Option<&[&str]>) {
         // Phase 2: rebuild graph once after first tick if topology changed.
@@ -5208,7 +5300,23 @@ impl Scheduler {
 
         if let Some(ref graph) = self.dependency_graph {
             if self.pending_config.timing.deterministic_order {
-                // Deterministic mode: sequential within steps, SimClock between steps
+                // Deterministic mode: sequential within steps.
+                //
+                // The SimClock advance used to sit INSIDE this loop, one per
+                // dependency-graph step. Steps are a parallelism decomposition
+                // of a single tick, not a sequence of instants, so that ran
+                // simulated time forward by `steps * period` every tick.
+                //
+                // `should_stop_loop` bounds a deterministic `run_for` by this
+                // same clock and states the intended invariant in as many words
+                // -- "a SimClock that advances by exactly one tick period per
+                // tick" -- so the two disagreed: a 500 ms run at 100 Hz gave 25
+                // ticks for a two-node chain and 13 for a four-node chain
+                // instead of 50 for both. Adding a stage to the end of a
+                // pipeline silently cut the length of every fixed-duration run,
+                // and `horus::now()` ran fast by the depth of the graph.
+                //
+                // Advanced once per tick below, after the steps, on every path.
                 let steps: Vec<Vec<usize>> = graph.steps().to_vec();
                 for step in &steps {
                     for &node_idx in step {
@@ -5216,9 +5324,9 @@ impl Scheduler {
                             return;
                         }
                     }
-                    let dt = self.tick.period;
-                    self.clock.advance(dt);
                 }
+                let dt = self.tick.period;
+                self.clock.advance(dt);
             } else if self.nodes.len() > 1 {
                 // Ready-dispatch mode: parallel execution driven by dependency graph.
                 // Nodes run as soon as all their predecessors complete.
@@ -5499,3 +5607,89 @@ impl Scheduler {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod tick_cadence_tests {
+    use super::tick_grid_step;
+    use std::time::{Duration, Instant};
+
+    const PERIOD: Duration = Duration::from_millis(10);
+
+    /// The bug this pins: the loop slept a FULL period after running every
+    /// node, so the realised cycle was `work + period`. At 100 Hz with 8 ms of
+    /// work that is 55 Hz, and nothing anywhere reported it.
+    ///
+    /// On the grid, a tick that consumed 8 ms of its 10 ms sleeps the
+    /// REMAINING 2 ms. The old code slept 10.
+    #[test]
+    fn work_is_subtracted_from_the_sleep_not_added_to_the_period() {
+        let now = Instant::now();
+        // 8ms of a 10ms period already spent → the deadline is 2ms out.
+        let deadline = now + Duration::from_millis(2);
+
+        let (sleep, _next, overran) = tick_grid_step(deadline, now, PERIOD);
+
+        assert_eq!(
+            sleep,
+            Duration::from_millis(2),
+            "the sleep must cover only the REMAINDER of the period; sleeping a \
+             full {PERIOD:?} here is what turned a 100 Hz loop into a 55 Hz one"
+        );
+        assert!(!overran, "8ms of a 10ms period is not an overrun");
+    }
+
+    /// The grid advances from the DEADLINE, not from `now`. This is what stops
+    /// the sleep's own overshoot accumulating: waking 300us late must not push
+    /// every subsequent tick 300us later.
+    #[test]
+    fn the_next_deadline_is_one_period_from_the_last_one_not_from_now() {
+        let now = Instant::now();
+        let deadline = now - Duration::from_micros(300); // woke 300us late
+        let (_sleep, next, overran) = tick_grid_step(deadline, now, PERIOD);
+
+        assert_eq!(
+            next,
+            deadline + PERIOD,
+            "advancing from `now` would bake the 300us lateness into every \
+             future tick; advancing from the deadline absorbs it"
+        );
+        assert!(!overran, "300us late on a 10ms period is not a full overrun");
+        assert_eq!(
+            next.saturating_duration_since(now),
+            PERIOD - Duration::from_micros(300),
+            "the next sleep is correspondingly shorter, which is how the phase \
+             is recovered"
+        );
+    }
+
+    /// A tick that ate a whole period re-anchors rather than handing back a
+    /// deadline already in the past — which would fire a burst of zero-length
+    /// catch-up ticks straight into whatever the nodes drive.
+    #[test]
+    fn a_full_overrun_re_anchors_instead_of_bursting() {
+        let now = Instant::now();
+        let deadline = now - Duration::from_millis(25); // 25ms late on a 10ms period
+
+        let (sleep, next, overran) = tick_grid_step(deadline, now, PERIOD);
+
+        assert_eq!(sleep, Duration::ZERO, "already past the deadline");
+        assert!(overran, "25ms late on a 10ms period must be counted as an overrun");
+        assert_eq!(
+            next,
+            now + PERIOD,
+            "re-anchored to now; `deadline + period` would still be 15ms in the \
+             past and the next three ticks would run back to back"
+        );
+    }
+
+    /// Exactly on the deadline is the boundary case and is NOT an overrun:
+    /// `next` lands a full period in the future, so there is nothing to catch up.
+    #[test]
+    fn landing_exactly_on_the_deadline_is_not_an_overrun() {
+        let now = Instant::now();
+        let (sleep, next, overran) = tick_grid_step(now, now, PERIOD);
+        assert_eq!(sleep, Duration::ZERO);
+        assert!(!overran);
+        assert_eq!(next, now + PERIOD);
+    }
+}

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -3709,7 +3709,8 @@ impl Scheduler {
             self.tick.period
         };
 
-        let (sleep, next, overran) = tick_grid_step(self.tick.next_deadline, Instant::now(), period);
+        let (sleep, next, overran) =
+            tick_grid_step(self.tick.next_deadline, Instant::now(), period);
         if overran {
             self.tick.overruns += 1;
         }
@@ -5692,7 +5693,10 @@ mod tick_cadence_tests {
             "advancing from `now` would bake the 300us lateness into every \
              future tick; advancing from the deadline absorbs it"
         );
-        assert!(!overran, "300us late on a 10ms period is not a full overrun");
+        assert!(
+            !overran,
+            "300us late on a 10ms period is not a full overrun"
+        );
         assert_eq!(
             next.saturating_duration_since(now),
             PERIOD - Duration::from_micros(300),
@@ -5712,7 +5716,10 @@ mod tick_cadence_tests {
         let (sleep, next, overran) = tick_grid_step(deadline, now, PERIOD);
 
         assert_eq!(sleep, Duration::ZERO, "already past the deadline");
-        assert!(overran, "25ms late on a 10ms period must be counted as an overrun");
+        assert!(
+            overran,
+            "25ms late on a 10ms period must be counted as an overrun"
+        );
         assert_eq!(
             next,
             now + PERIOD,

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -3372,6 +3372,45 @@ impl Scheduler {
     ///
     /// Returns `true` if the scheduler should stop (emergency stop triggered).
     fn check_safety_monitors(&mut self) -> bool {
+        // An EXTERNAL safe-state request -- a lost network link under
+        // `safety.on_link_lost = "safe_state"` -- reaches the scheduler as a
+        // state written by `install_safe_state_hook`. Consume it here and
+        // actually safe the robot.
+        //
+        // Nothing used to read that state. The hook set it, printed "nodes
+        // safing, scheduler continues", and no node was safed: the operator who
+        // chose per-node safing over a full halt got neither. This is the one
+        // safety path with no node to blame, so every node is driven, by both
+        // routes -- the scheduler owns only BestEffort nodes after the class
+        // partition, and `enter_safe_state()` needs `&mut dyn Node`, so an
+        // executor-owned node is reached through the shared control map and
+        // safed by its owning executor's `honor_safe_state_request`.
+        if self
+            .monitor
+            .safety
+            .as_ref()
+            .is_some_and(|m| m.take_external_safe_state())
+        {
+            if let Some(ref controls) = self.node_controls {
+                controls.request_safe_state_all();
+            }
+            for registered in self.nodes.iter_mut() {
+                if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    registered.node.enter_safe_state()
+                }))
+                .is_err()
+                {
+                    // It did not reach a safe state. Stop it rather than let it
+                    // keep ticking as though it had.
+                    registered.is_stopped = true;
+                    print_line(&format!(
+                        " SAFE STATE: '{}' PANICKED in enter_safe_state; node stopped",
+                        registered.name
+                    ));
+                }
+            }
+        }
+
         if let Some(ref monitor) = self.monitor.safety {
             // Use graduated check for per-node health state transitions
             monitor.check_watchdogs_graduated(&mut self.monitor.watchdog_graduated_buf);

--- a/horus_core/src/scheduling/types.rs
+++ b/horus_core/src/scheduling/types.rs
@@ -864,6 +864,24 @@ impl NodeControlMap {
         }
     }
 
+    /// Ask every registered node's owning executor to safe it.
+    ///
+    /// The fleet-wide counterpart to `request_safe_state`. Used by the external
+    /// safe-state path (a lost network link under
+    /// `safety.on_link_lost = "safe_state"`), which has no single node to blame
+    /// and must safe the whole robot.
+    pub fn request_safe_state_all(&self) {
+        for c in self
+            .inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+        {
+            c.safe_state_requested
+                .store(true, std::sync::atomic::Ordering::Release);
+        }
+    }
+
     /// Consume a pending safing request, returning whether one was set.
     ///
     /// Clears the flag, so a request is honoured exactly once per raise.

--- a/horus_core/tests/deterministic_parallel.rs
+++ b/horus_core/tests/deterministic_parallel.rs
@@ -410,3 +410,86 @@ fn deterministic_fallback_to_order_tiers() {
     assert_eq!(entries[0], "early");
     assert_eq!(entries[1], "late");
 }
+
+// ── Simulated time advances per TICK, not per dependency-graph step ─────────
+
+/// Build `n` nodes chained A->B->C..., so the dependency graph has `n` steps.
+///
+/// Node and topic names are unique per chain length. Topics are process-global,
+/// so reusing the `ab`/`bc` names the ordering tests above already registered
+/// would let their participants join this chain's graph and change its shape --
+/// which is exactly the confound this test is trying to measure.
+fn chained(n: usize, count: Arc<AtomicU64>) -> Scheduler {
+    let names: [[&str; 4]; 2] = [
+        ["clk2_a", "clk2_b", "clk2_c", "clk2_d"],
+        ["clk4_a", "clk4_b", "clk4_c", "clk4_d"],
+    ];
+    let edges: [[&str; 3]; 2] = [
+        ["clk2_ab", "clk2_bc", "clk2_cd"],
+        ["clk4_ab", "clk4_bc", "clk4_cd"],
+    ];
+    let v = if n <= 2 { 0 } else { 1 };
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let mut s = Scheduler::new().deterministic(true).tick_rate(100_u64.hz());
+    for i in 0..n {
+        let pubs = if i + 1 < n { vec![edges[v][i]] } else { vec![] };
+        let subs = if i > 0 { vec![edges[v][i - 1]] } else { vec![] };
+        s.add(TrackedNode::new(
+            names[v][i],
+            pubs,
+            subs,
+            log.clone(),
+            count.clone(),
+        ))
+        .order(i as u32)
+        .build()
+        .unwrap();
+    }
+    s
+}
+
+/// Simulated time must advance once per TICK, whatever shape the graph is.
+///
+/// `should_stop_loop` states this invariant in as many words -- "in
+/// deterministic mode `self.clock` is a `SimClock` that advances by exactly one
+/// tick period per tick, and the point of the mode is that a run does not depend
+/// on how fast the machine is" -- and `run_for` is bounded by that clock. But
+/// `clock.advance(period)` sat INSIDE the `for step in &steps` loop, so a graph
+/// with three steps ran simulated time forward three periods per tick.
+///
+/// The consequences were both visible to a user: `horus::now()` moved at 3x rate
+/// inside a chained pipeline, and `run_for(d)` in deterministic mode executed
+/// `d / (steps * period)` ticks instead of `d / period` -- so adding a node to
+/// the end of a pipeline silently cut the number of ticks a fixed-duration run
+/// performed.
+///
+/// The invariant under test is the one that makes the mode worth having: tick
+/// count for a fixed duration is a property of the RATE, not of the graph shape.
+#[test]
+fn simulated_time_does_not_run_faster_when_the_graph_has_more_steps() {
+    let two = Arc::new(AtomicU64::new(0));
+    chained(2, two.clone()).run_for(500_u64.ms()).unwrap();
+    // Each node ticks once per scheduler tick.
+    let two_ticks = two.load(Ordering::Relaxed) / 2;
+
+    let four = Arc::new(AtomicU64::new(0));
+    chained(4, four.clone()).run_for(500_u64.ms()).unwrap();
+    let four_ticks = four.load(Ordering::Relaxed) / 4;
+
+    assert_eq!(
+        two_ticks, four_ticks,
+        "a 4-step chain ran {four_ticks} ticks where a 2-step chain ran \
+         {two_ticks} for the same simulated duration. Simulated time is \
+         advancing per dependency-graph STEP rather than per tick, so the \
+         length of a fixed-duration deterministic run depends on the shape of \
+         the pipeline."
+    );
+
+    // Anti-vacuity: 500ms at 100Hz is 50 ticks. If both were 0 the equality
+    // above would hold while proving nothing.
+    assert!(
+        two_ticks >= 40,
+        "expected ~50 ticks from 500ms at 100Hz, got {two_ticks} — the run \
+         ended early and this test proves nothing"
+    );
+}

--- a/horus_core/tests/external_safe_state.rs
+++ b/horus_core/tests/external_safe_state.rs
@@ -1,0 +1,93 @@
+//! An external safe-state request must actually safe the robot.
+//!
+//! `safety.on_link_lost = "safe_state"` routes a lost network link to
+//! `trigger_external_safe_state`, whose installed hook set
+//! `SafetyState::SafeState` and printed
+//!
+//!     SAFE STATE (external): ... — nodes safing, scheduler continues
+//!
+//! Nothing read that state. The hook's own write was the only reference to the
+//! variant outside its own module, so the operator who deliberately chose
+//! per-node safing over a full halt got neither: the robot kept executing its
+//! last command with a reassuring line on stderr.
+//!
+//! This lives in its own test binary because the safe-state hook is a
+//! process-global installed by a running scheduler; sharing a binary with other
+//! scheduler tests would let their schedulers claim the hook.
+
+use horus_core::core::duration_ext::DurationExt;
+use horus_core::core::node::Node;
+use horus_core::scheduling::Scheduler;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+struct SafeStateRecordingNode {
+    safed: Arc<AtomicU64>,
+    ticks: Arc<AtomicU64>,
+}
+
+impl Node for SafeStateRecordingNode {
+    fn name(&self) -> &str {
+        "actuator"
+    }
+    fn tick(&mut self) {
+        self.ticks.fetch_add(1, Ordering::Relaxed);
+    }
+    fn enter_safe_state(&mut self) {
+        self.safed.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// One test, not two, because the safe-state hook is a PROCESS-GLOBAL installed
+/// by whichever scheduler is running. Two tests in this binary raced for it:
+/// one scheduler claimed the hook and absorbed both triggers while the other
+/// saw none, so the pair failed about half the time for a reason that had
+/// nothing to do with the code under test.
+#[test]
+fn an_external_safe_state_request_safes_the_robot_exactly_once() {
+    let safed = Arc::new(AtomicU64::new(0));
+    let ticks = Arc::new(AtomicU64::new(0));
+
+    let mut scheduler = Scheduler::new().tick_rate(200_u64.hz());
+    scheduler
+        .add(SafeStateRecordingNode {
+            safed: safed.clone(),
+            ticks: ticks.clone(),
+        })
+        .build()
+        .unwrap();
+
+    // Fire the external trigger once the scheduler is running and has installed
+    // its hook. Before it is installed, `trigger_external_safe_state` escalates
+    // to an emergency stop instead, which is a different path.
+    std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        horus_core::scheduling::trigger_external_safe_state("test: peer lost".to_string());
+    });
+
+    scheduler.run_for(600_u64.ms()).unwrap();
+
+    let n = safed.load(Ordering::Relaxed);
+    let t = ticks.load(Ordering::Relaxed);
+
+    assert!(t > 0, "the node never ticked, so this run exercised nothing");
+
+    // The fix: the request is consumed and the node is actually safed.
+    assert!(
+        n > 0,
+        "an external safe-state request was raised and no node was safed. The \
+         hook set SafetyState::SafeState and printed 'nodes safing', and nothing \
+         consumed it — which is what a robot losing its link to the fleet \
+         controller under on_link_lost=safe_state used to get."
+    );
+
+    // And it is an EDGE, not a level: one link loss produces one round of
+    // safing, not a fresh `enter_safe_state()` every tick for the rest of the
+    // run. `SafetyState::SafeState` stays latched as an observable condition,
+    // which is why consuming the state itself would have been the wrong fix.
+    assert!(
+        n < t / 4,
+        "safed {n} times over {t} ticks — the request is being re-consumed every \
+         tick instead of once per raise"
+    );
+}

--- a/horus_core/tests/external_safe_state.rs
+++ b/horus_core/tests/external_safe_state.rs
@@ -70,7 +70,10 @@ fn an_external_safe_state_request_safes_the_robot_exactly_once() {
     let n = safed.load(Ordering::Relaxed);
     let t = ticks.load(Ordering::Relaxed);
 
-    assert!(t > 0, "the node never ticked, so this run exercised nothing");
+    assert!(
+        t > 0,
+        "the node never ticked, so this run exercised nothing"
+    );
 
     // The fix: the request is consumed and the node is actually safed.
     assert!(


### PR DESCRIPTION
Supersedes #106, #108, #110, #111, #112 — same five commits, cherry-picked verbatim, as one review. They all touch `scheduling/`, mostly the same two files, and twenty open PRs had saturated the Actions queue badly enough that nothing was reaching the required contexts.

### 1. A malloc per node per tick, on the RT thread

`RuntimeProfiler::record` keyed its map with `entry(node_name.to_string())`. `entry` takes an owned key, so the String was allocated on **every** call including the hit path. `rt_executor` records once per node per tick and `enabled` defaults to true, so this was a malloc+free inside every tick of every RT node by default. `malloc` has no WCET bound. Same defect `safety_monitor.rs` was already fixed for; this site was missed.

### 2. The tick loop ran at `work + period`

`compute_tick_sleep` returned a full period and the caller sleeps *after* running every node, so a scheduler configured for 100 Hz whose nodes took 3 ms ran at **77 Hz**, load-dependently, and nothing said so. Now an absolute phase-locked grid — the same one the RT executor already uses — with `tick_overruns()` exposing what was previously unobservable.

### 3. Simulated time advanced per dependency-graph *step*

`clock.advance(period)` sat inside `for step in &steps` in **both** tick paths. A 500 ms deterministic run at 100 Hz gave **25 ticks for a two-node chain and 13 for a four-node chain** instead of 50 for both — so adding a stage to a pipeline silently shortened every fixed-duration run, and `horus::now()` ran fast by the depth of the graph. `should_stop_loop` states the violated invariant in its own comment. The no-graph fallback never advanced the clock at all.

### 4. An external safe-state request safed nothing

`safety.on_link_lost = "safe_state"` set `SafetyState::SafeState` and printed *"nodes safing, scheduler continues"*. **Nothing read that state** — the hook's own write was its only reference outside the module. An operator who chose per-node safing over a full halt got neither, and a robot that lost its fleet link kept executing its last command with a reassuring line on stderr. Now consumed by the tick loop, which drives every node by both routes (main-thread nodes directly, executor-owned ones through the control map the watchdog ladder already uses).

### 5. The deadline-miss ceiling was a process-wide lifetime total

`max_deadline_misses` defaults to 100 and nothing ever reset the counter, so a 1 kHz arm missing **0.0028% of its ticks over an hour** ground its way to a full emergency stop, and one badly tuned node spent every other node's budget. Now per-node and consecutive. **This is a deliberate behaviour change** — the two tests that pinned the old reading are rewritten, not deleted, each carrying why. Please review it as one.

### 6. The degradation ladder wrote to stdout from the SCHED_FIFO thread

`print_line` does `isatty` + `tcgetattr`, takes the global stdout lock, then writes and flushes — blocking for as long as a slow reader takes, on the thread driving an actuator. The `Isolate` and `Kill` rungs were not even verbose-gated and both safe or shut down the node in the same breath. All eight sites now use the existing lock-free `rt_diag` ring; the two teardown sites, on the caller's thread, are left alone.

### Also

A pre-existing flake fixed in passing: `trigger_queues_the_fleet_broadcast_on_the_rising_edge` fails on unmodified `main` whenever it runs beside the rest of its file, because `PENDING_LOCAL_ESTOP` is one global slot that `take()` empties and cargo runs those tests concurrently. Every test that latches an e-stop now takes a shared guard.

### Verification

2471 lib tests plus `external_safe_state`, `deterministic_parallel`, `watchdog_graduation`, `rt_readiness` green, in a **private `CARGO_TARGET_DIR`** — the shared `target/` in this checkout is rebuilt concurrently by other sessions and produced two false failures during this work.

Non-vacuity was checked by hand for the new tests: stubbing `take_external_safe_state` to `false` fails with *"an external safe-state request was raised and no node was safed"*; reverting just the `Isolate` site to `print_line` fails with *"Isolate queued nothing"*.