### PR TITLE
ci(autopilot): drain the convoy one PR per merge, not all of them daily

### DIFF
--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -244,6 +244,18 @@ jobs:
           gh pr update-branch "$front" --repo "$GITHUB_REPOSITORY" \
             || echo "::warning::could not update #$front"
 
+          # Re-arm auto-merge. Updating a branch CLEARS it, and this job
+          # selects candidates by auto-merge being enabled -- so without this
+          # line every PR the convoy helps drops out of the convoy's own queue
+          # permanently, and is never looked at again. Measured on the live
+          # repo: `gh pr update-branch 124` left it `autoMergeRequest=null`,
+          # and seven PRs updated earlier were all sitting disarmed.
+          #
+          # Re-arming only restores the state the PR was selected for; it
+          # cannot arm a PR that did not already have auto-merge on.
+          gh pr merge "$front" --repo "$GITHUB_REPOSITORY" --auto --squash \
+            || echo "::warning::could not re-arm auto-merge on #$front"
+
           if [ "$total" -gt 1 ]; then
             # paste joins with a single separator and no trailing one; `tr`
             # left a dangling space that made the list awkward to copy.

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -10,13 +10,18 @@ name: Autopilot
 #             from unexplained ones, and opens an issue only for failures that
 #             RECUR. Most red CI here is the runner, not the code.
 #   convoy  — main requires branches be up to date, and GitHub's auto-merge does
-#             not update them, so queued PRs starve. This updates them. It calls
+#             not update them, so queued PRs starve. This updates ONE. It calls
 #             `gh pr update-branch` and nothing else.
 
 on:
   schedule:
     # 06:00 UTC, after the existing nightly/weekly crons have reported.
     - cron: '0 6 * * *'
+  # Every merge invalidates every other queued branch, so that is exactly when
+  # the next one needs updating. Without this the convoy advances once a day:
+  # ten queued PRs took ten days regardless of how fast CI ran.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 # Default deny; each job takes only what it needs.
@@ -29,6 +34,11 @@ concurrency:
 jobs:
   triage:
     name: Triage failures on main
+    # Not on push. The push trigger exists for the convoy, which must react to
+    # each merge; triage reads the last N failed runs and opens issues, and
+    # doing that once per merge would be both noisy and pointless — its input
+    # is a rolling window, not the merge that just happened.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -181,7 +191,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Update queued PRs that have fallen behind
+      - name: Update the front of the queue
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -196,15 +206,34 @@ jobs:
           # help land changes to what executes inside CI with nobody reading
           # them. Excluding bot authors keeps this job out of that loop entirely;
           # dependabot's own workflow is unaffected either way.
