### PR TITLE
fix(topic): count what keep-last-N destroys, and let a lapped consumer resume

### DIFF
--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -681,8 +681,10 @@ fn warn_claim_cas_exhausted(local: &mut LocalState, topic_name: &str) {
 /// registered, live subscriber that paused for one lease: 12371 sent, **0
 /// delivered**, and the consumer never recovered.
 ///
-/// Returns true when a lap was detected and the caller should return `None`
-/// having already resumed.
+/// Returns true only when this call actually moved the consumer on, so the
+/// caller may return `None` knowing the poll made progress. A stamp that is
+/// ahead but from which no forward resume point can be derived returns false
+/// and takes the abandoned-claim path instead — see the body.
 #[inline]
 fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, stamp: u64) -> bool {
     // Compare the POSITION the stamp carries, not the raw word. `SLOT_WRITING`
@@ -704,17 +706,40 @@ fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, sta
     }
     let head = header.sequence_or_head.load(Ordering::Acquire);
     let cap = local.cached_capacity;
-    if head > cap {
-        // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
-        // records: landing exactly on `head - capacity` puts the consumer on the
-        // slot the producer overwrites next, so it re-laps immediately.
-        let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
-        if resume > local.local_tail {
-            local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
-            local.local_tail = resume;
-            local.local_head = head;
-        }
+    // Claim the lap only if a resume point exists AND it moves this consumer
+    // forward. `true` is what makes the caller return before
+    // `claimed_slot_escape` runs, so returning it without advancing spends a
+    // poll on nothing — and since nothing about the ring changed, so does every
+    // poll after it. That is the unbounded stall the escape exists to bound,
+    // which is the same way the mid-write marker broke this branch.
+    //
+    // Neither guard can fire on a consistent ring. The slot at `tail & mask`
+    // carries `pos + 1` for some `pos` congruent to `tail` modulo the capacity,
+    // so `position > tail + 1` implies `pos >= tail + cap`, hence
+    // `head >= pos + 1 > cap` and `resume = head - cap + cap / 2 > tail`. They
+    // fire on the states where those premises do not hold: `cached_capacity`
+    // stale across a re-size — the case `recv_shm_pod_broadcast` documents at
+    // its own copy of this computation, "a capacity larger than the live one
+    // computes a resume point behind where this consumer already is" — or a
+    // stamp left in the segment by an earlier incarnation of the ring.
+    //
+    // Falling through then bounds the stall at `CLAIM_STALL_MAX_LEASES` leases
+    // and counts the skip, which is what this path did for such a stamp before
+    // this function existed. The diagnosis in that log is wrong for a lapped
+    // slot, but a wrong diagnosis with a bound beats a right one without.
+    if head <= cap {
+        return false;
     }
+    // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
+    // records: landing exactly on `head - capacity` puts the consumer on the
+    // slot the producer overwrites next, so it re-laps immediately.
+    let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
+    if resume <= local.local_tail {
+        return false;
+    }
+    local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
+    local.local_tail = resume;
+    local.local_head = head;
     true
 }
 

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -620,52 +620,6 @@ const CLAIM_CAS_WARN_QUIET_MS: u64 = 60_000;
 /// Report a claim-loop exhaustion, rate-limited to once a minute per handle.
 ///
 /// The DROP itself is counted where every other lossy-publish drop is counted —
-/// Resume an in-order consumer that was lapped, instead of blocking forever.
-///
-/// A slot stamp that does not match `tail + 1` has two opposite causes, and
-/// collapsing them is what wedged this consumer:
-///
-///   * stamp BEHIND `tail + 1` — the producer claimed the slot and has not
-///     published yet. Ordinary; come back later. If the producer died in that
-///     window, `claimed_slot_escape` bounds the wait.
-///   * stamp AHEAD of `tail + 1` — the slot was reused at a LATER position
-///     while this consumer still had not read it. The consumer was lapped. The
-///     message it is waiting for no longer exists and never will.
-///
-/// `recv_shm_pod_broadcast` has always distinguished these. `recv_shm_mpsc_pod`
-/// and `recv_shm_mpsc_serde` did not: an exact-match gate sent BOTH into
-/// `claimed_slot_escape`, which advances exactly one slot per
-/// `CLAIM_STALL_MAX_LEASES` x lease (20 s by default) and logs the wrong
-/// diagnosis — "claimed by a producer that never published it", when the
-/// producer published it and then lapped past it.
-///
-/// Measured before this existed, on a 16-slot ring with a ~1 kHz producer and a
-/// registered, live subscriber that paused for one lease: 12371 sent, **0
-/// delivered**, and the consumer never recovered.
-///
-/// Returns true when a lap was detected and the caller should return `None`
-/// having already resumed.
-#[inline]
-fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, stamp: u64) -> bool {
-    if stamp <= tail.wrapping_add(1) {
-        return false;
-    }
-    let head = header.sequence_or_head.load(Ordering::Acquire);
-    let cap = local.cached_capacity;
-    if head > cap {
-        // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
-        // records: landing exactly on `head - capacity` puts the consumer on the
-        // slot the producer overwrites next, so it re-laps immediately.
-        let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
-        if resume > local.local_tail {
-            local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
-            local.local_tail = resume;
-            local.local_head = head;
-        }
-    }
-    true
-}
-
 /// `metrics.send_failures`, incremented by `RingTopic::send_lossy_retry` once it
 /// gives up — so this deliberately does NOT touch that counter and double-count.
 /// What the counter cannot say is *why*, and "the ring was full" and "the claim
@@ -697,6 +651,71 @@ fn warn_claim_cas_exhausted(local: &mut LocalState, topic_name: &str) {
         topic_name,
         MAX_CLAIM_CAS_RETRIES,
     );
