### PR TITLE
feat(rt): make deadlines mean deadlines, and make the fieldbus path usable

### DIFF
--- a/benchmarks/src/output.rs
+++ b/benchmarks/src/output.rs
@@ -170,11 +170,21 @@ pub enum Metric {
     TailRatioP99,
     /// `p99.9 / median` — dimensionless tail shape.
     TailRatioP999,
+    /// Nanoseconds per message: the RECIPROCAL of throughput.
+    ///
+    /// Throughput is higher-is-better and every comparison in this gate is
+    /// lower-is-better (`current > band` is a regression). Rather than teach
+    /// the comparator a direction — one more branch on every metric, and a
+    /// second meaning for "improved" — throughput enters as its reciprocal.
+    /// That keeps one direction in the gate and, as a bonus, puts throughput in
+    /// the same unit as every latency metric, so the thresholds below are
+    /// comparable to the ones above them.
+    ThroughputNsPerMsg,
 }
 
 impl Metric {
     /// Every metric the gate knows about, in report order.
-    pub const ALL: [Metric; 9] = [
+    pub const ALL: [Metric; 10] = [
         Metric::Median,
         Metric::P95,
         Metric::P99,
@@ -184,6 +194,7 @@ impl Metric {
         Metric::MaxJitter,
         Metric::TailRatioP99,
         Metric::TailRatioP999,
+        Metric::ThroughputNsPerMsg,
     ];
 
     /// Short label used in tables.
@@ -198,6 +209,7 @@ impl Metric {
             Metric::MaxJitter => "max_jitter",
             Metric::TailRatioP99 => "p99/median",
             Metric::TailRatioP999 => "p99.9/median",
+            Metric::ThroughputNsPerMsg => "ns/msg",
         }
     }
 
@@ -234,6 +246,10 @@ impl Metric {
             // `max` and `max_jitter` are single samples at any n; the floor
             // here only asserts the run was long enough to have seen anything.
             Metric::Max | Metric::MaxJitter => 1_000,
+            // A whole-run aggregate, not an order statistic: it needs enough
+            // messages for the rate to be meaningful, not enough to resolve a
+            // percentile.
+            Metric::ThroughputNsPerMsg => 100,
         }
     }
 
@@ -256,6 +272,16 @@ impl Metric {
             Metric::MaxJitter => Some(entry.max_jitter_ns as f64),
             Metric::TailRatioP99 => ratio(entry.p99 as f64),
             Metric::TailRatioP999 => ratio(entry.p999 as f64),
+            // 0 or non-finite means the producing binary did not measure
+            // throughput for this benchmark. `None` makes the gate skip it
+            // rather than compare against a fabricated zero.
+            Metric::ThroughputNsPerMsg => {
+                if entry.ns_per_msg.is_finite() && entry.ns_per_msg > 0.0 {
+                    Some(entry.ns_per_msg)
+                } else {
+                    None
+                }
+            }
         }
     }
 
@@ -476,6 +502,23 @@ impl Default for RegressionPolicy {
                     abs_floor: 1.0,
                     gross_multiplier: 6.0,
                 },
+                // Throughput, as ns/msg so it shares the lower-is-better
+                // comparison. Report-only to begin with: unlike the latency
+                // metrics there is no window of history for it yet, so its
+                // real spread on this runner class is unmeasured, and the
+                // honest thing is to watch it before letting it fail a build.
+                // The gross multiplier still applies, so a throughput COLLAPSE
+                // (2x the ns/msg, i.e. half the rate) is caught immediately.
+                // Promote to Blocking once BENCH_WINDOW runs have described
+                // its spread — the same path Median took.
+                MetricPolicy {
+                    metric: Metric::ThroughputNsPerMsg,
+                    enforcement: Enforcement::ReportOnly,
+                    rel_threshold: 0.20,
+                    noise_sigmas: 4.0,
+                    abs_floor: 50.0,
+                    gross_multiplier: 2.0,
+                },
             ],
             min_baseline_runs: 5,
             no_noise_fallback_rel: 1.0,
@@ -531,6 +574,16 @@ pub struct BaselineEntry {
     /// so it is never gated.
     #[serde(deserialize_with = "crate::stats::nan_from_null")]
     pub cv: f64,
+    /// Nanoseconds per message — the reciprocal of `throughput.messages_per_sec`.
+    ///
+    /// `#[serde(default)]` because the rolling baseline in the Actions cache
+    /// predates this field. Older runs deserialize to 0.0, which
+    /// `Metric::value` maps to `None`, so the gate reports "no baseline run
+    /// recorded this benchmark" for throughput until the window refills with
+    /// runs that have it. That is the correct rollout: no false regression on
+    /// the first build after this lands.
+    #[serde(default)]
+    pub ns_per_msg: f64,
 }
 
 impl BaselineEntry {
@@ -548,6 +601,14 @@ impl BaselineEntry {
             max: result.statistics.max,
             max_jitter_ns: result.determinism.max_jitter_ns,
             cv: result.determinism.cv,
+            ns_per_msg: {
+                let mps = result.throughput.messages_per_sec;
+                if mps.is_finite() && mps > 0.0 {
+                    1e9 / mps
+                } else {
+                    0.0
+                }
+            },
         }
     }
 
@@ -629,6 +690,7 @@ impl BaselineRun {
                 max: med_u(reps.iter().map(|e| e.max).collect()),
                 max_jitter_ns: med_u(reps.iter().map(|e| e.max_jitter_ns).collect()),
                 cv: med_f(reps.iter().map(|e| e.cv).collect()),
+                ns_per_msg: med_f(reps.iter().map(|e| e.ns_per_msg).collect()),
             })
             .collect();
 
@@ -1812,6 +1874,11 @@ fn remedy_for(metric: Metric) -> &'static str {
              contended cache line on the hot path — something that is cheap most of the time \
              and expensive sometimes."
         }
