### PR TITLE
fix(topic): pool-backed frames were freed while still unread

### DIFF
--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2650,8 +2650,23 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
     }
 
     /// Slots this ring can hold. Used to size the producer's keep-alive queue.
+    ///
+    /// Prefers the capacity `sync_local` validated against this handle's mapping
+    /// over a fresh read of the shared header, exactly as `init_shm_backend`
+    /// does and for the same reason: this number bounds how many pool slots the
+    /// producer pins, and a header rewritten to `u32::MAX` would have it hold a
+    /// reference to every frame it ever sent until the pool ran dry. Before this
+    /// handle has synced (cached capacity 0) there is nothing validated to use,
+    /// so fall back to the header.
+    ///
+    /// Meant to be read per publish, not cached by the caller: `sync_local`
+    /// adopts a new capacity across a grow, and the keep-alive depth has to grow
+    /// with it.
     pub(crate) fn ring_capacity(&self) -> u32 {
-        self.header().capacity
+        match self.local().cached_capacity as u32 {
+            0 => self.header().capacity,
+            cached => cached,
+        }
     }
 
     /// Record messages this handle lost for a reason the ring itself cannot see.
@@ -2663,7 +2678,12 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
     /// `stats()`, which is the difference between a lossy transport and an
     /// unaccountable one.
     pub(crate) fn note_missed(&self, n: u64) {
-        self.local().missed = self.local().missed.wrapping_add(n);
+        // One binding, read and written through: `local()` hands out a fresh
+        // `&mut LocalState` derived from the `UnsafeCell` on every call, and two
+        // of them in one statement is a question about evaluation order nobody
+        // should have to answer while reading a counter update.
+        let local = self.local();
+        local.missed = local.missed.wrapping_add(n);
     }
 
     /// Get a snapshot of the topic's metrics (compatible with Topic API)
@@ -3647,17 +3667,15 @@ pub struct Topic<T: TopicMessage> {
     /// How many times `resolve_owner` has looked for a node context and not
     /// found one. Bounds the per-send cost for a topic that has no owner.
     owner_attempts: std::cell::Cell<u16>,
-    /// Keep-alive reference(s) to the last pool-backed message sent, released on
-    /// the next send (or on Drop) so the producer's transport reference does not
-    /// leak. `(pool, primary, secondary)` — the exact pool the retain was taken
-    /// on (so release always matches, even for the auto-pool Tensor path);
-    /// `secondary` is `Some` only for the dual-tensor `CostMap`. Always `None`
-    /// for non-pool-backed message types.
-    /// Bounded to the ring's capacity, resolved on first publish.
+    /// Keep-alive reference(s) to the pool-backed messages this handle has sent
+    /// that the ring can still reach. Oldest first; an entry is released once
+    /// the ring's capacity has lapped past it (or on Drop), so the producer's
+    /// transport reference does not leak. `(pool, primary, secondary)` — the
+    /// exact pool the retain was taken on (so release always matches, even for
+    /// the auto-pool Tensor path); `secondary` is `Some` only for the
+    /// dual-tensor `CostMap`. Stays empty for non-pool-backed message types.
     sent_keepalives:
         std::cell::RefCell<std::collections::VecDeque<(Arc<TensorPool>, Tensor, Option<Tensor>)>>,
-    /// Ring capacity, cached on first publish. 0 = not yet resolved.
-    keepalive_depth: std::cell::Cell<u32>,
 }
 
 // SAFETY (Send): an owned `Topic` carries its `RingTopic` (itself `Send`) plus
@@ -3854,11 +3872,11 @@ impl<T: TopicMessage> Topic<T> {
             .unwrap_or_else(pool_registry::global_pool)
     }
 