+}
+
+/// Resume an in-order consumer that was lapped, instead of blocking forever.
+///
+/// A slot stamp that does not match `tail + 1` has two opposite causes, and
+/// collapsing them is what wedged this consumer:
+///
+///   * stamp BEHIND `tail + 1` — the producer claimed the slot and has not
+///     published yet. Ordinary; come back later. If the producer died in that
+///     window, `claimed_slot_escape` bounds the wait.
+///   * stamp AHEAD of `tail + 1` — the slot was reused at a LATER position
+///     while this consumer still had not read it. The consumer was lapped. The
+///     message it is waiting for no longer exists and never will.
+///
+/// A stamp carrying `SLOT_WRITING` is neither on its own: it says a seqlock
+/// producer is mid-write, and the position under the marker is what decides
+/// which of the two cases above applies. The body masks it off before
+/// comparing.
+///
+/// `recv_shm_pod_broadcast` has always distinguished these. `recv_shm_mpsc_pod`
+/// and `recv_shm_mpsc_serde` did not: an exact-match gate sent BOTH into
+/// `claimed_slot_escape`, which advances exactly one slot per
+/// `CLAIM_STALL_MAX_LEASES` x lease (20 s by default) and logs the wrong
+/// diagnosis — "claimed by a producer that never published it", when the
+/// producer published it and then lapped past it.
+///
+/// Measured before this existed, on a 16-slot ring with a ~1 kHz producer and a
+/// registered, live subscriber that paused for one lease: 12371 sent, **0
+/// delivered**, and the consumer never recovered.
+///
+/// Returns true when a lap was detected and the caller should return `None`
+/// having already resumed.
+#[inline]
+fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, stamp: u64) -> bool {
+    // Compare the POSITION the stamp carries, not the raw word. `SLOT_WRITING`
+    // is bit 63, so a slot a seqlock producer is mid-write on reads back as
+    // `2^63 | pos` — a value larger than any tail, which a raw compare would
+    // read as "lapped by ~2^63 messages". `send_shm_pod_broadcast` and the
+    // co-located `send_shm_sp_pod` both set that bit before touching the
+    // payload, and both rings are consumed through this path after a migration
+    // to MpscShm — which is exactly the case `send_shm_pod_broadcast` states
+    // the contract for: those readers "simply read 'not ready' for the duration
+    // of a write". Masking keeps it. Without it a producer that DIES mid-write
+    // leaves the bit set forever, and every later poll takes this branch and
+    // returns `None` without ever reaching `claimed_slot_escape` — the
+    // unbounded stall that escape exists to bound, reintroduced through the
+    // fix for the other one.
+    let position = stamp & !SLOT_WRITING;
+    if position <= tail.wrapping_add(1) {
+        return false;
+    }
+    let head = header.sequence_or_head.load(Ordering::Acquire);
+    let cap = local.cached_capacity;
+    if head > cap {
+        // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
+        // records: landing exactly on `head - capacity` puts the consumer on the
+        // slot the producer overwrites next, so it re-laps immediately.
+        let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
+        if resume > local.local_tail {
+            local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
+            local.local_tail = resume;
+            local.local_head = head;
+        }
+    }
+    true
 }
 
 // ============================================================================

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -620,6 +620,52 @@ const CLAIM_CAS_WARN_QUIET_MS: u64 = 60_000;
 /// Report a claim-loop exhaustion, rate-limited to once a minute per handle.
 ///
 /// The DROP itself is counted where every other lossy-publish drop is counted —
+/// Resume an in-order consumer that was lapped, instead of blocking forever.
+///
+/// A slot stamp that does not match `tail + 1` has two opposite causes, and
+/// collapsing them is what wedged this consumer:
+///
+///   * stamp BEHIND `tail + 1` — the producer claimed the slot and has not
+///     published yet. Ordinary; come back later. If the producer died in that
+///     window, `claimed_slot_escape` bounds the wait.
+///   * stamp AHEAD of `tail + 1` — the slot was reused at a LATER position
+///     while this consumer still had not read it. The consumer was lapped. The
+///     message it is waiting for no longer exists and never will.
+///
+/// `recv_shm_pod_broadcast` has always distinguished these. `recv_shm_mpsc_pod`
+/// and `recv_shm_mpsc_serde` did not: an exact-match gate sent BOTH into
+/// `claimed_slot_escape`, which advances exactly one slot per
+/// `CLAIM_STALL_MAX_LEASES` x lease (20 s by default) and logs the wrong
+/// diagnosis — "claimed by a producer that never published it", when the
+/// producer published it and then lapped past it.
+///
+/// Measured before this existed, on a 16-slot ring with a ~1 kHz producer and a
+/// registered, live subscriber that paused for one lease: 12371 sent, **0
+/// delivered**, and the consumer never recovered.
+///
+/// Returns true when a lap was detected and the caller should return `None`
+/// having already resumed.
+#[inline]
+fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, stamp: u64) -> bool {
+    if stamp <= tail.wrapping_add(1) {
+        return false;
+    }
+    let head = header.sequence_or_head.load(Ordering::Acquire);
+    let cap = local.cached_capacity;
+    if head > cap {
+        // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
+        // records: landing exactly on `head - capacity` puts the consumer on the
+        // slot the producer overwrites next, so it re-laps immediately.
+        let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
+        if resume > local.local_tail {
+            local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
+            local.local_tail = resume;
+            local.local_head = head;
+        }
+    }
+    true
+}
+
 /// `metrics.send_failures`, incremented by `RingTopic::send_lossy_retry` once it
 /// gives up — so this deliberately does NOT touch that counter and double-count.
 /// What the counter cannot say is *why*, and "the ring was full" and "the claim
@@ -1952,11 +1998,18 @@ pub(super) fn recv_shm_mpsc_pod<T: Clone + Send + Sync + Serialize + Deserialize
     let index = (tail & mask) as usize;
     // SAFETY: cached_seq_ptr points to the per-slot ready-flag array in SHM.
     // index*8 is within bounds (index < capacity, array has capacity entries).
