### PR TITLE
docs(py): stop advertising DLPack and CUDA allocation that do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ HORUS is a real-time distributed middleware that replaces DDS with shared-memory
 | RT support  | Built-in (budget, deadline, watchdog)         | Manual DDS QoS                              |
 | Safety      | Graduated watchdog, safe-state hook, BlackBox | Application-level                           |
 | AI + RT     | Same process — AsyncIo for GPU, RT for motors | Separate processes                          |
-| GPU tensors | DLPack zero-copy (PyTorch/JAX native)         | Serialize → deserialize                     |
+| Tensors     | Pool-backed, zero-copy to NumPy (host memory)  | Serialize → deserialize                     |
 | Languages   | **Rust + Python + C++** (same shared memory)  | C++ + Python (DDS serialization)            |
 | Config      | Single `horus.toml`                           | package.xml + CMakeLists.txt + launch files |
 | Setup       | `horus new && horus run`                      | colcon build + source install + launch      |
@@ -304,14 +304,14 @@ Isolating or stopping a node is the graduated watchdog's job, above.
 
 ### Zero-Copy AI Pipeline
 
-Run camera → YOLO → tracking → motor control in one process. 4K frames stay in shared memory; DLPack hands GPU tensors directly to PyTorch.
+Run camera → YOLO → tracking → motor control in one process. 4K frames stay in shared memory and reach NumPy without a copy. Tensor memory is host-side: the pool allocator is mmap, so moving a frame to a GPU is still an explicit host→device copy that you make.
 
 ```python
 def detector_tick(node):
     frame = node.recv("camera")
     if frame is not None:
-        tensor = torch.from_dlpack(frame)        # zero-copy GPU transfer
-        for det in model(tensor):
+        array = frame.to_numpy()                 # zero-copy view of shared memory
+        for det in model(array):
             node.send("detections", horus.Detection(
                 x=det.x, y=det.y, width=det.w, height=det.h,
                 confidence=det.conf, class_name=det.label

--- a/horus_py/src/tensor.rs
+++ b/horus_py/src/tensor.rs
@@ -73,27 +73,29 @@ pub struct PyTensorPool {
 
 #[pymethods]
 impl PyTensorPool {
+    // Why this docstring is worded the way it is (maintainer note, kept out of
+    // the pydoc below because `help(horus.TensorPool)` is not the place for it):
+    //
+    // It used to promise that the pool "automatically selects the optimal memory
+    // backend based on detected GPU hardware", listing cudaMallocManaged for
+    // Jetson and cudaMallocHost for discrete GPUs. `pool_allocator()` in this
+    // file returns `PoolAllocator::Mmap` unconditionally, and `PoolAllocator`
+    // has exactly one variant, so no such selection existed or could occur. The
+    // claim mattered: someone sizing an inference pipeline would have believed
+    // their host->device copies were already pinned and DMA-capable, and planned
+    // around a property they did not have.
+    //
+    // `horus_core::memory::backend` defines an open `PoolBackend` trait whose
+    // `BackendAllocation` already carries a `device_ptr`, and correctly labels
+    // the CUDA backends as future and feature-gated. That is where a real device
+    // path would go, and where this note should be re-read before the docstring
+    // grows a hardware claim again.
     /// Create or open a tensor pool
     ///
-    /// Pool memory is host memory, allocated with mmap. It is shared between
-    /// processes without a copy and reaches NumPy without a copy, but it is not
-    /// device memory: moving a tensor to a GPU is an explicit host->device copy
-    /// that the caller makes.
-    ///
-    /// This docstring used to promise that the pool "automatically selects the
-    /// optimal memory backend based on detected GPU hardware", listing
-    /// cudaMallocManaged for Jetson and cudaMallocHost for discrete GPUs.
-    /// `pool_allocator()` in this file returns `PoolAllocator::Mmap`
-    /// unconditionally, and `PoolAllocator` has exactly one variant, so no such
-    /// selection existed or could occur. The claim mattered: someone sizing an
-    /// inference pipeline would have believed their host->device copies were
-    /// already pinned and DMA-capable, and planned around a property they did
-    /// not have.
-    ///
-    /// `horus_core::memory::backend` defines an open `PoolBackend` trait whose
-    /// `BackendAllocation` already carries a `device_ptr`, and correctly labels
-    /// the CUDA backends as future and feature-gated. That is where a real
-    /// device path would go.
+    /// Pool memory is host memory, allocated with mmap: shared between processes
+    /// without a copy, and readable from NumPy without a copy. It is not device
+    /// memory — moving a tensor to a GPU is an explicit host->device copy that
+    /// the caller makes.
     ///
     /// Args:
     ///     pool_id: Unique identifier for the pool (default: 1)

--- a/horus_py/src/tensor.rs
+++ b/horus_py/src/tensor.rs
@@ -19,17 +19,20 @@ lazy_static::lazy_static! {
     static ref POOL_REGISTRY: RwLock<HashMap<u32, Arc<TensorPool>>> = RwLock::new(HashMap::new());
 }
 
-/// Auto-detect the optimal pool allocator based on GPU hardware.
+/// The pool allocator for a tensor pool.
 ///
-/// Returns the pool allocator — currently always mmap.
-fn auto_allocator() -> horus::memory::PoolAllocator {
+/// Named "auto-detect" when it detected nothing: `PoolAllocator` has exactly
+/// one variant. Kept as a single named place to change if a device-backed
+/// allocator is ever added, but it does not choose, and callers should not be
+/// told it does.
+fn pool_allocator() -> horus::memory::PoolAllocator {
     horus::memory::PoolAllocator::Mmap
 }
 
 /// Get or create a tensor pool by ID.
 ///
-/// When `config` is `None`, auto-detects the optimal allocator based on GPU
-/// hardware — users get the best backend without opt-in.
+/// When `config` is `None`, the pool uses the default mmap-backed host
+/// allocator. There is no hardware-dependent selection.
 fn get_or_create_pool(pool_id: u32, config: Option<TensorPoolConfig>) -> PyResult<Arc<TensorPool>> {
     // Check if pool already exists
     {
@@ -39,9 +42,9 @@ fn get_or_create_pool(pool_id: u32, config: Option<TensorPoolConfig>) -> PyResul
         }
     }
 
-    // Create new pool with auto-detected allocator when no config specified
+    // Create new pool with the default host allocator when no config specified
     let config = config.unwrap_or_else(|| TensorPoolConfig {
-        allocator: auto_allocator(),
+        allocator: pool_allocator(),
         ..TensorPoolConfig::default()
     });
     let pool = TensorPool::new(pool_id, config).map_err(|e| {
@@ -72,11 +75,25 @@ pub struct PyTensorPool {
 impl PyTensorPool {
     /// Create or open a tensor pool
     ///
-    /// The pool automatically selects the optimal memory backend based on
-    /// detected GPU hardware:
-    ///   - Jetson: cudaMallocManaged (unified CPU+GPU memory)
-    ///   - Discrete GPU: cudaMallocHost (pinned, fast DMA)
-    ///   - No GPU: mmap (standard shared memory)
+    /// Pool memory is host memory, allocated with mmap. It is shared between
+    /// processes without a copy and reaches NumPy without a copy, but it is not
+    /// device memory: moving a tensor to a GPU is an explicit host->device copy
+    /// that the caller makes.
+    ///
+    /// This docstring used to promise that the pool "automatically selects the
+    /// optimal memory backend based on detected GPU hardware", listing
+    /// cudaMallocManaged for Jetson and cudaMallocHost for discrete GPUs.
+    /// `pool_allocator()` in this file returns `PoolAllocator::Mmap`
+    /// unconditionally, and `PoolAllocator` has exactly one variant, so no such
+    /// selection existed or could occur. The claim mattered: someone sizing an
+    /// inference pipeline would have believed their host->device copies were
+    /// already pinned and DMA-capable, and planned around a property they did
+    /// not have.
+    ///
+    /// `horus_core::memory::backend` defines an open `PoolBackend` trait whose
+    /// `BackendAllocation` already carries a `device_ptr`, and correctly labels
+    /// the CUDA backends as future and feature-gated. That is where a real
+    /// device path would go.
     ///
     /// Args:
     ///     pool_id: Unique identifier for the pool (default: 1)
@@ -92,7 +109,7 @@ impl PyTensorPool {
             pool_size: size_mb * 1024 * 1024,
             max_slots,
             slot_alignment: 64,
-            allocator: auto_allocator(),
+            allocator: pool_allocator(),
         };
         let pool = get_or_create_pool(pool_id, Some(config))?;
         Ok(Self { pool })
@@ -1223,7 +1240,7 @@ mod fpy1_tests {
             pool_size: 4096,
             max_slots: 8,
             slot_alignment: 64,
-            allocator: auto_allocator(),
+            allocator: pool_allocator(),
         };
         let pool =
             Arc::new(TensorPool::new(60_000_000 + std::process::id(), config).expect("pool"));

--- a/horus_py/tests/test_readme_claims_match_code.py
+++ b/horus_py/tests/test_readme_claims_match_code.py
@@ -35,22 +35,40 @@ def test_readme_exists_where_we_think_it_does():
     assert README.exists(), f"expected the README at {README}"
 
 
+# Types a README DLPack claim could be about. The comparison-table row was
+# generic ("DLPack zero-copy (PyTorch/JAX native)") and the example passed a
+# received frame, which is an Image — so the protocol landing on either type
+# makes the claim true, and requiring it on one of them would fail a correct
+# implementation of the other.
+DLPACK_CARRIERS = ("Image", "Tensor")
+
+
 def test_dlpack_is_claimed_only_if_implemented():
     """
     `torch.from_dlpack(x)` requires `x.__dlpack__`. If the README names DLPack
-    as a capability, the protocol has to be on the object users would pass.
+    as a capability, the protocol has to be on an object users would pass.
     """
-    text = readme_text().lower()
-    claims_dlpack = "dlpack" in text
+    mentions = [
+        f"README.md:{lineno}: {line.strip()}"
+        for lineno, line in enumerate(readme_text().splitlines(), 1)
+        if "dlpack" in line.lower()
+    ]
+    if not mentions:
+        return
 
-    tensor_has_dlpack = hasattr(horus.Tensor, "__dlpack__")
+    if any(
+        hasattr(getattr(horus, name, None), "__dlpack__") for name in DLPACK_CARRIERS
+    ):
+        return
 
-    if claims_dlpack and not tensor_has_dlpack:
-        pytest.fail(
-            "README mentions DLPack but horus.Tensor has no __dlpack__, so "
-            "torch.from_dlpack() cannot work. Either implement the protocol "
-            "(__dlpack__ and __dlpack_device__) or drop the claim."
-        )
+    pytest.fail(
+        "README mentions DLPack but neither "
+        + " nor ".join(f"horus.{name}" for name in DLPACK_CARRIERS)
+        + " has __dlpack__, so torch.from_dlpack() cannot work on either. "
+        "Implement the protocol (__dlpack__ and __dlpack_device__) on the type "
+        "the text is about, or drop the claim. Lines that mention it:\n  "
+        + "\n  ".join(mentions)
+    )
 
 
 def test_gpu_memory_is_claimed_only_if_a_device_allocator_exists():
@@ -58,23 +76,25 @@ def test_gpu_memory_is_claimed_only_if_a_device_allocator_exists():
     The tensor pool is mmap-backed host memory. If the README starts promising
     device-resident tensors again, something has to be able to allocate them.
 
-    `PoolAllocator` has exactly one variant (Mmap) and `auto_allocator()` was
-    hardcoded to it while the Python docstring advertised cudaMallocManaged and
-    cudaMallocHost by name.
+    `PoolAllocator` has exactly one variant (Mmap) and `pool_allocator()` in
+    horus_py/src/tensor.rs is hardcoded to it, while the Python docstring used
+    to advertise cudaMallocManaged and cudaMallocHost by name.
     """
     text = readme_text()
-    promises_device_alloc = any(
-        marker in text
+    named = [
+        marker
         for marker in ("cudaMallocManaged", "cudaMallocHost", "cudaMalloc(")
-    )
-    if not promises_device_alloc:
+        if marker in text
+    ]
+    if not named:
         return
 
-    pool = horus.TensorPool(pool_id=9931, size_mb=1, max_slots=4)
-    t = pool.alloc([2, 2], "float32")
-    assert t is not None
+    # No allocation here on purpose: a pool proves nothing about device memory
+    # (it is mmap either way), and building one to throw away leaves a registry
+    # entry and a shared-memory file behind for a test that has already decided.
     pytest.fail(
-        "README names a CUDA allocator, but the pool allocator is mmap. "
+        f"README names a CUDA allocator ({', '.join(named)}), but pools are "
+        "built with PoolAllocator::Mmap and that enum has exactly one variant. "
         "Either add a device-backed PoolBackend or drop the claim."
     )
 

--- a/horus_py/tests/test_readme_claims_match_code.py
+++ b/horus_py/tests/test_readme_claims_match_code.py
@@ -1,0 +1,102 @@
+"""
+Capabilities the README names must exist in the built extension.
+
+The README advertised "DLPack zero-copy (PyTorch/JAX native)" in the comparison
+table and showed `torch.from_dlpack(frame)` in the AI-pipeline example. Nothing
+in horus_py implements the DLPack protocol: `grep -rn __dlpack__ horus_py`
+returns nothing, and `horus.Tensor` exposes no dlpack attribute. The claim was
+load-bearing for exactly the users it was aimed at — someone choosing a runtime
+for a GPU inference pipeline reads that row and plans around it.
+
+Documentation drifts from code silently because nothing executes it. These tests
+execute it. They are deliberately narrow: each one names a claim, finds it in the
+README, and asserts the corresponding capability is actually reachable from the
+built module. Adding the capability makes the test pass; removing the claim makes
+it pass; leaving them inconsistent fails.
+"""
+from pathlib import Path
+
+import pytest
+
+import horus
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+
+
+def readme_text() -> str:
+    if not README.exists():
+        pytest.skip(f"README not found at {README}")
+    return README.read_text(encoding="utf-8")
+
+
+def test_readme_exists_where_we_think_it_does():
+    """Guard the path: a skip that is really a missing file proves nothing."""
+    assert README.exists(), f"expected the README at {README}"
+
+
+def test_dlpack_is_claimed_only_if_implemented():
+    """
+    `torch.from_dlpack(x)` requires `x.__dlpack__`. If the README names DLPack
+    as a capability, the protocol has to be on the object users would pass.
+    """
+    text = readme_text().lower()
+    claims_dlpack = "dlpack" in text
+
+    tensor_has_dlpack = hasattr(horus.Tensor, "__dlpack__")
+
+    if claims_dlpack and not tensor_has_dlpack:
+        pytest.fail(
+            "README mentions DLPack but horus.Tensor has no __dlpack__, so "
+            "torch.from_dlpack() cannot work. Either implement the protocol "
+            "(__dlpack__ and __dlpack_device__) or drop the claim."
+        )
+
+
+def test_gpu_memory_is_claimed_only_if_a_device_allocator_exists():
+    """
+    The tensor pool is mmap-backed host memory. If the README starts promising
+    device-resident tensors again, something has to be able to allocate them.
+
+    `PoolAllocator` has exactly one variant (Mmap) and `auto_allocator()` was
+    hardcoded to it while the Python docstring advertised cudaMallocManaged and
+    cudaMallocHost by name.
+    """
+    text = readme_text()
+    promises_device_alloc = any(
+        marker in text
+        for marker in ("cudaMallocManaged", "cudaMallocHost", "cudaMalloc(")
+    )
+    if not promises_device_alloc:
+        return
+
+    pool = horus.TensorPool(pool_id=9931, size_mb=1, max_slots=4)
+    t = pool.alloc([2, 2], "float32")
+    assert t is not None
+    pytest.fail(
+        "README names a CUDA allocator, but the pool allocator is mmap. "
+        "Either add a device-backed PoolBackend or drop the claim."
+    )
+
+
+def test_advertised_numpy_path_actually_works():
+    """
+    The AI-pipeline example now shows `frame.to_numpy()`. That call has to exist
+    and round-trip, or the replacement claim is as false as the one it replaced.
+    """
+    import numpy as np
+
+    img = horus.Image.from_numpy(np.zeros((4, 4, 3), dtype="uint8"))
+    arr = img.to_numpy()
+    assert arr.shape == (4, 4, 3)
+    assert arr.dtype == np.uint8
+
+
+def test_tensor_numpy_round_trip_is_exact():
+    """The zero-copy claim in the same paragraph, on the Tensor path."""
+    import numpy as np
+
+    src = np.arange(6, dtype="float32").reshape(2, 3)
+    t = horus.Tensor.from_numpy(src)
+    back = t.numpy()
+    np.testing.assert_array_equal(back, src)


### PR DESCRIPTION
Two user-facing claims promised capabilities absent from the code, both aimed at
exactly the people most likely to act on them.

## DLPack

The comparison table against ROS 2 claimed **"DLPack zero-copy (PyTorch/JAX
native)"**, and the AI-pipeline example showed:

```python
tensor = torch.from_dlpack(frame)        # zero-copy GPU transfer
```

`torch.from_dlpack(x)` requires `x.__dlpack__`. `grep -rn __dlpack__ horus_py`
returns nothing, and `horus.Tensor` exposes no dlpack attribute — verified
against the **built extension**, not just the source. `horus_core/src/types/dtype.rs`
does map DLPack *type codes*, which is presumably where the claim came from, but
type codes are not the capsule protocol and nothing exports one.

The example now uses `frame.to_numpy()`, verified against the built module.
`Image` exposes `to_numpy`, not `numpy` — I got that wrong on the first pass and
caught it before it shipped. Replacing one false claim with another would have
been worse than leaving it alone.

## CUDA allocation

`PyTensorPool::new`'s docstring — the pydoc a Python user actually reads — said
the pool *"automatically selects the optimal memory backend based on detected
GPU hardware"*, naming `cudaMallocManaged` for Jetson and `cudaMallocHost` for
discrete GPUs.

```rust
fn auto_allocator() -> PoolAllocator {
    PoolAllocator::Mmap        // ← unconditional
}
```

`PoolAllocator` has **exactly one variant**. No such selection existed or could
occur. The function's own comment said "currently always mmap", contradicting
the public docstring 45 lines below it.

This one had teeth: someone sizing an inference pipeline would have believed
their host→device copies were already pinned and DMA-capable, and planned around
a property they did not have. Renamed to `pool_allocator()` — a function called
`auto_allocator` that detects nothing is how the docstring got written in the
first place.

**`horus_core::memory::backend` is deliberately untouched.** It labels the CUDA
backends "Future backends (feature-gated)", implements only `MmapBackend`, and
its `BackendAllocation` already carries a `device_ptr`. That is honest, and it is
where a real device path would go.

## Keeping it honest

Docs drift from code silently because nothing executes them. Five tests now do,
in `horus_py/tests/` — which #126 wired into CI, so they actually run.

Each names a claim, locates it in the README, and asserts the capability is
reachable from the built extension:

- implement the capability → passes
- drop the claim → passes
- leave them inconsistent → **fails**

Verified by ablation: re-adding "DLPack" to the README fails
`test_dlpack_is_claimed_only_if_implemented` with the reason spelled out.

447 Python tests pass.