-    /// Publish a new pool-backed keep-alive (on `self.pool`) and release the
-    /// previous one, which has now been superseded (drop-oldest). Subscribers
-    /// each hold their own `try_from_wire` reference, so releasing the transport
-    /// reference here can only ever drop the producer's ref — never a live
-    /// reader's.
+    /// Record a new pool-backed keep-alive (on `self.pool`) and release the ones
+    /// the ring can no longer reach — one reference per ring slot, oldest
+    /// evicted first. Subscribers each hold their own `try_from_wire` reference,
+    /// so releasing the transport reference here can only ever drop the
+    /// producer's ref — never a live reader's.
     #[inline]
     fn publish_keepalive(&self, primary: Tensor, secondary: Option<Tensor>) {
         let pool = self.keepalive_pool();
@@ -3894,14 +3912,13 @@ impl<T: TopicMessage> Topic<T> {
         // The bound is the ring's own capacity because that is exactly how many
         // descriptors can be outstanding. Fewer re-creates the bug for the
         // difference; more pins pool slots the ring can no longer reach.
-        let depth = self.keepalive_depth.get();
-        let depth = if depth == 0 {
-            let c = self.ring.ring_capacity().max(1);
-            self.keepalive_depth.set(c);
-            c
-        } else {
-            depth
-        } as usize;
+        //
+        // Read on every publish rather than resolved once: `sync_local` adopts a
+        // larger capacity across a grow, and a depth frozen at the pre-grow
+        // value would free frames the enlarged ring can still hand out — this
+        // same bug, in the window after a migration. `ring_capacity` reads local
+        // state this handle already caches, not the shared header.
+        let depth = self.ring.ring_capacity().max(1) as usize;
 
         let mut q = self.sent_keepalives.borrow_mut();
         q.push_back((pool, primary, secondary));
@@ -4151,7 +4168,6 @@ where
             owner_node: owner,
             owner_attempts: std::cell::Cell::new(0),
             sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
-            keepalive_depth: std::cell::Cell::new(0),
         })
     }
 
@@ -4214,7 +4230,6 @@ where
             owner_node: owner,
             owner_attempts: std::cell::Cell::new(0),
             sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
-            keepalive_depth: std::cell::Cell::new(0),
         })
     }
 
@@ -4245,7 +4260,6 @@ where
             owner_node: owner,
             owner_attempts: std::cell::Cell::new(0),
             sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
-            keepalive_depth: std::cell::Cell::new(0),
         })
     }
 }
@@ -4340,9 +4354,9 @@ where
             owner_node: self.owner_node.clone(),
             owner_attempts: self.owner_attempts.clone(),
             // A fresh clone has sent nothing yet; each handle tracks and releases
-            // only its own last-sent keep-alive, so clones never double-release.
+            // only the keep-alives it published itself, so clones never
+            // double-release.
             sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
-            keepalive_depth: std::cell::Cell::new(0),
         }
     }
 }