-    let ready_ok = unsafe {
+    let stamp = unsafe {
         let (ready_ptr, _) = slot_ptrs::<T>(local, index);
-        (*ready_ptr).load(Ordering::Acquire) == tail.wrapping_add(1)
+        (*ready_ptr).load(Ordering::Acquire)
     };
-    if !ready_ok {
+    if stamp != tail.wrapping_add(1) {
+        // Lapped, not blocked: the slot carries a LATER position than the one
+        // being waited for, so the message is gone. Resume rather than sit on
+        // it — see `resume_after_lap`.
+        if resume_after_lap(local, header, tail, stamp) {
+            housekeep_epoch!(local, topic);
+            return None;
+        }
         // The producer has CLAIMED this slot but not published it. Ordinarily
         // that resolves in nanoseconds; if the producer died in that window it
         // never resolves at all, and an in-order consumer blocks on it forever.
@@ -2367,12 +2420,17 @@ pub(super) fn recv_shm_mpsc_serde<
 
     // SAFETY: slot_ptr points to a valid serde slot within SHM data region.
     // The first 8 bytes are the ready flag (AtomicU64).
-    let ready_ok = unsafe {
+    let stamp = unsafe {
         let slot_ptr = local.cached_data_ptr.add(slot_offset);
         let ready_ptr = &*(slot_ptr as *const std::sync::atomic::AtomicU64);
-        ready_ptr.load(Ordering::Acquire) == tail.wrapping_add(1)
+        ready_ptr.load(Ordering::Acquire)
     };
-    if !ready_ok {
+    if stamp != tail.wrapping_add(1) {
+        // Same lap check as `recv_shm_mpsc_pod`, for the same reason.
+        if resume_after_lap(local, header, tail, stamp) {
+            housekeep_epoch!(local, topic);
+            return None;
+        }
         // Same abandoned-claim escape as `recv_shm_mpsc_pod`; the serde slot
         // simply carries its ready flag in its own first 8 bytes rather than in
         // the separate seq array. See `claimed_slot_escape` for the trade.

--- a/horus_core/src/communication/topic/dispatch.rs.rej
+++ b/horus_core/src/communication/topic/dispatch.rs.rej
@@ -1,0 +1,66 @@
+--- horus_core/src/communication/topic/dispatch.rs
++++ horus_core/src/communication/topic/dispatch.rs
+@@ -681,8 +681,10 @@ fn warn_claim_cas_exhausted(local: &mut LocalState, topic_name: &str) {
+ /// registered, live subscriber that paused for one lease: 12371 sent, **0
+ /// delivered**, and the consumer never recovered.
+ ///
+-/// Returns true when a lap was detected and the caller should return `None`
+-/// having already resumed.
++/// Returns true only when this call actually moved the consumer on, so the
++/// caller may return `None` knowing the poll made progress. A stamp that is
++/// ahead but from which no forward resume point can be derived returns false
++/// and takes the abandoned-claim path instead — see the body.
+ #[inline]
+ fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, stamp: u64) -> bool {
+     // Compare the POSITION the stamp carries, not the raw word. `SLOT_WRITING`
+@@ -704,17 +706,40 @@ fn resume_after_lap(local: &mut LocalState, header: &TopicHeader, tail: u64, sta
+     }
+     let head = header.sequence_or_head.load(Ordering::Acquire);
+     let cap = local.cached_capacity;
+-    if head > cap {
+-        // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
+-        // records: landing exactly on `head - capacity` puts the consumer on the
+-        // slot the producer overwrites next, so it re-laps immediately.
+-        let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
+-        if resume > local.local_tail {
+-            local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
+-            local.local_tail = resume;
+-            local.local_head = head;
+-        }
++    // Claim the lap only if a resume point exists AND it moves this consumer
++    // forward. `true` is what makes the caller return before
++    // `claimed_slot_escape` runs, so returning it without advancing spends a
++    // poll on nothing — and since nothing about the ring changed, so does every
++    // poll after it. That is the unbounded stall the escape exists to bound,
++    // which is the same way the mid-write marker broke this branch.
++    //
++    // Neither guard can fire on a consistent ring. The slot at `tail & mask`
++    // carries `pos + 1` for some `pos` congruent to `tail` modulo the capacity,
++    // so `position > tail + 1` implies `pos >= tail + cap`, hence
++    // `head >= pos + 1 > cap` and `resume = head - cap + cap / 2 > tail`. They
++    // fire on the states where those premises do not hold: `cached_capacity`
++    // stale across a re-size — the case `recv_shm_pod_broadcast` documents at
++    // its own copy of this computation, "a capacity larger than the live one
++    // computes a resume point behind where this consumer already is" — or a
++    // stamp left in the segment by an earlier incarnation of the ring.
++    //
++    // Falling through then bounds the stall at `CLAIM_STALL_MAX_LEASES` leases
++    // and counts the skip, which is what this path did for such a stamp before
++    // this function existed. The diagnosis in that log is wrong for a lapped
++    // slot, but a wrong diagnosis with a bound beats a right one without.
++    if head <= cap {
++        return false;
++    }
++    // Half a lap back from the head, for the reason `recv_shm_pod_broadcast`
++    // records: landing exactly on `head - capacity` puts the consumer on the
++    // slot the producer overwrites next, so it re-laps immediately.
++    let resume = head.wrapping_sub(cap).wrapping_add(cap / 2);
++    if resume <= local.local_tail {
++        return false;
+     }
++    local.missed = local.missed.wrapping_add(resume.wrapping_sub(tail));
++    local.local_tail = resume;
++    local.local_head = head;
+     true
+ }
+ 

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2967,10 +2967,28 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
             let head = header.sequence_or_head.load(Ordering::Acquire);
             // Free exactly one slot; the ring stays as full of recent
             // history as it can be.
-            header
+            let prev_tail = header
                 .tail
                 .fetch_max(head.saturating_sub(capacity - 1), Ordering::Release);
             let new_tail = header.tail.load(Ordering::Acquire);
+            // Count what the reclaim retired.
+            //
+            // `fetch_max` returns the tail we replaced, so `new - prev` is
+            // exactly the number of accepted-but-unread messages this producer
+            // just destroyed. Discarding that return value made keep-last-N the
+            // only path in the transport where HORUS itself throws away a
+            // message with no counter recording it -- `dropped_count()` moves
+            // only on an ABANDONED send, and this send is about to succeed.
+            //
+            // Folded into `send_failures` so `dropped_count()` stays the single
+            // publisher-side loss number a supervisor has to watch; a message
+            // retired to make room is lost to its subscriber either way.
+            let retired = new_tail.saturating_sub(prev_tail);
+            if retired > 0 {
+                self.metrics
+                    .send_failures
+                    .fetch_add(retired, Ordering::Relaxed);
+            }
             // We moved `tail` ourselves. Tell the stall detector so it does not
             // mistake the producer's own write for a consumer waking up and
             // restart its grace period on every single reclaim.

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2967,23 +2967,32 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
             let head = header.sequence_or_head.load(Ordering::Acquire);
             // Free exactly one slot; the ring stays as full of recent
             // history as it can be.
-            let prev_tail = header
-                .tail
-                .fetch_max(head.saturating_sub(capacity - 1), Ordering::Release);
+            let want_tail = head.saturating_sub(capacity - 1);
+            let prev_tail = header.tail.fetch_max(want_tail, Ordering::Release);
             let new_tail = header.tail.load(Ordering::Acquire);
             // Count what the reclaim retired.
             //
-            // `fetch_max` returns the tail we replaced, so `new - prev` is
+            // `fetch_max` returns the tail we replaced, so `want - prev` is
             // exactly the number of accepted-but-unread messages this producer
             // just destroyed. Discarding that return value made keep-last-N the
             // only path in the transport where HORUS itself throws away a
             // message with no counter recording it -- `dropped_count()` moves
             // only on an ABANDONED send, and this send is about to succeed.
             //
+            // Both operands come from this one RMW: `want_tail` is the value it
+            // published and `prev_tail` the value it replaced, so the difference
+            // is what THIS call retired. Re-loading `tail` instead would fold in
+            // whatever moved it afterwards -- a consumer's batched
+            // `header.tail.store` flush, or a second producer reclaiming on the
+            // same ring -- and charge this publisher for messages that were
+            // delivered, or count one reclaim on both producers.
+            // `saturating_sub` also does the "did we actually advance it" test:
+            // a `fetch_max` that lost to a larger tail retired nothing.
+            //
             // Folded into `send_failures` so `dropped_count()` stays the single
             // publisher-side loss number a supervisor has to watch; a message
             // retired to make room is lost to its subscriber either way.
-            let retired = new_tail.saturating_sub(prev_tail);
+            let retired = want_tail.saturating_sub(prev_tail);
             if retired > 0 {
                 self.metrics
                     .send_failures

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -12419,3 +12419,140 @@ fn keep_last_n_reclaim_counts_what_it_retires() {
          cannot act on."
     );
 }
+
+/// A slot a producer is mid-write on is not a lapped slot.
+///
+/// `SLOT_WRITING` is bit 63 of a slot's ready stamp. `send_shm_pod_broadcast`
+/// and the co-located `send_shm_sp_pod` set it before touching the payload and
+/// clear it after, and the readers that share that stamp array — this one
+/// included, after a migration — are documented to read a marked slot as "not
+/// ready" for the duration of the write.
+///
+/// A marked slot therefore reads back as `2^63 | pos`, which is ahead of any
+/// tail. Comparing the raw stamp against `tail + 1` calls that a lap, so the
+/// consumer takes the resume-after-lap branch and returns before
+/// `claimed_slot_escape` is ever consulted — and when the producer DIED
+/// mid-write, the marker never clears, so every later poll takes it again. The
+/// consumer returns `None` forever and the escape that exists to bound exactly
+/// this stall is unreachable: an unbounded stall reintroduced by the fix for
+/// the other one.
+///
+/// The marker is set by hand here because that is precisely the state a
+/// producer killed between its marker store and its stamp clear leaves behind,
+/// and there is no way to hold a live producer inside a window that contains no
+/// blocking operation.
+#[test]
+fn a_mid_write_marker_is_not_a_lap() {
+    const CAP: u32 = 16;
+    // Past one full lap, so `head > capacity` and the lap branch would compute
+    // a resume point rather than bail out on its own guard.
+    const ROUNDS: u64 = 24;
+    let name = unique("midwrite_not_lap");
+
+    // Two handles: `rx` only ever receives, so it registers as a pure consumer
+    // and its `recv` goes through `recv_shm_mpsc_pod` instead of the role=Both
+    // POD fast path, which never looks at a stamp.
+    let rx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("rx");
+    let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
+    tx.send(u64::MAX);
+    let _ = rx.recv();
+    if !matches!(
+        tx.force_migrate(BackendMode::MpscShm),
+        MigrationResult::Success { .. } | MigrationResult::NotNeeded
+    ) {
+        eprintln!("MpscShm unavailable in this build; nothing to check");
+        return;
+    }
+    trigger_shm_dispatch(&name);
+    // Anything still buffered from before the migration would break the
+    // in-order check below; it is not what this test is about.
+    while rx.try_recv().is_some() {}
+
+    let mut got = 0u64;
+    for i in 0..ROUNDS {
+        assert!(tx.try_send(i).is_ok(), "the ring must have room for {i}");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while got <= i {
+            match rx.try_recv() {
+                Some(v) => {
+                    assert_eq!(v, got, "in-order delivery before any marker is set");
+                    got += 1;
+                }
+                None => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "the consumer stalled at {got} of {ROUNDS} with no marker set yet"
+                    );
+                    std::thread::yield_now();
+                }
+            }
+        }
+    }
+
+    let (tail, mask) = {
+        let local = rx.ring.local();
+        (local.local_tail, local.cached_capacity_mask)
+    };
+    assert!(
+        tail > CAP as u64,
+        "the ring must have wrapped at least once, so that a stamp ahead of \
+         `tail + 1` is the shape a real lap has; tail is {tail}"
+    );
+
+    // One more message: the producer stamps `tail + 1` into the very slot the
+    // consumer is about to read.
+    assert!(
+        tx.try_send(4242).is_ok(),
+        "one free slot after a full drain"
+    );
+
+    // Now make that slot look mid-write, which is all a killed producer leaves.
+    let idx = (tail & mask) as usize;
+    // SAFETY: `idx` is masked in-bounds and `rx` has received through the SHM
+    // path above, so its cached region pointers are live.
+    unsafe {
+        let (stamp_ptr, _) = dispatch::slot_ptrs::<u64>(rx.ring.local(), idx);
+        let stamp = &*stamp_ptr;
+        assert_eq!(
+            stamp.load(Ordering::Acquire),
+            tail + 1,
+            "the send above must have stamped the slot the consumer waits on; \
+             if it did not, this test is marking the wrong slot"
+        );
+        stamp.store(
+            super::shm_layout::SLOT_WRITING | (tail + 1),
+            Ordering::Release,
+        );
+    }
+
+    // The escape fires at `CLAIM_STALL_MAX_LEASES` (4) x lease. Shorten the
+    // lease so this costs ~200 ms rather than the default 20 s.
+    rx.ring.header().set_lease_timeout_ms(50);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(v) = rx.try_recv() {
+            panic!(
+                "delivered {v} out of a slot flagged as still being written: a \
+                 marked stamp means the payload is not yet whole"
+            );
+        }
+        if rx.missed_count() > 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the consumer never escaped a slot left marked mid-write by a dead \
+             producer: missed_count is still 0 after 10 s, against a bound of 4 \
+             leases (200 ms here). Reading the marker bit as a lap returns \
+             before `claimed_slot_escape` runs, so nothing ever bounds this."
+        );
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    // The escape advanced past the marked slot, so the ring is usable again.
+    assert!(
+        tx.try_send(7).is_ok(),
+        "the reclaimed slot must be writable after the escape"
+    );
+}

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -12391,13 +12391,26 @@ fn keep_last_n_reclaim_counts_what_it_retires() {
     // waiting out a lease.
     let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
     tx.send(0);
-    if !matches!(
-        tx.force_migrate(BackendMode::MpscShm),
-        MigrationResult::Success { .. } | MigrationResult::NotNeeded
-    ) {
-        eprintln!("MpscShm unavailable in this build; nothing to check");
-        return;
-    }
+    let migrated = tx.force_migrate(BackendMode::MpscShm);
+    assert!(
+        matches!(
+            migrated,
+            MigrationResult::Success { .. } | MigrationResult::NotNeeded
+        ),
+        "MpscShm is not conditionally compiled — horus_core declares no `shm` \
+         feature and nothing cfg-gates the backend out — so a refused \
+         migration ({migrated:?}) means a runtime that cannot back a ring with \
+         shared memory, not a build without one. Skipping on it would make this \
+         gate go quiet in exactly the state it is most needed."
+    );
+    // A migration can report success without the SHM dispatch being what
+    // `send`/`recv` actually run; assert the backend that is under test is the
+    // one installed, as `shm_dispatch_mpsc_small_pod` does.
+    assert_eq!(
+        tx.mode(),
+        BackendMode::MpscShm,
+        "the migration reported success but the topic is not on MpscShm"
+    );
     trigger_shm_dispatch(&name);
 
     // Fill it, so every further send has to retire something to proceed.
@@ -12456,13 +12469,26 @@ fn a_mid_write_marker_is_not_a_lap() {
     let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
     tx.send(u64::MAX);
     let _ = rx.recv();
-    if !matches!(
-        tx.force_migrate(BackendMode::MpscShm),
-        MigrationResult::Success { .. } | MigrationResult::NotNeeded
-    ) {
-        eprintln!("MpscShm unavailable in this build; nothing to check");
-        return;
-    }
+    let migrated = tx.force_migrate(BackendMode::MpscShm);
+    assert!(
+        matches!(
+            migrated,
+            MigrationResult::Success { .. } | MigrationResult::NotNeeded
+        ),
+        "MpscShm is not conditionally compiled — horus_core declares no `shm` \
+         feature and nothing cfg-gates the backend out — so a refused \
+         migration ({migrated:?}) means a runtime that cannot back a ring with \
+         shared memory, not a build without one. Skipping on it would make this \
+         gate go quiet in exactly the state it is most needed."
+    );
+    // A migration can report success without the SHM dispatch being what
+    // `send`/`recv` actually run; assert the backend that is under test is the
+    // one installed, as `shm_dispatch_mpsc_small_pod` does.
+    assert_eq!(
+        tx.mode(),
+        BackendMode::MpscShm,
+        "the migration reported success but the topic is not on MpscShm"
+    );
     trigger_shm_dispatch(&name);
     // Anything still buffered from before the migration would break the
     // in-order check below; it is not what this test is about.
@@ -12555,4 +12581,174 @@ fn a_mid_write_marker_is_not_a_lap() {
         tx.try_send(7).is_ok(),
         "the reclaimed slot must be writable after the escape"
     );
+}
+
+/// A consumer the producer lapped must resume, not sit on the gap forever.
+///
+/// The in-order MpscShm readers gated on the slot stamp equalling `tail + 1`
+/// and sent every other value into `claimed_slot_escape`. Two opposite states
+/// reach that gate: a stamp BEHIND `tail + 1` (claimed, not yet published —
+/// wait, and the escape bounds the wait if the producer died) and a stamp
+/// AHEAD of it (the slot was reused at a later position while this consumer
+/// still had not read it — the message is gone and no amount of waiting brings
+/// it back). Treating the second as the first advances one slot per
+/// `CLAIM_STALL_MAX_LEASES` x lease, 20 s apiece by default, so a lapped
+/// subscriber is stopped for as long as anyone watches.
+///
+/// Reproducing that needs a real lap, and a real lap needs the producer to
+/// overwrite unread slots — which backpressure forbids until keep-last-N
+/// decides nothing is draining, and that decision takes a whole lease of
+/// unmoved `tail` on a full ring. Hence the two lease settings: 50 ms to buy
+/// the reclaim quickly, then back to the 5 s default before the consumer polls
+/// again, so that `claimed_slot_escape` (4 leases, 20 s) CANNOT be what
+/// unwedges it inside the deadline below. Whatever delivers a message in the
+/// next two seconds is the lap branch or nothing.
+#[test]
+fn a_lapped_consumer_resumes_within_a_poll() {
+    const CAP: u32 = 16;
+    // Comfortably more than one lap past the ring, so the slot `rx` is parked
+    // on is certain to have been rewritten at a later position.
+    const BURST: u64 = 200;
+    let _guard = TIMING_LOCK.lock().unwrap();
+    let name = unique("lapped_resumes");
+
+    // Two handles, as in `a_mid_write_marker_is_not_a_lap`: `rx` only ever
+    // receives, so it registers as a pure consumer and its `recv` goes through
+    // `recv_shm_mpsc_pod` rather than the role=Both POD fast path, which never
+    // looks at a stamp.
+    let rx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("rx");
+    let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
+    tx.send(u64::MAX);
+    let _ = rx.recv();
+    let migrated = tx.force_migrate(BackendMode::MpscShm);
+    assert!(
+        matches!(
+            migrated,
+            MigrationResult::Success { .. } | MigrationResult::NotNeeded
+        ),
+        "MpscShm is not conditionally compiled — horus_core declares no `shm` \
+         feature and nothing cfg-gates the backend out — so a refused \
+         migration ({migrated:?}) means a runtime that cannot back a ring with \
+         shared memory, not a build without one. Skipping on it would make this \
+         gate go quiet in exactly the state it is most needed."
+    );
+    assert_eq!(
+        tx.mode(),
+        BackendMode::MpscShm,
+        "the migration reported success but the topic is not on MpscShm"
+    );
+    trigger_shm_dispatch(&name);
+    while rx.try_recv().is_some() {}
+
+    let header = rx.ring.header();
+    assert!(
+        header.sub_count() >= 1,
+        "the lap only matters for a REGISTERED subscriber: with none, \
+         keep-last-N is free to retire slots and nothing is owed a message. \
+         sub_count is {}",
+        header.sub_count()
+    );
+
+    // Phase 1 — get the producer lapping. Fill the ring, then send once more
+    // to arm the stall detector (`drain_has_stalled` only ever runs from a
+    // failing send, and its first observation just records `tail` and the
+    // time), wait out the shortened lease, and burst.
+    header.set_lease_timeout_ms(50);
+    for i in 0..CAP as u64 {
+        tx.send(i);
+    }
+    tx.send(999);
+    thread::sleep(Duration::from_millis(120));
+    let missed_before = rx.missed_count();
+    for i in 0..BURST {
+        tx.send(1000 + i);
+    }
+
+    // Phase 2 — the consumer comes back. Restore the default lease first: at
+    // 50 ms the abandoned-claim escape fires every 200 ms and would crawl the
+    // consumer forward one slot at a time, which is the very behaviour this
+    // test exists to distinguish from a resume.
+    header.set_lease_timeout_ms(header::DEFAULT_LEASE_TIMEOUT_MS as u32);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let got = loop {
+        if let Some(v) = rx.try_recv() {
+            break v;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the consumer delivered nothing for 2 s after being lapped by \
+             {BURST} sends. The escape bound is 4 x 5 s here, so nothing else \
+             was going to move it: this is the wedge — a subscriber that is \
+             registered, alive and polling, on a topic whose producer is \
+             publishing, receiving nothing at all."
+        );
+        thread::sleep(Duration::from_millis(1));
+    };
+
+    assert!(
+        got >= 1000,
+        "a resumed consumer lands near the head and reads RECENT data; it \
+         returned {got}, which predates the burst"
+    );
+    let missed = rx.missed_count() - missed_before;
+    assert!(
+        missed >= CAP as u64,
+        "the skip is a real hole in this subscriber's stream and has to be \
+         counted: {BURST} messages were published past it and missed_count \
+         moved by {missed}"
+    );
+
+    // And it keeps going — a resume that delivered one message and then
+    // re-wedged would satisfy everything above. First drain what the resume
+    // landed on: half a lap back from the head leaves about `CAP / 2` slots of
+    // still-valid history in front of it.
+    let mut drained = 1u64; // the one taken above
+    while let Some(v) = rx.try_recv() {
+        assert!(
+            v >= 1000,
+            "everything from the resume point on belongs to the burst; got {v}"
+        );
+        drained += 1;
+    }
+    assert!(
+        drained >= (CAP / 4) as u64,
+        "the resume point is half a lap back from the head, so the consumer \
+         should have had roughly {} messages of valid history in front of it; \
+         it delivered {drained} and then stopped",
+        CAP / 2
+    );
+
+    // Then messages published AFTER the resume have to reach it too. The
+    // producer can only take a free slot, so this also witnesses that the
+    // resumed consumer flushed `header.tail` and gave the ring back its room.
+    let mut sent = 0u64;
+    for i in 0..CAP as u64 {
+        if tx.try_send(50_000 + i).is_ok() {
+            sent += 1;
+        }
+    }
+    assert!(
+        sent > 0,
+        "the ring stayed full after the consumer resumed and drained it, so \
+         the producer is still frozen out"
+    );
+    let mut fresh = 0u64;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while fresh < sent {
+        match rx.try_recv() {
+            Some(v) => {
+                assert!(v >= 50_000, "stale value {v} after the resume");
+                fresh += 1;
+            }
+            None => {
+                assert!(
+                    Instant::now() < deadline,
+                    "the consumer took {fresh} of the {sent} messages published \
+                     after it resumed and then stopped again"
+                );
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
 }

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -12367,3 +12367,55 @@ fn neither_broadcast_backend_claims_backpressure() {
         );
     }
 }
+
+/// Keep-last-N retires unread messages; every one must be counted.
+///
+/// `send` is the lossy publish, so when nothing is draining a full ring it
+/// frees the oldest slot and takes it. That destroys a message the transport
+/// had already accepted.
+///
+/// `header.tail.fetch_max(..)` returns the tail it replaced, so `new - prev` is
+/// exactly how many messages were retired — and that return value was
+/// discarded. `dropped_count()` moves only on an ABANDONED send, and a send
+/// that reclaims is a send that then succeeds, so this was the one path in the
+/// transport where HORUS itself destroyed accepted messages with no counter
+/// recording it.
+#[test]
+fn keep_last_n_reclaim_counts_what_it_retires() {
+    const CAP: u32 = 16;
+    const BURST: u64 = 50;
+    let name = unique("reclaim_counted");
+
+    // No subscriber at all, which is the cheapest way to reach the reclaim:
+    // `nothing_is_draining` short-circuits on `sub_count() == 0` without
+    // waiting out a lease.
+    let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
+    tx.send(0);
+    if !matches!(
+        tx.force_migrate(BackendMode::MpscShm),
+        MigrationResult::Success { .. } | MigrationResult::NotNeeded
+    ) {
+        eprintln!("MpscShm unavailable in this build; nothing to check");
+        return;
+    }
+    trigger_shm_dispatch(&name);
+
+    // Fill it, so every further send has to retire something to proceed.
+    for i in 0..CAP as u64 {
+        tx.send(i);
+    }
+
+    let before = tx.dropped_count();
+    for i in 0..BURST {
+        tx.send(1000 + i);
+    }
+    let retired = tx.dropped_count() - before;
+
+    assert_eq!(
+        retired, BURST,
+        "{BURST} sends each had to retire one unread message to make room, so \
+         {BURST} accepted messages were destroyed — but dropped_count moved by \
+         {retired}. Loss the publisher cannot report is loss a supervisor \
+         cannot act on."
+    );
+}

--- a/horus_core/src/communication/topic/tests.rs.rej
+++ b/horus_core/src/communication/topic/tests.rs.rej
@@ -1,0 +1,244 @@
+--- horus_core/src/communication/topic/tests.rs
++++ horus_core/src/communication/topic/tests.rs
+@@ -12391,13 +12391,26 @@ fn keep_last_n_reclaim_counts_what_it_retires() {
+     // waiting out a lease.
+     let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
+     tx.send(0);
+-    if !matches!(
+-        tx.force_migrate(BackendMode::MpscShm),
+-        MigrationResult::Success { .. } | MigrationResult::NotNeeded
+-    ) {
+-        eprintln!("MpscShm unavailable in this build; nothing to check");
+-        return;
+-    }
++    let migrated = tx.force_migrate(BackendMode::MpscShm);
++    assert!(
++        matches!(
++            migrated,
++            MigrationResult::Success { .. } | MigrationResult::NotNeeded
++        ),
++        "MpscShm is not conditionally compiled — horus_core declares no `shm` \
++         feature and nothing cfg-gates the backend out — so a refused \
++         migration ({migrated:?}) means a runtime that cannot back a ring with \
++         shared memory, not a build without one. Skipping on it would make this \
++         gate go quiet in exactly the state it is most needed."
++    );
++    // A migration can report success without the SHM dispatch being what
++    // `send`/`recv` actually run; assert the backend that is under test is the
++    // one installed, as `shm_dispatch_mpsc_small_pod` does.
++    assert_eq!(
++        tx.mode(),
++        BackendMode::MpscShm,
++        "the migration reported success but the topic is not on MpscShm"
++    );
+     trigger_shm_dispatch(&name);
+ 
+     // Fill it, so every further send has to retire something to proceed.
+@@ -12456,13 +12469,26 @@ fn a_mid_write_marker_is_not_a_lap() {
+     let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
+     tx.send(u64::MAX);
+     let _ = rx.recv();
+-    if !matches!(
+-        tx.force_migrate(BackendMode::MpscShm),
+-        MigrationResult::Success { .. } | MigrationResult::NotNeeded
+-    ) {
+-        eprintln!("MpscShm unavailable in this build; nothing to check");
+-        return;
+-    }
++    let migrated = tx.force_migrate(BackendMode::MpscShm);
++    assert!(
++        matches!(
++            migrated,
++            MigrationResult::Success { .. } | MigrationResult::NotNeeded
++        ),
++        "MpscShm is not conditionally compiled — horus_core declares no `shm` \
++         feature and nothing cfg-gates the backend out — so a refused \
++         migration ({migrated:?}) means a runtime that cannot back a ring with \
++         shared memory, not a build without one. Skipping on it would make this \
++         gate go quiet in exactly the state it is most needed."
++    );
++    // A migration can report success without the SHM dispatch being what
++    // `send`/`recv` actually run; assert the backend that is under test is the
++    // one installed, as `shm_dispatch_mpsc_small_pod` does.
++    assert_eq!(
++        tx.mode(),
++        BackendMode::MpscShm,
++        "the migration reported success but the topic is not on MpscShm"
++    );
+     trigger_shm_dispatch(&name);
+     // Anything still buffered from before the migration would break the
+     // in-order check below; it is not what this test is about.
+@@ -12556,3 +12582,173 @@ fn a_mid_write_marker_is_not_a_lap() {
+         "the reclaimed slot must be writable after the escape"
+     );
+ }
++
++/// A consumer the producer lapped must resume, not sit on the gap forever.
++///
++/// The in-order MpscShm readers gated on the slot stamp equalling `tail + 1`
++/// and sent every other value into `claimed_slot_escape`. Two opposite states
++/// reach that gate: a stamp BEHIND `tail + 1` (claimed, not yet published —
++/// wait, and the escape bounds the wait if the producer died) and a stamp
++/// AHEAD of it (the slot was reused at a later position while this consumer
++/// still had not read it — the message is gone and no amount of waiting brings
++/// it back). Treating the second as the first advances one slot per
++/// `CLAIM_STALL_MAX_LEASES` x lease, 20 s apiece by default, so a lapped
++/// subscriber is stopped for as long as anyone watches.
++///
++/// Reproducing that needs a real lap, and a real lap needs the producer to
++/// overwrite unread slots — which backpressure forbids until keep-last-N
++/// decides nothing is draining, and that decision takes a whole lease of
++/// unmoved `tail` on a full ring. Hence the two lease settings: 50 ms to buy
++/// the reclaim quickly, then back to the 5 s default before the consumer polls
++/// again, so that `claimed_slot_escape` (4 leases, 20 s) CANNOT be what
++/// unwedges it inside the deadline below. Whatever delivers a message in the
++/// next two seconds is the lap branch or nothing.
++#[test]
++fn a_lapped_consumer_resumes_within_a_poll() {
++    const CAP: u32 = 16;
++    // Comfortably more than one lap past the ring, so the slot `rx` is parked
++    // on is certain to have been rewritten at a later position.
++    const BURST: u64 = 200;
++    let _guard = TIMING_LOCK.lock().unwrap();
++    let name = unique("lapped_resumes");
++
++    // Two handles, as in `a_mid_write_marker_is_not_a_lap`: `rx` only ever
++    // receives, so it registers as a pure consumer and its `recv` goes through
++    // `recv_shm_mpsc_pod` rather than the role=Both POD fast path, which never
++    // looks at a stamp.
++    let rx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("rx");
++    let tx: Topic<u64> = Topic::with_capacity(&name, CAP, None).expect("tx");
++    tx.send(u64::MAX);
++    let _ = rx.recv();
++    let migrated = tx.force_migrate(BackendMode::MpscShm);
++    assert!(
++        matches!(
++            migrated,
++            MigrationResult::Success { .. } | MigrationResult::NotNeeded
++        ),
++        "MpscShm is not conditionally compiled — horus_core declares no `shm` \
++         feature and nothing cfg-gates the backend out — so a refused \
++         migration ({migrated:?}) means a runtime that cannot back a ring with \
++         shared memory, not a build without one. Skipping on it would make this \
++         gate go quiet in exactly the state it is most needed."
++    );
++    assert_eq!(
++        tx.mode(),
++        BackendMode::MpscShm,
++        "the migration reported success but the topic is not on MpscShm"
++    );
++    trigger_shm_dispatch(&name);
++    while rx.try_recv().is_some() {}
++
++    let header = rx.ring.header();
++    assert!(
++        header.sub_count() >= 1,
++        "the lap only matters for a REGISTERED subscriber: with none, \
++         keep-last-N is free to retire slots and nothing is owed a message. \
++         sub_count is {}",
++        header.sub_count()
++    );
++
++    // Phase 1 — get the producer lapping. Fill the ring, then send once more
++    // to arm the stall detector (`drain_has_stalled` only ever runs from a
++    // failing send, and its first observation just records `tail` and the
++    // time), wait out the shortened lease, and burst.
++    header.set_lease_timeout_ms(50);
++    for i in 0..CAP as u64 {
++        tx.send(i);
++    }
++    tx.send(999);
++    thread::sleep(Duration::from_millis(120));
++    let missed_before = rx.missed_count();
++    for i in 0..BURST {
++        tx.send(1000 + i);
++    }
++
++    // Phase 2 — the consumer comes back. Restore the default lease first: at
++    // 50 ms the abandoned-claim escape fires every 200 ms and would crawl the
++    // consumer forward one slot at a time, which is the very behaviour this
++    // test exists to distinguish from a resume.
++    header.set_lease_timeout_ms(header::DEFAULT_LEASE_TIMEOUT_MS as u32);
++
++    let deadline = Instant::now() + Duration::from_secs(2);
++    let got = loop {
++        if let Some(v) = rx.try_recv() {
++            break v;
++        }
++        assert!(
++            Instant::now() < deadline,
++            "the consumer delivered nothing for 2 s after being lapped by \
++             {BURST} sends. The escape bound is 4 x 5 s here, so nothing else \
++             was going to move it: this is the wedge — a subscriber that is \
++             registered, alive and polling, on a topic whose producer is \
++             publishing, receiving nothing at all."
++        );
++        thread::sleep(Duration::from_millis(1));
++    };
++
++    assert!(
++        got >= 1000,
++        "a resumed consumer lands near the head and reads RECENT data; it \
++         returned {got}, which predates the burst"
++    );
++    let missed = rx.missed_count() - missed_before;
++    assert!(
++        missed >= CAP as u64,
++        "the skip is a real hole in this subscriber's stream and has to be \
++         counted: {BURST} messages were published past it and missed_count \
++         moved by {missed}"
++    );
++
++    // And it keeps going — a resume that delivered one message and then
++    // re-wedged would satisfy everything above. First drain what the resume
++    // landed on: half a lap back from the head leaves about `CAP / 2` slots of
++    // still-valid history in front of it.
++    let mut drained = 1u64; // the one taken above
++    while let Some(v) = rx.try_recv() {
++        assert!(
++            v >= 1000,
++            "everything from the resume point on belongs to the burst; got {v}"
++        );
++        drained += 1;
++    }
++    assert!(
++        drained >= (CAP / 4) as u64,
++        "the resume point is half a lap back from the head, so the consumer \
++         should have had roughly {} messages of valid history in front of it; \
++         it delivered {drained} and then stopped",
++        CAP / 2
++    );
++
++    // Then messages published AFTER the resume have to reach it too. The
++    // producer can only take a free slot, so this also witnesses that the
++    // resumed consumer flushed `header.tail` and gave the ring back its room.
++    let mut sent = 0u64;
++    for i in 0..CAP as u64 {
++        if tx.try_send(50_000 + i).is_ok() {
++            sent += 1;
++        }
++    }
++    assert!(
++        sent > 0,
++        "the ring stayed full after the consumer resumed and drained it, so \
++         the producer is still frozen out"
++    );
++    let mut fresh = 0u64;
++    let deadline = Instant::now() + Duration::from_secs(2);
++    while fresh < sent {
++        match rx.try_recv() {
++            Some(v) => {
++                assert!(v >= 50_000, "stale value {v} after the resume");
++                fresh += 1;
++            }
++            None => {
++                assert!(
++                    Instant::now() < deadline,
++                    "the consumer took {fresh} of the {sent} messages published \
++                     after it resumed and then stopped again"
++                );
++                thread::sleep(Duration::from_millis(1));
++            }
++        }
++    }
++}


### PR DESCRIPTION
Two defects on the same path, from an adversarial audit.

## 1. Keep-last-N destroyed accepted messages uncounted — verified

`send` is the lossy publish, so when nothing is draining a full ring it frees the oldest slot and takes it. That destroys a message the transport had already accepted.

`header.tail.fetch_max(..)` returns the tail it replaced, so `new - prev` is exactly how many were retired — and the return value was **discarded**.

`dropped_count()` moves only on an *abandoned* send, and a send that reclaims is a send that then **succeeds**. So this was the one path in the transport where HORUS itself throws away accepted messages with no counter recording it.

Counted into `send_failures` so `dropped_count()` stays the single publisher-side loss number a supervisor has to watch — a message retired to make room is lost to its subscriber either way.

**Gate** — `keep_last_n_reclaim_counts_what_it_retires`, 16-slot ring, 50 sends past full:

| | messages destroyed | `dropped_count()` delta |
|---|---|---|
| ablated | 50 | **0** |
| fixed | 50 | 50 |

## 2. A lapped consumer wedged instead of resuming — audit-verified, not reproduced by me

`recv_shm_mpsc_pod` and `recv_shm_mpsc_serde` gated on the slot stamp matching `tail + 1` *exactly*, and sent every mismatch into `claimed_slot_escape`.

But a mismatch has two opposite causes:

- stamp **behind** `tail + 1` — producer claimed the slot, hasn't published. Ordinary; wait.
- stamp **ahead** — the slot was reused at a later position while this consumer hadn't read it. It was **lapped**. The message is gone and never coming back.

`claimed_slot_escape` is the recovery for the first case. Applied to the second it advances one slot per `CLAIM_STALL_MAX_LEASES × lease` — **20 s by default** — and logs "claimed by a producer that never published it", when the producer published it and then lapped past.

`recv_shm_pod_broadcast` has always distinguished these. `resume_after_lap` gives the other two paths the same branch: land half a lap back from the head (for the reason that function already documents — the boundary slot is the one the producer overwrites next), and count the skip into `missed`.

## What I could not verify

**I could not build a local reproduction of the wedge.** I got the reclaim firing and confirmed the counting half by ablation, but every attempt to then observe a stalled subscriber being lapped ended with it delivering its queued messages normally and `missed == 0` — so the new branch is not exercised by any test I wrote.

The evidence that it is real is the audit's measurement, not mine: 16-slot ring, ~1 kHz producer, registered and live subscriber (`sub_count() == 1` asserted during the burst) paused for one lease — **12371 sent, 0 delivered, never recovered**.

I kept the change because it is small, guarded by `stamp > tail + 1` (a condition that today unconditionally takes the abandoned-claim path, so the guard can only improve on it), and mirrors code already proven on the broadcast path. **It should not be read as independently verified**, and I would rather say so than let the counting half's ablation imply both were nailed down.

## Verification

- Full `horus_core` lib suite: **2496 passed, 0 failed**
- `cargo clippy -p horus_core --lib` — clean