+        Metric::ThroughputNsPerMsg => {
+            "sustained throughput dropped (this is ns per message, so higher is worse). \
+             Look for added per-message work on the send path, a copy that used to be \
+             elided, or a batch that stopped batching."
+        }
         Metric::Max | Metric::MaxJitter | Metric::P9999 => {
             "a worst-case excursion grew far past anything the runner explains. Check for an \
              unbounded loop, a blocking wait, or a fault path newly reachable from the hot path."
@@ -1954,7 +2021,7 @@ mod tests {
 
     /// Shape of one benchmark result, parameterised on the numbers the gate
     /// actually reads.
-    struct Shape {
+    pub(super) struct Shape {
         median: f64,
         p95: u64,
         p99: u64,
@@ -1967,7 +2034,7 @@ mod tests {
     impl Shape {
         /// A plausible healthy SHM topic: ~100 ns median with a tail an order
         /// of magnitude out, measured over enough samples for p99.9.
-        fn healthy(median: f64) -> Self {
+        pub(super) fn healthy(median: f64) -> Self {
             Self {
                 median,
                 p95: (median * 1.8) as u64,
@@ -1980,7 +2047,7 @@ mod tests {
         }
     }
 
-    fn make_result(name: &str, shape: &Shape) -> BenchmarkResult {
+    pub(super) fn make_result(name: &str, shape: &Shape) -> BenchmarkResult {
         BenchmarkResult {
             provenance: Provenance::Measured,
             name: name.to_string(),
@@ -2301,5 +2368,95 @@ mod tests {
         assert_eq!(format_throughput(500.0), "500.0 msg/s");
         assert_eq!(format_throughput(50_000.0), "50.00 K msg/s");
         assert_eq!(format_throughput(5_000_000.0), "5.00 M msg/s");
+    }
+}
+
+#[cfg(test)]
+mod throughput_metric_tests {
+    use super::tests::{make_result, Shape};
+    use super::*;
+
+    /// Throughput reaches the gate as its reciprocal, in the same unit as the
+    /// latency metrics and in the same (lower-is-better) direction.
+    #[test]
+    fn throughput_becomes_nanoseconds_per_message() {
+        let shape = Shape::healthy(400.0);
+        let result = make_result("topic_send", &shape);
+        let entry = BaselineEntry::from_result(&result);
+
+        // The fixture publishes 1e6 msg/s, i.e. 1000 ns per message.
+        assert!(
+            (entry.ns_per_msg - 1000.0).abs() < 1e-6,
+            "1e6 msg/s should be 1000 ns/msg, got {}",
+            entry.ns_per_msg
+        );
+        assert_eq!(
+            Metric::ThroughputNsPerMsg.value(&entry),
+            Some(entry.ns_per_msg)
+        );
+    }
+
+    /// A benchmark that did not measure throughput must be SKIPPED, not
+    /// compared against a fabricated zero. A zero would read as an infinitely
+    /// fast baseline and make every later run look like a regression.
+    #[test]
+    fn unmeasured_throughput_is_none_not_zero() {
+        let shape = Shape::healthy(400.0);
+        let mut result = make_result("topic_send", &shape);
+        result.throughput.messages_per_sec = 0.0;
+        let entry = BaselineEntry::from_result(&result);
+        assert_eq!(entry.ns_per_msg, 0.0);
+        assert_eq!(Metric::ThroughputNsPerMsg.value(&entry), None);
+
+        result.throughput.messages_per_sec = f64::NAN;
+        let entry = BaselineEntry::from_result(&result);
+        assert_eq!(Metric::ThroughputNsPerMsg.value(&entry), None);
+    }
+
+    /// The rolling baseline in the Actions cache predates this field. Older
+    /// entries must still deserialize, and must gate as "no baseline" rather
+    /// than as a regression, or the first build after this lands fails for
+    /// everyone on history it never recorded.
+    #[test]
+    fn baseline_entries_without_the_field_still_load() {
+        let legacy = r#"{
+            "name": "topic_send",
+            "message_size": 64,
+            "count": 100000,
+            "median": 400.0,
+            "p95": 500,
+            "p99": 600,
+            "p999": 900,
+            "p9999": 1500,
+            "max": 4000,
+            "max_jitter_ns": 3600,
+            "cv": 0.1
+        }"#;
+        let entry: BaselineEntry =
+            serde_json::from_str(legacy).expect("legacy baseline entry must still parse");
+        assert_eq!(entry.ns_per_msg, 0.0);
+        assert_eq!(
+            Metric::ThroughputNsPerMsg.value(&entry),
+            None,
+            "a legacy entry must be skipped by the throughput gate, not compared"
+        );
+        // The metrics that existed before must be unaffected.
+        assert_eq!(Metric::Median.value(&entry), Some(400.0));
+        assert_eq!(Metric::P99.value(&entry), Some(600.0));
+    }
+
+    /// Every metric the gate knows about must have a policy, or it is silently
+    /// tracked and never enforced — which is how `Max` and `MaxJitter` would
+    /// have looked if they had been missed.
+    #[test]
+    fn every_metric_has_a_policy() {
+        let policy = RegressionPolicy::default();
+        for m in Metric::ALL {
+            assert!(
+                policy.for_metric(m).is_some(),
+                "Metric::{:?} has no MetricPolicy, so it is tracked but never gated",
+                m
+            );
+        }
     }
 }

--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -412,7 +412,40 @@ impl TimingEnforcer {
         deadline: Duration,
         miss: Miss,
     ) -> Option<DeadlineMissResult> {
-        let elapsed = tick_start.elapsed();
+        Self::check_deadline_from_release(tick_start, Duration::ZERO, deadline, miss)
+    }
+
+    /// Deadline measured from the node's SCHEDULED RELEASE, not from the moment
+    /// its `tick()` happened to start.
+    ///
+    /// `check_deadline` measures `tick_start.elapsed()` — how long the node's
+    /// own code ran. So does `check_tick_budget`, against `tr.duration`. Two
+    /// knobs measuring the same quantity is the defect class this codebase
+    /// names elsewhere: "two named options that do the same thing means one of
+    /// them is a lie". The lie here is that `deadline` sounded like a deadline.
+    ///
+    /// What a control loop actually promises is that the command LEAVES by a
+    /// certain time after the period began. A node released 3.5 ms late that
+    /// then executes in 10 us has blown a 900 us deadline by 2.6 ms — the
+    /// actuator got its command three cycles late — while the old check saw
+    /// 10 us against 900 us and recorded a healthy tick. The deadline-miss
+    /// ladder, and every degradation and safe-state response hanging off it,
+    /// therefore never fired for the dominant real-world failure mode. It fired
+    /// only for the rarer one where the node's own code is slow, which
+    /// `budget` already covers.
+    ///
+    /// `release_late` is how late the tick was released relative to its
+    /// scheduled slot; the RT executor's cyclic waiter already computes it.
+    /// Passing `Duration::ZERO` reproduces the old execution-time-only
+    /// behaviour exactly, which is what the non-RT paths do — they have no
+    /// scheduled slot to be late against.
+    pub fn check_deadline_from_release(
+        tick_start: Instant,
+        release_late: Duration,
+        deadline: Duration,
+        miss: Miss,
+    ) -> Option<DeadlineMissResult> {
+        let elapsed = tick_start.elapsed() + release_late;
         if elapsed > deadline {
             let action = match miss {
                 Miss::Warn => DeadlineAction::Warn,
@@ -541,6 +574,83 @@ mod tests {
         assert!(dm.elapsed >= 50_u64.ms());
         assert_eq!(dm.deadline, 10_u64.ms());
         assert!(matches!(dm.action, DeadlineAction::EmergencyStop));
+    }
+
+    /// A tick released late misses its deadline even when its own code is fast.
+    ///
+    /// This is the case the old check could not see. On a 1 kHz loop with a
+    /// 900us deadline, a node woken 3.5ms late — the max lateness actually
+    /// measured on a stock kernel — and executing in microseconds has delivered
+    /// its command three cycles after it was due. Judged on execution time
+    /// alone it looked perfectly healthy, so the deadline-miss ladder, the
+    /// degradation ladder and the safe-state response all stayed silent.
+    #[test]
+    fn release_lateness_alone_misses_the_deadline() {
+        let tick_start = Instant::now(); // execution ~0
+        let result = TimingEnforcer::check_deadline_from_release(
+            tick_start,
+            3_500_u64.us(),
+            900_u64.us(),
+            Miss::SafeMode,
+        );
+        let dm = result.expect(
+            "a tick released 3.5ms late against a 900us deadline is a miss, \
+             however fast its own code ran",
+        );
+        assert!(dm.elapsed >= 3_500_u64.us());
+        assert_eq!(dm.deadline, 900_u64.us());
+        assert!(matches!(dm.action, DeadlineAction::SafeMode));
+
+        // And the old entry point, which cannot see the lateness, still says
+        // healthy — this is precisely the gap, pinned so it cannot come back.
+        assert!(
+            TimingEnforcer::check_deadline(tick_start, 900_u64.us(), Miss::SafeMode).is_none(),
+            "execution-time-only check should see nothing wrong; if this starts \
+             failing the two entry points have converged and one is redundant"
+        );
+    }
+
+    /// Zero lateness must reproduce the old behaviour exactly, since every
+    /// non-RT caller passes zero — they have no scheduled slot to be late against.
+    #[test]
+    fn zero_release_lateness_matches_the_execution_only_check() {
+        for (start_ago_ms, deadline_ms) in [(0_u64, 100_u64), (50, 10), (9, 10), (11, 10)] {
+            let tick_start = Instant::now() - start_ago_ms.ms();
+            let a = TimingEnforcer::check_deadline_from_release(
+                tick_start,
+                Duration::ZERO,
+                deadline_ms.ms(),
+                Miss::Warn,
+            );
+            let b = TimingEnforcer::check_deadline(tick_start, deadline_ms.ms(), Miss::Warn);
+            assert_eq!(
+                a.is_some(),
+                b.is_some(),
+                "zero lateness diverged from the old check at \
+                 {start_ago_ms}ms/{deadline_ms}ms"
+            );
+        }
+    }
+
+    /// Execution time and release lateness add: neither alone would miss here,
+    /// together they do. A budget check on execution alone cannot express this.
+    #[test]
+    fn release_lateness_and_execution_time_combine() {
+        let tick_start = Instant::now() - 600_u64.us();
+        let result = TimingEnforcer::check_deadline_from_release(
+            tick_start,
+            600_u64.us(),
+            900_u64.us(),
+            Miss::Warn,
+        );
+        assert!(
+            result.is_some(),
+            "600us late plus 600us of execution exceeds a 900us deadline"
+        );
+        assert!(
+            TimingEnforcer::check_deadline(tick_start, 900_u64.us(), Miss::Warn).is_none(),
+            "600us of execution alone is inside a 900us deadline"
+        );
     }
 
     #[test]

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -727,7 +727,14 @@ impl CyclicWaiter {
 
     /// Wait out the remainder of the current period and return at the next
     /// slot boundary.
-    fn wait(&mut self) {
+    /// Wait for the next slot; returns how late the wake was, in nanoseconds.
+    ///
+    /// The return value is the same `late_ns` this function already accumulated
+    /// into `wake_late_max_ns`. It was computed and thrown away, so nothing
+    /// downstream could act on it — in particular the deadline check, which
+    /// measured only how long a node's own code ran and so never saw the
+    /// lateness that dominates on a real machine.
+    fn wait(&mut self) -> u64 {
         let now = cyclic_now_ns();
         self.local.slots += 1;
 
@@ -800,6 +807,8 @@ impl CyclicWaiter {
             self.flush();
             self.last_flush_ns = t;
         }
+
+        late_ns
     }
 
     /// Publish the local counters to the process-wide totals and reset them.
@@ -1151,6 +1160,7 @@ impl RtExecutor {
         monitors: &SharedMonitors,
         running: &Arc<AtomicBool>,
         is_first_tick: bool,
+        release_late_ns: u64,
     ) {
         // Failure-policy backoff (Restart) / cooldown (Skip): skip this tick
         // while the node is suppressed.
@@ -1323,7 +1333,17 @@ impl RtExecutor {
 
         // Deadline check via TimingEnforcer
         if let Some(deadline) = node.deadline {
-            let miss = TimingEnforcer::check_deadline(tr.tick_start, deadline, node.miss_policy);
+            // Measured from the scheduled RELEASE, not from when tick() started.
+            // A node woken 3.5 ms late that executes in 10 us has missed a
+            // 900 us deadline by 2.6 ms; the old check compared 10 us against
+            // 900 us and called it healthy, so the whole degradation ladder was
+            // blind to the failure mode that actually dominates.
+            let miss = TimingEnforcer::check_deadline_from_release(
+                tr.tick_start,
+                Duration::from_nanos(release_late_ns),
+                deadline,
+                node.miss_policy,
+            );
             if miss.is_none() && node.in_safe_mode {
                 // Met the deadline again: clear the latch so a node that
                 // recovers can be safed once more if it degrades later.
@@ -1723,6 +1743,12 @@ impl RtExecutor {
         // affinity/governor/IRQ work that only happens once.
         let mut waiter = CyclicWaiter::new(tick_period, rt_policy_active, monitors.verbose);
 
+        // Lateness of the slot THIS iteration is serving. `waiter.wait()` at the
+        // bottom of the loop returns the lateness of the wake that releases the
+        // next iteration, so carrying it across the loop boundary is what makes
+        // it describe the right tick. Zero for the first iteration, which is
+        // released by the loop being entered rather than by a wait.
+        let mut release_late_ns: u64 = 0;
         while running.load(Ordering::Relaxed) {
             let loop_start = Instant::now();
 
@@ -1785,7 +1811,7 @@ impl RtExecutor {
                 // continues ticking remaining nodes.
                 let is_first_tick = !warmed[idx];
                 let infra_result = catch_unwind(AssertUnwindSafe(|| {
-                    Self::tick_node(node, &monitors, &running, is_first_tick)
+                    Self::tick_node(node, &monitors, &running, is_first_tick, release_late_ns)
                 }));
                 warmed[idx] = true;
 
@@ -1816,7 +1842,7 @@ impl RtExecutor {
             // ~50 ms dequeue, on top of unbounded phase drift. See the
             // `CyclicWaiter` section at the top of this file for the full
             // reasoning and for the median-jitter cost this trade accepts.
-            waiter.wait();
+            release_late_ns = waiter.wait();
         }
 
         waiter.finish(monitors.verbose);
@@ -2063,7 +2089,13 @@ mod tests {
         node.health_state.store(NodeHealthState::Unhealthy);
 
         let monitors = test_monitors();
-        RtExecutor::tick_node(&mut node, &monitors, &Arc::new(AtomicBool::new(true)), true);
+        RtExecutor::tick_node(
+            &mut node,
+            &monitors,
+            &Arc::new(AtomicBool::new(true)),
+            true,
+            0,
+        );
 
         assert_eq!(
             count.load(AOrd::Relaxed),

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -1543,6 +1543,52 @@ impl Scheduler {
         }
     }
 
+    /// Topic edges between two RT nodes, which the executor does not order.
+    ///
+    /// Returns `(producer, consumer)` name pairs rather than printing, so the
+    /// detection can be tested without standing up executors or capturing
+    /// stdout. The caller does the reporting.
+    fn unordered_rt_edges(
+        nodes: &[super::types::RegisteredNode],
+        graph: Option<&super::dependency_graph::DependencyGraph>,
+    ) -> Vec<(String, String)> {
+        let mut found = Vec::new();
+        use super::types::ExecutionClass;
+
+        let Some(graph) = graph else { return found };
+        if !graph.has_topic_metadata() {
+            // No edges were derived, so there is nothing to say. Staying quiet
+            // is right here: a false "your nodes are unordered" on a graph that
+            // simply has no metadata would train people to ignore the warning.
+            return found;
+        }
+        let successors = graph.successors();
+        if successors.len() != nodes.len() {
+            // Indices would not line up with names; say nothing rather than
+            // name the wrong pair of nodes.
+            return found;
+        }
+
+        let is_rt = |i: usize| matches!(nodes[i].execution_class, ExecutionClass::Rt);
+
+        for (producer, downstream) in successors.iter().enumerate() {
+            if !is_rt(producer) {
+                continue;
+            }
+            for &consumer in downstream {
+                if consumer >= nodes.len() || !is_rt(consumer) {
+                    continue;
+                }
+                found.push((
+                    nodes[producer].name.to_string(),
+                    nodes[consumer].name.to_string(),
+                ));
+            }
+        }
+
+        found
+    }
+
     /// Apply OS-level RT optimizations (memory locking, scheduling, affinity, NUMA).
     fn apply_rt_optimizations(
         &mut self,
@@ -1776,7 +1822,74 @@ impl Scheduler {
     /// ```ignore
     /// scheduler.set_os_priority(99)?;  // Highest priority
     /// ```
-    #[doc(hidden)]
+    /// Apply RT hygiene to the CALLING thread, in the order that works.
+    ///
+    /// `run()` does all of this for the threads it spawns. A scheduler driven
+    /// externally through [`tick_once()`](Self::tick_once) ticks on the
+    /// caller's thread instead, and that thread gets none of it — so a fieldbus
+    /// integration (`ec_receive_processdata()` -> `tick_once()` ->
+    /// `ec_send_processdata()`) runs the control loop on an ordinary
+    /// `SCHED_OTHER` thread with pageable memory unless it asks.
+    ///
+    /// Order is not arbitrary and is the reason this exists as one call:
+    ///
+    /// 1. `mlockall` FIRST, so every later allocation is locked as it is made.
+    ///    Locking after the stack has grown leaves the already-faulted pages
+    ///    fine but does nothing for what the thread has yet to touch.
+    /// 2. Pre-fault the stack, so the first deep call in the loop does not take
+    ///    a page fault at cycle time. With memory already locked, the faulted
+    ///    pages stay resident.
+    /// 3. Raise scheduling priority, so the thread is only made
+    ///    latency-critical once its memory is in order.
+    /// 4. Pin last — affinity is independent of the rest, and doing it after
+    ///    the policy change keeps the placement decision on the final policy.
+    ///
+    /// Returns the degradations that occurred rather than failing: a caller
+    /// that must not run degraded should inspect the result and refuse, the
+    /// same choice [`require_rt()`](Self::require_rt) makes for `run()`. An
+    /// empty vector means everything requested was applied.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let degraded = sched.prepare_current_thread_rt(80, Some(2), 8 << 20);
+    /// if !degraded.is_empty() {
+    ///     // Do not arm the robot on a thread that did not get what it asked for.
+    ///     return Err(format!("RT setup incomplete: {degraded:?}").into());
+    /// }
+    /// loop {
+    ///     bus.receive()?;
+    ///     sched.tick_once()?;
+    ///     bus.send()?;
+    /// }
+    /// ```
+    pub fn prepare_current_thread_rt(
+        &self,
+        priority: i32,
+        cpu: Option<usize>,
+        prefault_bytes: usize,
+    ) -> Vec<String> {
+        let mut degradations = Vec::new();
+
+        if let Err(e) = self.lock_memory() {
+            degradations.push(format!("memory locking: {e}"));
+        }
+        if prefault_bytes > 0 {
+            if let Err(e) = self.prefault_stack(prefault_bytes) {
+                degradations.push(format!("stack prefault: {e}"));
+            }
+        }
+        if let Err(e) = self.set_os_priority(priority) {
+            degradations.push(format!("rt priority: {e}"));
+        }
+        if let Some(cpu_id) = cpu {
+            if let Err(e) = self.pin_to_cpu(cpu_id) {
+                degradations.push(format!("cpu affinity: {e}"));
+            }
+        }
+
+        degradations
+    }
+
     pub fn set_os_priority(&self, priority: i32) -> crate::error::HorusResult<()> {
         if !(1..=99).contains(&priority) {
             return Err(crate::error::HorusError::config(
@@ -1799,7 +1912,6 @@ impl Scheduler {
     /// ```ignore
     /// scheduler.pin_to_cpu(7)?;
     /// ```
-    #[doc(hidden)]
     pub fn pin_to_cpu(&self, cpu_id: usize) -> crate::error::HorusResult<()> {
         super::rt::set_thread_affinity(&[cpu_id])?;
         print_line(&format!("[OK] Scheduler pinned to CPU core {}", cpu_id));
@@ -1814,7 +1926,6 @@ impl Scheduler {
     /// ```ignore
     /// scheduler.lock_memory()?;
     /// ```
-    #[doc(hidden)]
     pub fn lock_memory(&self) -> crate::error::HorusResult<()> {
         super::rt::lock_all_memory()?;
         print_line("[OK] Memory locked (no page faults)");
@@ -1829,7 +1940,6 @@ impl Scheduler {
     /// ```ignore
     /// scheduler.prefault_stack(8 * 1024 * 1024)?;  // 8MB stack
     /// ```
-    #[doc(hidden)]
     pub fn prefault_stack(&self, stack_size: usize) -> crate::error::HorusResult<()> {
         super::rt::prefault_stack(stack_size)?;
         print_line(&format!(
@@ -2759,6 +2869,42 @@ impl Scheduler {
                 // - AsyncIo nodes → AsyncExecutor (tokio blocking pool)
                 // - BestEffort nodes → stay in self.nodes for main-thread sequential execution
                 let all_nodes = std::mem::take(&mut self.nodes);
+
+                // Warn on RT->RT topic edges before the partition consumes the
+                // list, while node names and graph indices still line up.
+                //
+                // Every RT node becomes its own single-node chain below, and the
+                // executor gives NO ordering guarantee between chains (see the
+                // comment at the `rt_chains` construction). So an RT consumer
+                // downstream of an RT producer reads the producer's PREVIOUS
+                // tick, at a phase offset fixed when the threads happened to
+                // start. That is invisible: the graph edge exists, the data
+                // flows, every value looks plausible, and it is simply one
+                // cycle stale at an offset nobody chose.
+                //
+                // On a legged robot this is the estimator->controller edge, and
+                // one stale cycle of state estimate at 1 kHz is a real torque
+                // error. Silence is the wrong default for a hazard whose only
+                // symptom is slightly-wrong numbers, so name it: which two
+                // nodes, and what to do about it.
+                for (producer, consumer) in
+                    Self::unordered_rt_edges(&all_nodes, self.dependency_graph.as_ref())
+                {
+                    print_line(&format!(
+                        "[SCHEDULER] '{producer}' -> '{consumer}': both are real-time \
+                         nodes, and the RT executor does not order RT nodes against \
+                         each other. '{consumer}' will read the value '{producer}' \
+                         published on its PREVIOUS tick, at a phase offset fixed at \
+                         thread start."
+                    ));
+                    print_line(
+                        "  To sequence them: put both in one node, or drive the chain \
+                         yourself with tick_once(). To keep them independent, treat \
+                         the input as one cycle old — which for a state estimate \
+                         feeding a controller is a real torque error.",
+                    );
+                }
+
                 let groups = super::types::group_nodes_by_class(all_nodes);
 
                 // BestEffort nodes remain on the main thread
@@ -4539,12 +4685,34 @@ impl Scheduler {
         }
 
         // Rate limiting (skip in deterministic mode — SimClock controls timing)
+        //
+        // The comparison carries a half-driving-period tolerance for the same
+        // reason rt_executor.rs does (see "halving the effective rate of every
+        // RT node" there). `last_tick` is stamped inside the tick, after this
+        // gate, so an on-time cycle measures a hair under one period and a
+        // strict `<` refuses it — the node then fires every *other* cycle.
+        //
+        // This path is the one `tick_once()` uses, which is how a fieldbus
+        // drives HORUS: ec_receive_processdata() -> tick_once() ->
+        // ec_send_processdata(). There the effect is worse than on the internal
+        // loop, because the cycle arrives on the BUS's crystal rather than this
+        // host's CLOCK_MONOTONIC, so "a hair early" is the normal case rather
+        // than a boundary condition. Measured before this tolerance: a
+        // .rate(1000hz) node saw 240 of 400 cycles from a 1 kHz drive.
+        //
+        // The tolerance is half the DRIVING period (the scheduler's configured
+        // tick rate), not half the node's own period. That bound is what keeps
+        // a slower node honest: a 100 Hz node driven at 1 kHz can be admitted at
+        // most 500 us early, never a full period early, so it cannot be
+        // accelerated toward the drive rate.
         if !self.pending_config.timing.deterministic_order {
             if let Some(rate_hz) = registered.rate_hz {
                 if let Some(last_tick) = registered.last_tick {
                     let elapsed_secs = (Instant::now() - last_tick).as_secs_f64();
                     let period_secs = if rate_hz > 0.0 { 1.0 / rate_hz } else { 0.0 };
-                    if elapsed_secs < period_secs {
+                    let drive_hz = self.pending_config.timing.global_rate_hz;
+                    let tolerance_secs = if drive_hz > 0.0 { 0.5 / drive_hz } else { 0.0 };
+                    if elapsed_secs < period_secs - tolerance_secs {
                         return false;
                     }
                 }

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -5860,3 +5860,123 @@ fn a_zero_copy_publisher_is_attributed_under_a_real_scheduler() {
          (none)\""
     );
 }
+
+// ---------------------------------------------------------------------------
+// RT nodes joined by a topic edge are not ordered against each other
+// ---------------------------------------------------------------------------
+
+/// Two RT nodes connected by a topic must be reported, because the executor
+/// gives them no ordering.
+///
+/// Every RT node becomes its own single-node chain, and the RT executor does not
+/// sequence chains against each other (the `rt_chains` construction says so in
+/// as many words). So an RT consumer downstream of an RT producer reads the
+/// producer's PREVIOUS tick at a phase offset fixed when the threads started.
+/// Nothing about that is visible at runtime: the edge exists, data flows, and
+/// every value looks plausible while being one cycle stale.
+///
+/// On a legged robot that edge is estimator -> controller, and one stale cycle
+/// of state estimate at 1 kHz is a real torque error. It has to be said out loud
+/// at build time.
+#[test]
+fn rt_nodes_joined_by_a_topic_are_reported_as_unordered() {
+    let _guard = lock_scheduler();
+
+    struct Producer {
+        out: crate::communication::topic::Topic<u64>,
+    }
+    impl Node for Producer {
+        fn name(&self) -> &'static str {
+            "rt_producer"
+        }
+        fn tick(&mut self) {
+            let _ = self.out.send(1u64);
+        }
+    }
+    struct Consumer {
+        inp: crate::communication::topic::Topic<u64>,
+    }
+    impl Node for Consumer {
+        fn name(&self) -> &'static str {
+            "rt_consumer"
+        }
+        fn tick(&mut self) {
+            let _ = self.inp.recv();
+        }
+    }
+
+    let topic = format!("rt_edge_probe_{}", std::process::id());
+    let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
+    let _ = scheduler
+        .add(Producer {
+            out: crate::communication::topic::Topic::new(&topic).expect("pub topic"),
+        })
+        .rate(1000_u64.hz())
+        .build();
+    let _ = scheduler
+        .add(Consumer {
+            inp: crate::communication::topic::Topic::new(&topic).expect("sub topic"),
+        })
+        .rate(1000_u64.hz())
+        .build();
+
+    // Roles are normally learned from real send/recv during ticks. Declare them
+    // directly so the graph has edges without running the scheduler.
+    let tnr = crate::communication::topic_node_registry();
+    tnr.register_with_type(
+        &topic,
+        "rt_producer",
+        crate::communication::topic::NodeTopicRole::Publisher,
+        "u64",
+    );
+    tnr.register_with_type(
+        &topic,
+        "rt_consumer",
+        crate::communication::topic::NodeTopicRole::Subscriber,
+        "u64",
+    );
+
+    scheduler.build_dependency_graph();
+
+    let edges =
+        Scheduler::unordered_rt_edges(&scheduler.nodes, scheduler.dependency_graph.as_ref());
+
+    assert!(
+        edges
+            .iter()
+            .any(|(p, c)| p == "rt_producer" && c == "rt_consumer"),
+        "an RT->RT topic edge was not reported; found {:?}. Two RT nodes sharing \
+         a topic get no ordering from the executor and the consumer silently \
+         reads a one-cycle-old value.",
+        edges
+    );
+}
+
+/// A node with no RT peer must produce no report.
+///
+/// The warning is only useful if it is quiet when there is nothing to say; a
+/// warning that fires on every graph trains people to ignore it.
+#[test]
+fn a_lone_rt_node_reports_nothing() {
+    let _guard = lock_scheduler();
+
+    struct Solo;
+    impl Node for Solo {
+        fn name(&self) -> &'static str {
+            "rt_solo"
+        }
+        fn tick(&mut self) {}
+    }
+
+    let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
+    let _ = scheduler.add(Solo).rate(1000_u64.hz()).build();
+    scheduler.build_dependency_graph();
+
+    let edges =
+        Scheduler::unordered_rt_edges(&scheduler.nodes, scheduler.dependency_graph.as_ref());
+    assert!(
+        edges.is_empty(),
+        "a single RT node with no peers reported {:?}",
+        edges
+    );
+}

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -5890,7 +5890,7 @@ fn rt_nodes_joined_by_a_topic_are_reported_as_unordered() {
             "rt_producer"
         }
         fn tick(&mut self) {
-            let _ = self.out.send(1u64);
+            self.out.send(1u64);
         }
     }
     struct Consumer {

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -5922,6 +5922,25 @@ fn rt_nodes_joined_by_a_topic_are_reported_as_unordered() {
 
     // Roles are normally learned from real send/recv during ticks. Declare them
     // directly so the graph has edges without running the scheduler.
+    //
+    // `topic_node_registry()` is a process-wide singleton, so these two entries
+    // outlive the test unless something takes them out again — and a panicking
+    // assertion below must not be what leaves them behind, since the harness
+    // keeps running the other tests in this binary afterwards. Hence a guard
+    // that unregisters on drop rather than two calls at the end.
+    struct RegistryEntries {
+        topic: String,
+        nodes: [&'static str; 2],
+    }
+    impl Drop for RegistryEntries {
+        fn drop(&mut self) {
+            let tnr = crate::communication::topic_node_registry();
+            for node in self.nodes {
+                tnr.unregister(&self.topic, node);
+            }
+        }
+    }
+
     let tnr = crate::communication::topic_node_registry();
     tnr.register_with_type(
         &topic,
@@ -5935,6 +5954,10 @@ fn rt_nodes_joined_by_a_topic_are_reported_as_unordered() {
         crate::communication::topic::NodeTopicRole::Subscriber,
         "u64",
     );
+    let _registry_entries = RegistryEntries {
+        topic: topic.clone(),
+        nodes: ["rt_producer", "rt_consumer"],
+    };
 
     scheduler.build_dependency_graph();
 

--- a/horus_core/tests/externally_driven_tick.rs
+++ b/horus_core/tests/externally_driven_tick.rs
@@ -121,15 +121,49 @@ fn rate_node_ticks_once_per_external_cycle() {
 
 /// The tolerance must not let a SLOWER node run early.
 ///
-/// A 100 Hz node driven by a 1 kHz cycle must still see ~100 ticks/second, not
-/// 1000. Widening the gate is only safe if it is bounded by the driving period.
+/// A 100 Hz node driven by a 1 kHz cycle must still tick ~10ms apart, not on
+/// every bus cycle. Widening the gate is only safe if it is bounded by the
+/// driving period.
+///
+/// The property is the SPACING of the node's ticks, not how many it got. A
+/// count is a function of how much of the run the host let us have — the same
+/// trap the first test fell into — and it is also blunt: a tolerance scaled to
+/// the NODE's half-period would admit at 5ms and produce exactly 80 ticks in
+/// the nominal 0.4s, which the old `observed <= 80` bound waved through. Host
+/// load can only ever push ticks further apart, never closer, so a floor on
+/// the smallest observed gap tests the gate and nothing else.
 #[test]
 fn slower_node_is_not_accelerated_by_the_tolerance() {
+    /// Records the gap between its own consecutive ticks.
+    struct SpacingNode {
+        ticks: Arc<AtomicU64>,
+        min_gap_ns: Arc<AtomicU64>,
+        last: Option<Instant>,
+    }
+
+    impl Node for SpacingNode {
+        fn name(&self) -> &'static str {
+            "spacing_node"
+        }
+        fn tick(&mut self) {
+            let now = Instant::now();
+            if let Some(prev) = self.last {
+                let gap = now.duration_since(prev).as_nanos() as u64;
+                self.min_gap_ns.fetch_min(gap, Ordering::Relaxed);
+            }
+            self.last = Some(now);
+            self.ticks.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     let ticks = Arc::new(AtomicU64::new(0));
+    let min_gap_ns = Arc::new(AtomicU64::new(u64::MAX));
     let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
     let _ = scheduler
-        .add(CycleNode {
+        .add(SpacingNode {
             ticks: ticks.clone(),
+            min_gap_ns: min_gap_ns.clone(),
+            last: None,
         })
         .rate(100_u64.hz())
         .build();
@@ -137,34 +171,67 @@ fn slower_node_is_not_accelerated_by_the_tolerance() {
     const CYCLES: u64 = 400;
     const PERIOD: Duration = Duration::from_micros(1000);
 
+    // Same delivery model as the first test, for the same reason: a bus master
+    // that falls behind drops the missed slots and carries on from the present.
+    // Replaying the backlog instead (`target = start + n*PERIOD` for every n)
+    // fires bunched calls after a preemption, which makes the tick count a
+    // measure of host scheduling rather than of the gate.
+    let mut delivered: u64 = 0;
     let start = Instant::now();
-    for c in 0..CYCLES {
-        let target = start + PERIOD * (c as u32);
+    let mut target = start;
+    for _ in 0..CYCLES {
+        let now = Instant::now();
+        if now > target + PERIOD {
+            let behind = now.duration_since(target).as_nanos() as u64;
+            let skip = behind / PERIOD.as_nanos() as u64 + 1;
+            target += PERIOD * (skip as u32);
+            continue;
+        }
         while Instant::now() < target {
             std::hint::spin_loop();
         }
         scheduler.tick_once().expect("tick_once");
+        delivered += 1;
+        target += PERIOD;
     }
 
     let observed = ticks.load(Ordering::Relaxed);
+    let min_gap = Duration::from_nanos(min_gap_ns.load(Ordering::Relaxed));
     eprintln!(
-        "{} bus cycles at 1kHz -> {} ticks of a 100Hz node",
-        CYCLES, observed
+        "{} on-time bus cycles delivered (of {} attempted) -> {} ticks of a \
+         100Hz node, closest pair {:?} apart",
+        delivered, CYCLES, observed, min_gap
     );
 
-    // 400 cycles at 1 kHz is 0.4 s, so a 100 Hz node owes ~40 ticks. Allow a
-    // wide band for host jitter, but nothing near the 400 that a tolerance
-    // scaled to the NODE's period instead of the DRIVING period would produce.
     assert!(
-        observed <= 80,
-        "a 100 Hz node ticked {} times in 400 cycles of a 1 kHz drive: the \
-         tolerance is scaled wrongly and is letting slow nodes run early",
-        observed
+        delivered >= 50,
+        "host delivered only {delivered} on-time cycles of {CYCLES}; too few to \
+         conclude anything about the rate gate"
     );
+
+    // Not starved: with regular delivery a 100 Hz node ticks on one delivered
+    // cycle in ten, and sparser delivery only raises that ratio. One in twenty
+    // is the floor.
     assert!(
-        observed >= 20,
-        "a 100 Hz node ticked only {} times in 0.4 s; it is being starved",
-        observed
+        observed * 20 >= delivered,
+        "a 100 Hz node ticked only {} times in {} delivered cycles of a 1 kHz \
+         drive; it is being starved",
+        observed,
+        delivered
+    );
+
+    // Not accelerated: the gate admits this node at period - half the DRIVING
+    // period = 10ms - 0.5ms, so no two ticks may be closer than 9.5ms. The 9ms
+    // floor is that minus slop, since the stamp above is taken inside tick(),
+    // a little after the gate that admitted it. A tolerance scaled to the
+    // node's own period would admit at 5ms and land here.
+    assert!(
+        min_gap >= Duration::from_micros(9_000),
+        "two ticks of a 100 Hz node were only {:?} apart under a 1 kHz drive \
+         (>= 9.5ms expected, allowing 9ms): the tolerance is scaled to the \
+         node's period instead of the driving period and is letting slow nodes \
+         run early",
+        min_gap
     );
 }
 

--- a/horus_core/tests/externally_driven_tick.rs
+++ b/horus_core/tests/externally_driven_tick.rs
@@ -56,34 +56,65 @@ fn rate_node_ticks_once_per_external_cycle() {
     const CYCLES: u64 = 400;
     const PERIOD: Duration = Duration::from_micros(1000);
 
-    // A bus cycle arrives on the bus's clock, not ours. Emulate that faithfully:
-    // sleep to an absolute grid so the cadence does not accumulate our own
-    // overhead, which is exactly how a real master hands off cycles.
+    // A bus cycle arrives on the BUS's clock, not ours, and a bus master that
+    // falls behind does not then deliver a burst of backlogged cycles — it
+    // drops them and carries on from the present. Model that, because the naive
+    // version (spin to `start + n*PERIOD` for every n) does the opposite: when
+    // this thread is preempted it returns to find several targets already past
+    // and fires them back to back with no spacing at all. Those bunched cycles
+    // are correctly refused by the rate gate, and the test then measures host
+    // load rather than the gate. Under load average ~43 it read 66/400 on code
+    // that reads 399/400 on an idle box — a flaky gate, and a flaky gate in a
+    // required check is worse than no gate.
+    //
+    // So: skip missed slots, and count only the cycles actually delivered near
+    // their slot. `delivered` is the denominator the assertion uses, which makes
+    // the ratio independent of how much of the run the host stole.
+    let mut delivered: u64 = 0;
     let start = Instant::now();
-    for c in 0..CYCLES {
-        let target = start + PERIOD * (c as u32);
+    let mut target = start;
+    for _ in 0..CYCLES {
+        let now = Instant::now();
+        if now > target + PERIOD {
+            // Fell behind by at least a whole cycle: realign to the present
+            // instead of replaying the backlog, exactly as a bus master would.
+            let behind = now.duration_since(target).as_nanos() as u64;
+            let skip = behind / PERIOD.as_nanos() as u64 + 1;
+            target += PERIOD * (skip as u32);
+            continue;
+        }
         while Instant::now() < target {
             std::hint::spin_loop();
         }
         scheduler.tick_once().expect("tick_once");
+        delivered += 1;
+        target += PERIOD;
     }
 
     let observed = ticks.load(Ordering::Relaxed);
-    eprintln!("{} bus cycles -> {} node ticks", CYCLES, observed);
+    eprintln!(
+        "{} on-time bus cycles delivered (of {} attempted) -> {} node ticks",
+        delivered, CYCLES, observed
+    );
 
-    // The failure this pins is a HALVING (or worse): the strict gate rejects the
-    // boundary cycle every time, so the node sees ~50%. Requiring 90% leaves room
-    // for the first cycle and for genuine host stalls while still failing hard on
-    // a systematic every-other-cycle refusal.
-    let floor = (CYCLES as f64 * 0.90) as u64;
+    assert!(
+        delivered >= 50,
+        "host delivered only {delivered} on-time cycles of {CYCLES}; too few to \
+         conclude anything about the rate gate"
+    );
+
+    // The failure this pins is a systematic refusal of the boundary cycle: the
+    // node sees ~50-60% of cycles, or worse. 90% of DELIVERED cycles leaves room
+    // for the first cycle and for a stall inside an otherwise on-time run.
+    let floor = (delivered as f64 * 0.90) as u64;
     assert!(
         observed >= floor,
         "a .rate(1000hz) node driven by a 1 kHz external cycle ticked only {} \
-         times in {} cycles (needed >= {}). The rate gate is refusing cycles \
-         that arrive a hair early; the RT executor solved this with a \
+         times in {} on-time cycles (needed >= {}). The rate gate is refusing \
+         cycles that arrive a hair early; the RT executor solved this with a \
          half-period tolerance and the externally-driven path needs the same.",
         observed,
-        CYCLES,
+        delivered,
         floor
     );
 }

--- a/horus_core/tests/externally_driven_tick.rs
+++ b/horus_core/tests/externally_driven_tick.rs
@@ -1,0 +1,184 @@
+//! `tick_once()` is HORUS's externally-driven step API — the integration point
+//! for a fieldbus.
+//!
+//! A quadruped or humanoid on EtherCAT/CAN does, once per bus cycle:
+//!
+//! ```text
+//!     ec_receive_processdata()  ->  sched.tick_once()  ->  ec_send_processdata()
+//! ```
+//!
+//! The bus owns the clock. `tick_once()` documents exactly this contract: "Does
+//! **not** loop. Does **not** sleep. The caller controls timing."
+//!
+//! For that to work, a node declared `.rate(1000hz)` must actually tick on every
+//! 1 kHz bus cycle. It did not: the rate gate compared `elapsed < period` with a
+//! strict `<` and no tolerance, so a cycle arriving a hair early — which is the
+//! normal case, since a bus crystal is not the host's CLOCK_MONOTONIC and the
+//! caller's own work sits inside the measured interval — was refused, and the
+//! node fired every *other* cycle at half its declared rate.
+//!
+//! The RT executor already hit this and fixed it (rt_executor.rs, "halving the
+//! effective rate of every RT node"). The externally-driven path never got the
+//! same treatment.
+
+use horus_core::core::{DurationExt, Node};
+use horus_core::scheduling::Scheduler;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+struct CycleNode {
+    ticks: Arc<AtomicU64>,
+}
+
+impl Node for CycleNode {
+    fn name(&self) -> &'static str {
+        "bus_driven_node"
+    }
+    fn tick(&mut self) {
+        self.ticks.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Drive the scheduler from a simulated 1 kHz bus and require that a
+/// `.rate(1000hz)` node ticks on (nearly) every cycle.
+#[test]
+fn rate_node_ticks_once_per_external_cycle() {
+    let ticks = Arc::new(AtomicU64::new(0));
+    let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
+    let _ = scheduler
+        .add(CycleNode {
+            ticks: ticks.clone(),
+        })
+        .rate(1000_u64.hz())
+        .build();
+
+    const CYCLES: u64 = 400;
+    const PERIOD: Duration = Duration::from_micros(1000);
+
+    // A bus cycle arrives on the bus's clock, not ours. Emulate that faithfully:
+    // sleep to an absolute grid so the cadence does not accumulate our own
+    // overhead, which is exactly how a real master hands off cycles.
+    let start = Instant::now();
+    for c in 0..CYCLES {
+        let target = start + PERIOD * (c as u32);
+        while Instant::now() < target {
+            std::hint::spin_loop();
+        }
+        scheduler.tick_once().expect("tick_once");
+    }
+
+    let observed = ticks.load(Ordering::Relaxed);
+    eprintln!("{} bus cycles -> {} node ticks", CYCLES, observed);
+
+    // The failure this pins is a HALVING (or worse): the strict gate rejects the
+    // boundary cycle every time, so the node sees ~50%. Requiring 90% leaves room
+    // for the first cycle and for genuine host stalls while still failing hard on
+    // a systematic every-other-cycle refusal.
+    let floor = (CYCLES as f64 * 0.90) as u64;
+    assert!(
+        observed >= floor,
+        "a .rate(1000hz) node driven by a 1 kHz external cycle ticked only {} \
+         times in {} cycles (needed >= {}). The rate gate is refusing cycles \
+         that arrive a hair early; the RT executor solved this with a \
+         half-period tolerance and the externally-driven path needs the same.",
+        observed,
+        CYCLES,
+        floor
+    );
+}
+
+/// The tolerance must not let a SLOWER node run early.
+///
+/// A 100 Hz node driven by a 1 kHz cycle must still see ~100 ticks/second, not
+/// 1000. Widening the gate is only safe if it is bounded by the driving period.
+#[test]
+fn slower_node_is_not_accelerated_by_the_tolerance() {
+    let ticks = Arc::new(AtomicU64::new(0));
+    let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
+    let _ = scheduler
+        .add(CycleNode {
+            ticks: ticks.clone(),
+        })
+        .rate(100_u64.hz())
+        .build();
+
+    const CYCLES: u64 = 400;
+    const PERIOD: Duration = Duration::from_micros(1000);
+
+    let start = Instant::now();
+    for c in 0..CYCLES {
+        let target = start + PERIOD * (c as u32);
+        while Instant::now() < target {
+            std::hint::spin_loop();
+        }
+        scheduler.tick_once().expect("tick_once");
+    }
+
+    let observed = ticks.load(Ordering::Relaxed);
+    eprintln!(
+        "{} bus cycles at 1kHz -> {} ticks of a 100Hz node",
+        CYCLES, observed
+    );
+
+    // 400 cycles at 1 kHz is 0.4 s, so a 100 Hz node owes ~40 ticks. Allow a
+    // wide band for host jitter, but nothing near the 400 that a tolerance
+    // scaled to the NODE's period instead of the DRIVING period would produce.
+    assert!(
+        observed <= 80,
+        "a 100 Hz node ticked {} times in 400 cycles of a 1 kHz drive: the \
+         tolerance is scaled wrongly and is letting slow nodes run early",
+        observed
+    );
+    assert!(
+        observed >= 20,
+        "a 100 Hz node ticked only {} times in 0.4 s; it is being starved",
+        observed
+    );
+}
+
+/// The RT hygiene a bus-driven loop needs must be reachable and must report
+/// honestly when it does not get what it asked for.
+///
+/// `run()` applies all of this to the threads it spawns. `tick_once()` ticks on
+/// the caller's thread, which gets none of it — so the externally-driven path
+/// needs a way to ask, and a way to find out it was refused. This runs
+/// unprivileged in CI, where SCHED_FIFO and mlockall are both denied, so it
+/// pins the REPORTING contract: refusal is visible, not silent.
+#[test]
+fn bus_driven_thread_can_request_rt_and_learn_what_it_got() {
+    let ticks = Arc::new(AtomicU64::new(0));
+    let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
+    let _ = scheduler
+        .add(CycleNode {
+            ticks: ticks.clone(),
+        })
+        .rate(1000_u64.hz())
+        .build();
+
+    let degradations = scheduler.prepare_current_thread_rt(80, None, 1 << 20);
+    eprintln!("rt setup degradations: {:?}", degradations);
+
+    // Whatever the environment granted, the scheduler must still tick. A
+    // failed RT setup is a degradation to report, not a reason to stop.
+    for _ in 0..10 {
+        scheduler
+            .tick_once()
+            .expect("tick_once after rt setup attempt");
+    }
+    assert!(
+        ticks.load(Ordering::Relaxed) > 0,
+        "scheduler stopped ticking after an RT setup attempt"
+    );
+
+    // Every degradation must name the thing that failed, so an integrator can
+    // decide whether to arm. An empty string, or a bare "error", is useless at
+    // the point where the decision gets made.
+    for d in &degradations {
+        assert!(
+            d.contains(':') && d.len() > 8,
+            "degradation {:?} does not say what failed",
+            d
+        );
+    }
+}


### PR DESCRIPTION
Four changes for running HORUS on a quadruped, humanoid, or any bus-synchronous
real-time system. Each has a test that fails without it.

## 1. `deadline` could not see the thing that misses deadlines

`TimingEnforcer::check_deadline` measured `tick_start.elapsed()` — how long the
node's own code ran. `check_tick_budget` measures `tr.duration`. **Those are the
same quantity.** Two knobs measuring one thing is the defect class
`safety_monitor.rs` already names: *"two named options that do the same thing
means one of them is a lie."* The lie was that `deadline` sounded like a deadline.

What a control loop promises is that the command **leaves** by a fixed time after
the period began — release lateness *plus* execution. On this machine a 1 kHz
tick was measured up to **3529 µs** late. A node woken 3.5 ms late that executes
in 10 µs has delivered its command three cycles after it was due; the old check
compared 10 µs against a 900 µs deadline and recorded a healthy tick.

So the deadline-miss ladder — and the degradation ladder and safe-state response
hanging off it — **never fired for the failure mode that dominates in practice.**
It fired only for the rarer one where the node's own code is slow, which `budget`
already covers.

`CyclicWaiter::wait` already computed the lateness and threw it away. It now
returns it; the RT loop carries it across the loop boundary (the wait at the
bottom releases the *next* iteration, so that is the tick it describes).

`check_deadline` stays, delegating with `Duration::ZERO`. Non-RT callers have no
scheduled slot to be late against, so their behaviour is bit-identical.

The tests assert **both directions on the same inputs**: the release-aware check
reports a miss, the old one reports healthy. If they ever agree, one is redundant
and the test says so.

## 2. The bus-driven path silently dropped ticks

`tick_once()` is the documented way to drive HORUS from something else's clock —
*"Does not loop. Does not sleep. The caller controls timing."* For a legged robot
that clock is the fieldbus: `ec_receive_processdata()` → `tick_once()` →
`ec_send_processdata()`.

`should_tick_node` compared `elapsed < period` strictly, while `last_tick` is
stamped **inside** the tick, after the gate. An on-time cycle measures a hair
under one period and gets refused. The RT executor hit exactly this and fixed it
("halving the effective rate of every RT node"); this path never got the fix.

It bites harder here, because a bus cycle arrives on the **bus's crystal**, not
this host's `CLOCK_MONOTONIC` — so "a hair early" is the normal case, not a
boundary condition.

| | before | after |
|---|---|---|
| `.rate(1000hz)` node, 400 cycles at 1 kHz | **240** | **399** |
| `.rate(100hz)` node, same drive | 37 | 39 (must NOT accelerate) |

The tolerance is half the **driving** period, not half the node's own — that
bound is what keeps slow nodes honest.

## 3. The RT hygiene that path needs was `#[doc(hidden)]`

`run()` applies priority/affinity/mlockall/prefault to threads it spawns.
`tick_once()` ticks on the **caller's** thread, which gets none of it — so the
documented bus integration ran the control loop on an ordinary `SCHED_OTHER`
thread with pageable memory, and the fix was undiscoverable.

Un-hidden, plus `prepare_current_thread_rt()` doing all four in the order that
works: mlockall first (so later allocations are locked as made), then prefault
(those pages stay resident), then priority, then affinity. It **returns** the
degradations instead of discarding them, so a caller that must not run degraded
can refuse — the choice `require_rt()` already makes for `run()`:

```
["memory locking: mlockall failed: Cannot allocate memory (os error 12)",
 "rt priority: Permission denied on 'RT scheduling': requires CAP_SYS_NICE"]
```

## 4. RT→RT topic edges are now named at build time

Every RT node becomes its own singleton chain and the executor does not sequence
chains against each other — the code says so in as many words. So an RT consumer
downstream of an RT producer reads the producer's **previous** tick at a phase
offset fixed when the threads happened to start. Nothing is visible at runtime:
the edge exists, data flows, every value is plausible and one cycle stale.

On a legged robot that edge is estimator → controller, and one stale cycle of
state estimate at 1 kHz is a real torque error. Now reported by name with the two
ways out. Detection returns pairs rather than printing so it is testable, and a
second test asserts a lone RT node reports nothing — a warning that fires on
every graph trains people to ignore it.

## Also: throughput now reaches the regression gate

Measured as `messages_per_sec`, written to the CSV, gated by nothing — while
Median and TailRatioP99 block.

It enters as its **reciprocal, ns/msg**. Every comparison in the gate is
lower-is-better (`current > band`), so a higher-is-better metric would mean
teaching the comparator a direction — a branch on every metric and a second
meaning for "improved". The reciprocal keeps one direction and puts throughput in
the same unit as the latency metrics.

ReportOnly to start (no history window yet, so its spread is unmeasured), but the
**2× gross multiplier still applies, so a throughput collapse blocks
immediately**. Promote once `BENCH_WINDOW` runs describe its spread — the path
Median took. `#[serde(default)]` on the new baseline field so the existing
rolling cache produces "no baseline" rather than a false regression on the first
build; pinned by a test that parses a legacy entry.

Plus a test asserting every `Metric::ALL` entry has a `MetricPolicy` — a metric
tracked but never gated is exactly what throughput was.

## Verification

2500 `horus_core` lib tests, 56 benchmark tests, and
`rt_deadline_enforcement`, `rt_scheduler_integration`, `externally_driven_tick`,
`acceptance_scheduler`, `stress_scheduling`, `multi_process_scheduler`. fmt and
clippy clean. Full `--test '*'` sweep still running locally; CI runs the same and
is authoritative.