@@ -4355,8 +4369,8 @@ impl Topic<Image> {
     /// Send an image (zero-copy).
     ///
     /// Accepts both owned and borrowed images: `topic.send(img)` or `topic.send(&img)`.
-    /// Retains the tensor so it stays alive for receivers, then sends the
-    /// descriptor through the ring buffer.
+    /// Sends the descriptor through the ring buffer, then retains the tensor so
+    /// it stays alive for receivers until the ring has lapped past the frame.
     pub fn send(&self, img: impl Borrow<Image>) {
         self.register_pub("Image");
         let wire = img.borrow().to_wire(&self.pool);

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2655,16 +2655,31 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
     /// over a fresh read of the shared header, exactly as `init_shm_backend`
     /// does and for the same reason: this number bounds how many pool slots the
     /// producer pins, and a header rewritten to `u32::MAX` would have it hold a
-    /// reference to every frame it ever sent until the pool ran dry. Before this
-    /// handle has synced (cached capacity 0) there is nothing validated to use,
-    /// so fall back to the header.
+    /// reference to every frame it ever sent until the pool ran dry.
+    ///
+    /// With nothing cached the header is the only source, but it is put through
+    /// the same test `sync_local` would have applied rather than trusted raw. A
+    /// cached capacity of 0 is not only the pre-sync state: `sync_local` also
+    /// leaves it at 0 when it REFUSES a geometry, so the raw fallback read the
+    /// hostile header on precisely the path that had just rejected it. A header
+    /// `geometry_is_addressable` will not accept falls back to a single
+    /// keep-alive instead — bounded, and self-correcting, since the depth is
+    /// re-read on the next publish and grows the moment a real geometry is
+    /// adopted.
     ///
     /// Meant to be read per publish, not cached by the caller: `sync_local`
     /// adopts a new capacity across a grow, and the keep-alive depth has to grow
     /// with it.
     pub(crate) fn ring_capacity(&self) -> u32 {
         match self.local().cached_capacity as u32 {
-            0 => self.header().capacity,
+            0 => {
+                let header = self.header();
+                if Self::geometry_is_addressable(header, self.storage.len()) {
+                    header.capacity
+                } else {
+                    1
+                }
+            }
             cached => cached,
         }
     }
@@ -3922,10 +3937,12 @@ impl<T: TopicMessage> Topic<T> {
 
         let mut q = self.sent_keepalives.borrow_mut();
         q.push_back((pool, primary, secondary));
-        while q.len() > depth {
-            if let Some(prev) = q.pop_front() {
-                release_keepalive_tuple(prev);
-            }
+        // Everything past the depth is a frame the ring can no longer hand out,
+        // released oldest first. Draining the overflow as a range says that in
+        // one line and leaves no unreachable `None` arm to reason about.
+        let overflow = q.len().saturating_sub(depth);
+        for prev in q.drain(..overflow) {
+            release_keepalive_tuple(prev);
         }
     }
 }
@@ -4395,17 +4412,30 @@ impl Topic<Image> {
     }
 
     /// Receive the next image.
+    ///
+    /// A frame whose backing was released before it could be read is skipped and
+    /// counted as missed, so `None` means the ring is empty and nothing else.
     pub fn recv(&self) -> Option<Image> {
         self.register_sub("Image");
-        let wire = self.ring.recv()?;
-        // A frame whose backing was already released is lost. The ring dropped
-        // nothing and lapped nobody, so nothing inside it can count this —
-        // record it here or it is invisible to every counter.
-        match Image::try_from_wire(wire, &self.pool) {
-            Some(v) => Some(v),
-            None => {
-                self.ring.note_missed(1);
-                None
+        loop {
+            let wire = self.ring.recv()?;
+            match Image::try_from_wire(wire, &self.pool) {
+                Some(img) => return Some(img),
+                None => {
+                    // The frame is lost: its backing went away before we read
+                    // it. The ring dropped nothing and lapped nobody, so nothing
+                    // inside it can count this — record it here or it is
+                    // invisible to every counter.
+                    //
+                    // Then keep reading rather than answering `None`. `None` is
+                    // also how an empty ring answers, so returning it for one
+                    // dead frame ends `while let Some(f) = t.recv()` with
+                    // readable frames still sitting in the ring — the same
+                    // failure this whole change is about, just with one bad
+                    // frame in front instead of a whole stream of them. The loop
+                    // is bounded by the ring: every turn consumes a slot.
+                    self.ring.note_missed(1);
+                }
             }
         }
     }
@@ -4443,17 +4473,17 @@ impl Topic<PointCloud> {
     }
 
     /// Receive the next point cloud.
+    ///
+    /// Skips and counts frames whose backing is gone, as `Topic<Image>::recv`
+    /// does and for the reason spelled out there: `None` has to mean an empty
+    /// ring, or a drain loop stops on the first dead frame.
     pub fn recv(&self) -> Option<PointCloud> {
         self.register_sub("PointCloud");
-        let wire = self.ring.recv()?;
-        // A frame whose backing was already released is lost. The ring dropped
-        // nothing and lapped nobody, so nothing inside it can count this —
-        // record it here or it is invisible to every counter.
-        match PointCloud::try_from_wire(wire, &self.pool) {
-            Some(v) => Some(v),
-            None => {
-                self.ring.note_missed(1);
-                None
+        loop {
+            let wire = self.ring.recv()?;
+            match PointCloud::try_from_wire(wire, &self.pool) {
+                Some(msg) => return Some(msg),
+                None => self.ring.note_missed(1),
             }
         }
     }
@@ -4491,17 +4521,17 @@ impl Topic<DepthImage> {
     }
 
     /// Receive the next depth image.
+    ///
+    /// Skips and counts frames whose backing is gone, as `Topic<Image>::recv`
+    /// does and for the reason spelled out there: `None` has to mean an empty
+    /// ring, or a drain loop stops on the first dead frame.
     pub fn recv(&self) -> Option<DepthImage> {
         self.register_sub("DepthImage");
-        let wire = self.ring.recv()?;
-        // A frame whose backing was already released is lost. The ring dropped
-        // nothing and lapped nobody, so nothing inside it can count this —
-        // record it here or it is invisible to every counter.
-        match DepthImage::try_from_wire(wire, &self.pool) {
-            Some(v) => Some(v),
-            None => {
-                self.ring.note_missed(1);
-                None
+        loop {
+            let wire = self.ring.recv()?;
+            match DepthImage::try_from_wire(wire, &self.pool) {
+                Some(msg) => return Some(msg),
+                None => self.ring.note_missed(1),
             }
         }
     }
@@ -4810,6 +4840,57 @@ mod untrusted_ring_geometry_tests {
             return;
         }
         assert!(RingTopic::<u64>::new(&name).is_err());
+        cleanup(&name);
+    }
+
+    /// `ring_capacity` sizes the producer's keep-alive queue, i.e. how many pool
+    /// slots a publisher pins. A handle that has not yet validated a geometry has
+    /// only the header to go on, and the header is shared memory: this is the
+    /// one number in that fallback path, so it gets the same test `sync_local`
+    /// applies before it is believed.
+    #[test]
+    fn an_unvalidated_capacity_does_not_size_the_keepalive_queue() {
+        let name = format!("untrusted_geom_keepalive_{}", std::process::id());
+        let Ok(topic) = RingTopic::<u64>::new(&name) else {
+            eprintln!("skipping: no shared memory available");
+            return;
+        };
+
+        // SAFETY: single-threaded test, sole handle on this region. The header is
+        // rewritten the way a hostile peer would after attach — a geometry that
+        // looks internally consistent (power of two, matching mask) but is far
+        // larger than this mapping, which is precisely what `sync_local` refuses
+        // and therefore what leaves the cached capacity at 0.
+        let header_ptr = topic.header() as *const TopicHeader as *mut TopicHeader;
+        let (real_capacity, real_mask) =
+            unsafe { ((*header_ptr).capacity, (*header_ptr).capacity_mask) };
+        unsafe {
+            (*header_ptr).capacity = 1 << 20;
+            (*header_ptr).capacity_mask = (1 << 20) - 1;
+        }
+
+        let depth = topic.ring_capacity();
+        unsafe {
+            (*header_ptr).capacity = real_capacity;
+            (*header_ptr).capacity_mask = real_mask;
+        }
+
+        assert_eq!(
+            depth,
+            1,
+            "a capacity this mapping cannot hold must not become a keep-alive \
+             depth: at {} the publisher would pin a pool reference to every frame \
+             it ever sent until the pool ran dry",
+            1u32 << 20
+        );
+        assert_eq!(
+            topic.ring_capacity(),
+            real_capacity,
+            "and a header that IS addressable is still usable pre-sync — the \
+             guard must not cost the first publish its real depth"
+        );
+
+        drop(topic);
         cleanup(&name);
     }
 

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2649,6 +2649,23 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
         self.local().missed
     }
 
+    /// Slots this ring can hold. Used to size the producer's keep-alive queue.
+    pub(crate) fn ring_capacity(&self) -> u32 {
+        self.header().capacity
+    }
+
+    /// Record messages this handle lost for a reason the ring itself cannot see.
+    ///
+    /// The pool-backed types need this: a frame whose backing was released
+    /// before the subscriber read it is lost, but the ring dropped nothing and
+    /// lapped nobody, so no counter inside the ring has anything to report.
+    /// Without this the loss is invisible to `missed_count()` and to
+    /// `stats()`, which is the difference between a lossy transport and an
+    /// unaccountable one.
+    pub(crate) fn note_missed(&self, n: u64) {
+        self.local().missed = self.local().missed.wrapping_add(n);
+    }
+
     /// Get a snapshot of the topic's metrics (compatible with Topic API)
     pub fn metrics(&self) -> TopicMetrics {
         TopicMetrics::new(
@@ -3636,7 +3653,11 @@ pub struct Topic<T: TopicMessage> {
     /// on (so release always matches, even for the auto-pool Tensor path);
     /// `secondary` is `Some` only for the dual-tensor `CostMap`. Always `None`
     /// for non-pool-backed message types.
-    last_sent_keepalive: std::cell::Cell<Option<(Arc<TensorPool>, Tensor, Option<Tensor>)>>,
+    /// Bounded to the ring's capacity, resolved on first publish.
+    sent_keepalives:
+        std::cell::RefCell<std::collections::VecDeque<(Arc<TensorPool>, Tensor, Option<Tensor>)>>,
+    /// Ring capacity, cached on first publish. 0 = not yet resolved.
+    keepalive_depth: std::cell::Cell<u32>,
 }
 
 // SAFETY (Send): an owned `Topic` carries its `RingTopic` (itself `Send`) plus
@@ -3646,10 +3667,11 @@ unsafe impl<T: TopicMessage> Send for Topic<T> where T::Wire: Send {}
 
 // No `Sync` impl, for the same reason as `RingTopic` above: `send`/`recv` take
 // `&self` and mutate `registered_pub`/`registered_sub`/`owner_attempts` and the
-// `last_sent_keepalive` `Cell`. Two threads sharing one `&Topic<Image>` could
-// both `Cell::replace` the same keep-alive tuple and release the pool slot
+// `sent_keepalives` `RefCell`. Two threads sharing one `&Topic<Image>` could
+// both push and evict from the same keep-alive queue and release the pool slot
 // twice — a use-after-free of shared-memory the subscribers are still reading.
-// `Cell` makes `Topic` `!Sync` all by itself.
+// `RefCell` makes `Topic` `!Sync` all by itself, exactly as the `Cell` it
+// replaced did.
 
 // Compile-time guard: `Topic` must stay `Send` (owned handles move between
 // threads all over the tree) even though it is no longer `Sync`. If a future
@@ -3852,11 +3874,41 @@ impl<T: TopicMessage> Topic<T> {
         primary: Tensor,
         secondary: Option<Tensor>,
     ) {
-        if let Some(prev) = self
-            .last_sent_keepalive
-            .replace(Some((pool, primary, secondary)))
-        {
-            release_keepalive_tuple(prev);
+        // Hold one reference per slot the ring can hold, not one in total.
+        //
+        // This used to be a depth-1 `Cell`: every send released the previous
+        // frame's pool reference, so a frame that was still sitting unread in
+        // the ring had its backing freed the moment the next one was published.
+        // `try_from_wire` then failed its `try_retain` and `recv()` returned
+        // `None` while `pending_count()` was non-zero — which also breaks
+        // `while let Some(f) = topic.recv()` drain loops.
+        //
+        // Nothing counted that loss, and correctly so: the ring dropped
+        // nothing and lapped nobody, so `dropped_count()` and `missed_count()`
+        // had nothing to report. Measured on a realistic pipeline (publisher
+        // ~10 kHz, subscriber polling ~2 kHz, separate threads) it was 500
+        // frames sent and 1 received, every counter at zero. These are the
+        // Image / PointCloud / DepthImage / Tensor types — camera, lidar and
+        // depth, the highest-volume payloads a robot carries.
+        //
+        // The bound is the ring's own capacity because that is exactly how many
+        // descriptors can be outstanding. Fewer re-creates the bug for the
+        // difference; more pins pool slots the ring can no longer reach.
+        let depth = self.keepalive_depth.get();
+        let depth = if depth == 0 {
+            let c = self.ring.ring_capacity().max(1);
+            self.keepalive_depth.set(c);
+            c
+        } else {
+            depth
+        } as usize;
+
+        let mut q = self.sent_keepalives.borrow_mut();
+        q.push_back((pool, primary, secondary));
+        while q.len() > depth {
+            if let Some(prev) = q.pop_front() {
+                release_keepalive_tuple(prev);
+            }
         }
     }
 }
@@ -3866,7 +3918,7 @@ impl<T: TopicMessage> Drop for Topic<T> {
         // Release the final message's keep-alive so it isn't leaked when the
         // producer stops sending. A late subscriber is unaffected: it holds its
         // own reference (`try_from_wire`), which keeps the slot alive.
-        if let Some(ka) = self.last_sent_keepalive.take() {
+        for ka in self.sent_keepalives.borrow_mut().drain(..) {
             release_keepalive_tuple(ka);
         }
     }
@@ -4098,7 +4150,8 @@ where
             registered_sub: std::cell::Cell::new(false),
             owner_node: owner,
             owner_attempts: std::cell::Cell::new(0),
-            last_sent_keepalive: std::cell::Cell::new(None),
+            sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
+            keepalive_depth: std::cell::Cell::new(0),
         })
     }
 
@@ -4160,7 +4213,8 @@ where
             registered_sub: std::cell::Cell::new(false),
             owner_node: owner,
             owner_attempts: std::cell::Cell::new(0),
-            last_sent_keepalive: std::cell::Cell::new(None),
+            sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
+            keepalive_depth: std::cell::Cell::new(0),
         })
     }
 
@@ -4190,7 +4244,8 @@ where
             registered_sub: std::cell::Cell::new(false),
             owner_node: owner,
             owner_attempts: std::cell::Cell::new(0),
-            last_sent_keepalive: std::cell::Cell::new(None),
+            sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
+            keepalive_depth: std::cell::Cell::new(0),
         })
     }
 }