-          gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 50 \
-            --json number,mergeStateStatus,autoMergeRequest,author \
-            -q '.[] | select(.autoMergeRequest != null)
-                    | select(.author.is_bot != true)
-                    | select((.author.login // "") | startswith("app/") | not)
-                    | select(.mergeStateStatus == "BEHIND") | .number' \
-          | while read -r n; do
-              [ -z "$n" ] && continue
-              echo "PR #$n is BEHIND with auto-merge on — updating branch"
-              gh pr update-branch "$n" --repo "$GITHUB_REPOSITORY" || \
-                echo "::warning::could not update #$n"
-            done
+          # ONE PR per run, the oldest.
+          #
+          # Updating every behind branch at once looks faster and is not: main
+          # takes one merge at a time, and that merge puts every other branch
+          # behind again, so the rest of the fleet re-runs its whole matrix for
+          # nothing. With ten PRs queued that is ~600 jobs burned to land one.
+          # Updating only the front runner costs one CI cycle per merge, and
+          # the push trigger above starts the next one the moment it lands.
+          candidates=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --limit 50 --json number,mergeStateStatus,autoMergeRequest,author \
+            -q '[.[] | select(.autoMergeRequest != null)
+                     | select(.author.is_bot != true)
+                     | select((.author.login // "") | startswith("app/") | not)
+                     | select(.mergeStateStatus == "BEHIND") | .number]
+                | sort | .[]')
+
+          if [ -z "$candidates" ]; then
+            echo "No queued PR is behind. Nothing to do."
+            exit 0
+          fi
+
+          total=$(echo "$candidates" | wc -l | tr -d ' ')
+          front=$(echo "$candidates" | head -1)
+          echo "$total queued PR(s) behind; updating #$front, rest wait."
+
+          gh pr update-branch "$front" --repo "$GITHUB_REPOSITORY" \
+            || echo "::warning::could not update #$front"
+
+          if [ "$total" -gt 1 ]; then
+            echo "Still waiting: $(echo "$candidates" | tail -n +2 | tr '\n' ' ')"
+          fi

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -206,7 +206,14 @@ jobs:
           # help land changes to what executes inside CI with nobody reading
           # them. Excluding bot authors keeps this job out of that loop entirely;
           # dependabot's own workflow is unaffected either way.
-          # ONE PR per run, the oldest.
+          # A failed `gh pr list` prints nothing and exits non-zero, which
+          # without this reads as "the queue is empty" and the job reports
+          # success having done nothing. Silent no-op is the worst failure mode
+          # for an unattended job: the convoy would appear healthy while every
+          # PR starved. Fail loudly instead.
+          set -euo pipefail
+
+          # ONE PR per run, the lowest-numbered.
           #
           # Updating every behind branch at once looks faster and is not: main
           # takes one merge at a time, and that merge puts every other branch
@@ -214,6 +221,8 @@ jobs:
           # nothing. With ten PRs queued that is ~600 jobs burned to land one.
           # Updating only the front runner costs one CI cycle per merge, and
           # the push trigger above starts the next one the moment it lands.
+          # `|| exit` is redundant under `set -e` but states the intent at the
+          # point it matters: no candidate list means stop, not proceed empty.
           candidates=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
             --limit 50 --json number,mergeStateStatus,autoMergeRequest,author \
             -q '[.[] | select(.autoMergeRequest != null)

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -227,13 +227,17 @@ jobs:
             exit 0
           fi
 
-          total=$(echo "$candidates" | wc -l | tr -d ' ')
-          front=$(echo "$candidates" | head -1)
-          echo "$total queued PR(s) behind; updating #$front, rest wait."
+          total=$(printf '%s\n' "$candidates" | wc -l | tr -d ' ')
+          front=$(printf '%s\n' "$candidates" | head -1)
+          printf '%s queued PR(s) behind; updating #%s, rest wait.\n' \
+            "$total" "$front"
 
           gh pr update-branch "$front" --repo "$GITHUB_REPOSITORY" \
             || echo "::warning::could not update #$front"
 
           if [ "$total" -gt 1 ]; then
-            echo "Still waiting: $(echo "$candidates" | tail -n +2 | tr '\n' ' ')"
+            # paste joins with a single separator and no trailing one; `tr`
+            # left a dangling space that made the list awkward to copy.
+            rest=$(printf '%s\n' "$candidates" | tail -n +2 | paste -sd' ' -)
+            printf 'Still waiting: %s\n' "$rest"
           fi


### PR DESCRIPTION
## The problem

The convoy job updates **every** behind auto-merge PR on each run. That looks like the fast option and is the opposite of one.

`main` takes one merge at a time, and that merge puts every other branch behind again. So updating the whole fleet re-runs everyone's full matrix in order to land exactly one PR — and leaves the rest behind for the next day.

Measured against the queue as it stands right now: **13 PRs behind with auto-merge on**, ~60 jobs each. That is roughly **780 jobs burned to merge one**, repeated daily.

And because the only trigger was a 06:00 UTC cron, a 13-deep queue takes 13 days regardless of how fast CI runs. That is the starvation this job was written to fix, still present in a different shape.

## The change

**Update only the front runner** — the lowest-numbered behind PR. One CI cycle per merge instead of thirteen.

**Trigger on push to main**, in addition to the cron. Every merge is exactly when the next branch needs updating. The queue now drains at the speed of CI rather than one per day.

The second change is what makes the first correct: updating one PR per *day* would be strictly worse than the status quo. Updating one per *merge* is strictly better.

## Triage is excluded from the push trigger

```yaml
if: github.event_name != 'push'
```

Triage reads a rolling window of failed runs and opens issues for recurrences. Running it once per merge would be noisy and would tell it nothing new — its input is not the merge that just happened.

## Unchanged

The selection filter — auto-merge enabled, human author, `BEHIND` — is untouched, including the bot exclusion and its reasoning. The job still calls `gh pr update-branch` and nothing else. It never merges and never edits code.

## Verification

Ran the exact selection pipeline against the live repo:

```
13 queued PR(s) behind; updating #93, rest wait.
Still waiting: 96 99 103 107 109 113 114 115 116 117 120 121
```

It picks the front of the queue and names the twelve it is deliberately leaving alone, so a reader of the log can tell "working through a backlog" from "stuck".

`yaml.safe_load` parses the file; triggers resolve to `push`, `schedule`, `workflow_dispatch`.