@@ -4286,7 +4341,8 @@ where
             owner_attempts: self.owner_attempts.clone(),
             // A fresh clone has sent nothing yet; each handle tracks and releases
             // only its own last-sent keep-alive, so clones never double-release.
-            last_sent_keepalive: std::cell::Cell::new(None),
+            sent_keepalives: std::cell::RefCell::new(std::collections::VecDeque::new()),
+            keepalive_depth: std::cell::Cell::new(0),
         }
     }
 }
@@ -4304,8 +4360,11 @@ impl Topic<Image> {
     pub fn send(&self, img: impl Borrow<Image>) {
         self.register_pub("Image");
         let wire = img.borrow().to_wire(&self.pool);
-        self.publish_keepalive(*wire.tensor(), None);
+        // Ring first, then retain — `try_send` already does this. Retaining
+        // first meant a frame the ring immediately dropped still displaced the
+        // keep-alive of a previously published, still-unread frame.
         self.ring.send(wire);
+        self.publish_keepalive(*wire.tensor(), None);
     }
 
     /// Try to send an image without blocking. Returns `Err(img)` if the ring is full.
@@ -4325,7 +4384,16 @@ impl Topic<Image> {
     pub fn recv(&self) -> Option<Image> {
         self.register_sub("Image");
         let wire = self.ring.recv()?;
-        Image::try_from_wire(wire, &self.pool)
+        // A frame whose backing was already released is lost. The ring dropped
+        // nothing and lapped nobody, so nothing inside it can count this —
+        // record it here or it is invisible to every counter.
+        match Image::try_from_wire(wire, &self.pool) {
+            Some(v) => Some(v),
+            None => {
+                self.ring.note_missed(1);
+                None
+            }
+        }
     }
 }
 
@@ -4340,8 +4408,11 @@ impl Topic<PointCloud> {
     pub fn send(&self, pc: impl Borrow<PointCloud>) {
         self.register_pub("PointCloud");
         let wire = pc.borrow().to_wire(&self.pool);
-        self.publish_keepalive(*wire.tensor(), None);
+        // Ring first, then retain — `try_send` already does this. Retaining
+        // first meant a frame the ring immediately dropped still displaced the
+        // keep-alive of a previously published, still-unread frame.
         self.ring.send(wire);
+        self.publish_keepalive(*wire.tensor(), None);
     }
 
     /// Try to send a point cloud without blocking. Returns `Err(pc)` if the ring is full.
@@ -4361,7 +4432,16 @@ impl Topic<PointCloud> {
     pub fn recv(&self) -> Option<PointCloud> {
         self.register_sub("PointCloud");
         let wire = self.ring.recv()?;
-        PointCloud::try_from_wire(wire, &self.pool)
+        // A frame whose backing was already released is lost. The ring dropped
+        // nothing and lapped nobody, so nothing inside it can count this —
+        // record it here or it is invisible to every counter.
+        match PointCloud::try_from_wire(wire, &self.pool) {
+            Some(v) => Some(v),
+            None => {
+                self.ring.note_missed(1);
+                None
+            }
+        }
     }
 }
 
@@ -4376,8 +4456,11 @@ impl Topic<DepthImage> {
     pub fn send(&self, depth: impl Borrow<DepthImage>) {
         self.register_pub("DepthImage");
         let wire = depth.borrow().to_wire(&self.pool);
-        self.publish_keepalive(*wire.tensor(), None);
+        // Ring first, then retain — `try_send` already does this. Retaining
+        // first meant a frame the ring immediately dropped still displaced the
+        // keep-alive of a previously published, still-unread frame.
         self.ring.send(wire);
+        self.publish_keepalive(*wire.tensor(), None);
     }
 
     /// Try to send a depth image without blocking. Returns `Err(depth)` if the ring is full.
@@ -4397,7 +4480,16 @@ impl Topic<DepthImage> {
     pub fn recv(&self) -> Option<DepthImage> {
         self.register_sub("DepthImage");
         let wire = self.ring.recv()?;
-        DepthImage::try_from_wire(wire, &self.pool)
+        // A frame whose backing was already released is lost. The ring dropped
+        // nothing and lapped nobody, so nothing inside it can count this —
+        // record it here or it is invisible to every counter.
+        match DepthImage::try_from_wire(wire, &self.pool) {
+            Some(v) => Some(v),
+            None => {
+                self.ring.note_missed(1);
+                None
+            }
+        }
     }
 }
 

--- a/horus_core/src/communication/topic/topic_message.rs
+++ b/horus_core/src/communication/topic/topic_message.rs
@@ -341,7 +341,7 @@ mod tests {
             Topic::<Image>::with_capacity("test.comm_h2.keepalive.drain", CAP, None).expect("rx");
 
         for i in 0..SENT {
-            let mut img = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc");
+            let img = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc");
             img.data_mut()[0] = i as u8;
             tx.send(img);
         }

--- a/horus_core/src/communication/topic/topic_message.rs
+++ b/horus_core/src/communication/topic/topic_message.rs
@@ -363,4 +363,70 @@ mod tests {
             tx.dropped_count()
         );
     }
+
+    /// `None` from `recv()` has to mean "the ring is empty", not "the frame at
+    /// the head is unreadable".
+    ///
+    /// The keep-alive fix removes the case that made every frame unreadable, but
+    /// not the case itself: a producer that exits and releases, or a descriptor
+    /// whose pool generation has moved on, still lands a dead frame in a ring
+    /// with live ones behind it. Answering `None` there ends
+    /// `while let Some(f) = rx.recv()` with those live frames unread — the same
+    /// failure as the bug this change fixes, with one bad frame in front instead
+    /// of a whole stream.
+    #[test]
+    fn image_recv_skips_a_dead_frame_and_keeps_draining() {
+        use crate::communication::topic::Topic;
+        const CAP: u32 = 8;
+
+        let tx =
+            Topic::<Image>::with_capacity("test.comm_h2.keepalive.skip", CAP, None).expect("tx");
+        let rx =
+            Topic::<Image>::with_capacity("test.comm_h2.keepalive.skip", CAP, None).expect("rx");
+
+        let a = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc a");
+        let pool = a.pool().clone();
+        let slot_a = *a.descriptor().tensor();
+        tx.send(a);
+
+        let b = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc b");
+        let slot_b = *b.descriptor().tensor();
+        tx.send(b);
+
+        // Kill A's backing and leave B's alone: what the depth-1 keep-alive did
+        // to every frame, reproduced for exactly one. `release` is generation-
+        // and underflow-guarded, so the producer's own release of this tuple on
+        // drop is a no-op.
+        while pool.refcount(&slot_a) > 0 {
+            pool.release(&slot_a);
+        }
+        assert!(
+            pool.refcount(&slot_b) >= 1,
+            "test setup: B must still be alive, only A was released"
+        );
+
+        let mut got = Vec::new();
+        while let Some(img) = rx.recv() {
+            got.push(*img.descriptor().tensor());
+        }
+
+        assert_eq!(
+            got.len(),
+            1,
+            "B was sent after A and is still readable, so recv() must skip past \
+             the dead frame and deliver it. Got {} frames — a `None` for A stops \
+             the drain loop on a non-empty ring.",
+            got.len()
+        );
+        assert_eq!(
+            got[0].slot_id, slot_b.slot_id,
+            "the delivered frame must be B"
+        );
+        assert_eq!(
+            rx.missed_count(),
+            1,
+            "the skipped frame is still a lost frame and must be counted, or it \
+             is invisible to every counter a supervisor can read"
+        );
+    }
 }

--- a/horus_core/src/communication/topic/topic_message.rs
+++ b/horus_core/src/communication/topic/topic_message.rs
@@ -285,29 +285,82 @@ mod tests {
     // sends does not leak pool slots. Before the fix, `to_wire`'s retain was
     // never balanced for multi-subscriber topics and each send leaked a slot.
     #[test]
-    fn image_topic_releases_superseded_keepalive() {
+    fn image_topic_holds_keepalives_for_the_whole_ring_then_releases() {
         use crate::communication::topic::Topic;
-        let topic = Topic::<Image>::new("test.comm_h2.keepalive.release").expect("topic");
+        const CAP: u32 = 4;
+        let topic = Topic::<Image>::with_capacity("test.comm_h2.keepalive.bound", CAP, None)
+            .expect("topic");
 
         let a = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc a");
         let pool = a.pool().clone();
         let slot_a = *a.descriptor().tensor();
         topic.send(a);
-        // A's keep-alive is held until a later send supersedes it.
+
+        // The next send must NOT release A. A is still sitting unread in the
+        // ring, and freeing its backing is what made `recv()` return None on a
+        // non-empty ring: a subscriber polling slower than the publisher got
+        // one frame in five hundred, with every counter reading zero.
+        //
+        // This assertion used to be the opposite (`refcount == 0` right here),
+        // which encoded the depth-1 keep-alive as a requirement. The concern
+        // behind it — that the producer must not leak pool slots — is real and
+        // is what the rest of this test now covers.
+        topic.send(Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc b"));
         assert!(
             pool.refcount(&slot_a) >= 1,
-            "A's keep-alive should be held after send (refcount {})",
+            "A is still readable in the ring, so its backing must stay alive \
+             (refcount {})",
             pool.refcount(&slot_a)
         );
 
-        // Sending B supersedes A. No subscriber ever read A, so releasing A's
-        // keep-alive returns its slot to the pool (refcount 0) — no leak.
-        let b = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc b");
-        topic.send(b);
+        // Past the ring's depth A can no longer be reached, so holding it would
+        // be a leak. Retention is bounded by capacity, not unbounded.
+        for _ in 0..CAP {
+            topic.send(Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc filler"));
+        }
         assert_eq!(
             pool.refcount(&slot_a),
             0,
-            "A's keep-alive must be released once superseded (else every send leaks a slot)"
+            "once the ring has lapped past A the producer must release it, or \
+             every send leaks a slot"
+        );
+    }
+
+    /// The bug this file's keep-alive machinery caused: frames sent while the
+    /// subscriber was not draining became unreadable, and `recv()` returned
+    /// None on a non-empty ring.
+    #[test]
+    fn image_frames_survive_until_the_subscriber_drains_them() {
+        use crate::communication::topic::Topic;
+        const CAP: u32 = 8;
+        const SENT: usize = 5;
+
+        let tx =
+            Topic::<Image>::with_capacity("test.comm_h2.keepalive.drain", CAP, None).expect("tx");
+        let rx =
+            Topic::<Image>::with_capacity("test.comm_h2.keepalive.drain", CAP, None).expect("rx");
+
+        for i in 0..SENT {
+            let mut img = Image::new(8, 8, ImageEncoding::Rgb8).expect("alloc");
+            img.data_mut()[0] = i as u8;
+            tx.send(img);
+        }
+
+        let mut got = 0;
+        while rx.recv().is_some() {
+            got += 1;
+        }
+
+        assert_eq!(
+            got,
+            SENT,
+            "{SENT} frames were sent into a {CAP}-slot ring and never lapped, so \
+             all {SENT} must be readable. Got {got}, missed={}, dropped={}. A \
+             depth-1 keep-alive freed each frame's backing on the next send, so \
+             recv() returned None while the ring was non-empty — and because \
+             the ring dropped nothing and lapped nobody, no counter could see it.",
+            rx.missed_count(),
+            tx.dropped_count()
         );
     }
 }


### PR DESCRIPTION
## 500 frames sent, 1 received

`Image`, `PointCloud`, `DepthImage` and `Tensor` topics had an effective queue depth of **one**.

The producer held a single keep-alive in a `Cell`, so every `send()` released the previous frame's pool reference — including when that frame was still sitting unread in the ring. `try_from_wire` then failed its `try_retain`, and `recv()` returned `None` **on a non-empty ring**. That also silently breaks the idiomatic drain loop:

```rust
while let Some(frame) = topic.recv() { ... }   // exits with the ring full
```

Measured on a realistic pipeline — publisher ~10 kHz, subscriber polling ~2 kHz, separate threads, release build:

| | sent | received |
|---|---|---|
| pool-backed (`Image`) | 500 | **1** |
| control (`Topic<u64>`, same shape) | 80 | 80 |

These are the highest-volume payloads a robot carries: camera, lidar, depth.

## The counters were not broken — they had nothing to report

`dropped_count()` and `missed_count()` both read **zero** throughout. Correctly so: the ring dropped nothing and lapped nobody. The frames were destroyed underneath it.

That is the one thing a lossy transport must never do. Loss is survivable; loss a supervisor cannot detect is not, because it cannot tell a quiet camera from a dead one.

## Three changes

**Hold one keep-alive per ring slot**, bounded by the ring's own capacity. That is exactly how many descriptors can be outstanding — fewer re-creates the bug for the difference, more pins pool slots the ring can no longer reach.

**Count what is still lost.** On a failed retain the subscriber's `missed` now moves, so any residue is visible to `missed_count()` and `stats()` instead of reading zero.

**`send` retains after the ring takes the descriptor**, matching what `try_send` already did correctly. Retaining first meant a frame the ring dropped immediately still displaced the keep-alive of a previously published, still-unread frame.

## An existing test encoded the bug as a requirement

`image_topic_releases_superseded_keepalive` asserted `refcount == 0` on the very next send — i.e. it required depth-1 behaviour.

The concern behind it is real: the producer must not leak pool slots. So it is replaced rather than deleted, and the replacement covers both halves:

- the frame stays alive while it is **still readable** (the fix)
- retention is **bounded by capacity**, so nothing leaks (the original concern)

## Gate

Forcing the keep-alive depth back to 1:

```
5 frames were sent into a 8-slot ring and never lapped, so all 5 must be
readable. Got 0, missed=1, dropped=0.
```

0 of 5 delivered — and `missed=1` shows the new counting reporting loss that read as zero before the change.

## Verification

- Full `horus_core` lib suite: **2496 passed, 0 failed**
- `cargo clippy -p horus_core --lib` — clean
- `cargo fmt --all` — clean

Found by an adversarial audit; the finding survived independent verification including a refcount trace (`after send(A) rc(A)=1; after send(B) rc(A)=0`) and causal isolation (a producer keeping its own handles alive delivers 8/8 where dropping them delivers 1/8).
