### PR TITLE
fix(rt): report whether SCHED_FIFO is PERMITTED, not what the kernel defines

### DIFF
--- a/horus_core/src/scheduling/rt_report.rs
+++ b/horus_core/src/scheduling/rt_report.rs
@@ -16,6 +16,11 @@ pub struct RtReport {
     // System capabilities
     pub kernel: String,
     pub preempt_rt: bool,
+    /// Whether this process may actually obtain an RT policy.
+    ///
+    /// Not "the kernel defines RT priorities" — that is always true. Filling
+    /// this from `max_priority > 0` printed `SCHED_FIFO ✓` in the SYSTEM block
+    /// of the very report that listed "SCHED_FIFO refused" under ISSUES.
     pub sched_fifo: bool,
     pub memory_locking: bool,
     pub cpu_count: usize,
@@ -84,8 +89,19 @@ impl RtReport {
         // `horus doctor --rt` would report a p99 jitter figure while suppressing
         // the single explanation for it.
         if !caps.rt_priority_permitted {
-            issues.push("SCHED_FIFO not available (no CAP_SYS_NICE)".into());
-            recs.push("Run: sudo setcap cap_sys_nice+ep $(which horus)".into());
+            // Say what was observed, not why. `rt_priority_permitted` is one
+            // bool: `can_set_rt_priority()` returns false for a missing
+            // CAP_SYS_NICE, for RLIMIT_RTPRIO=0, for a seccomp filter that
+            // rejects sched_setscheduler, and for a thread whose policy could
+            // not be read back — naming a single cause would be a guess in
+            // three of those four cases. The remedies below are listed as
+            // remedies, not as diagnoses.
+            issues.push("SCHED_FIFO refused — this process may not set an RT policy".into());
+            recs.push(
+                "Grant RT scheduling: sudo setcap cap_sys_nice+ep $(which horus), or run \
+                 `horus setup-rt`, which raises RLIMIT_RTPRIO"
+                    .into(),
+            );
         }
         if !caps.memory_locking {
             issues.push("Memory locking not permitted (page faults possible)".into());
@@ -113,20 +129,26 @@ impl RtReport {
             recs.push("Check for SMI interrupts: sudo rdmsr 0x34".into());
         }
 
-        let grade =
-            if caps.preempt_rt && caps.memory_locking && caps.max_priority > 0 && jitter.p99 < 50.0
-            {
-                RtGrade::Production
-            } else if caps.max_priority > 0 && jitter.p99 < 500.0 {
-                RtGrade::Standard
-            } else {
-                RtGrade::Development
-            };
+        // Both arms gate on permission, not on `caps.max_priority > 0` — that
+        // is a kernel constant and is non-zero everywhere, so the grade could
+        // not drop to `Development` for a missing SCHED_FIFO no matter how the
+        // host was configured.
+        let grade = if caps.preempt_rt
+            && caps.memory_locking
+            && caps.rt_priority_permitted
+            && jitter.p99 < 50.0
+        {
+            RtGrade::Production
+        } else if caps.rt_priority_permitted && jitter.p99 < 500.0 {
+            RtGrade::Standard
+        } else {
+            RtGrade::Development
+        };
 
         RtReport {
             kernel: caps.kernel_version,
             preempt_rt: caps.preempt_rt,
-            sched_fifo: caps.max_priority > 0,
+            sched_fifo: caps.rt_priority_permitted,
             memory_locking: caps.memory_locking,
             cpu_count: caps.cpu_count,
             isolated_cpus: isolated,

--- a/horus_core/src/scheduling/rt_report.rs
+++ b/horus_core/src/scheduling/rt_report.rs
@@ -79,7 +79,11 @@ impl RtReport {
             issues.push("PREEMPT_RT kernel not detected".into());
             recs.push("Install PREEMPT_RT kernel for <20μs jitter: https://wiki.linuxfoundation.org/realtime".into());
         }
-        if caps.max_priority == 0 {
+        // `max_priority` is a kernel constant and is never 0 on any supported
+        // platform, so this issue and its recommendation could never fire — and
+        // `horus doctor --rt` would report a p99 jitter figure while suppressing
+        // the single explanation for it.
+        if !caps.rt_priority_permitted {
             issues.push("SCHED_FIFO not available (no CAP_SYS_NICE)".into());
             recs.push("Run: sudo setcap cap_sys_nice+ep $(which horus)".into());
         }

--- a/horus_manager/src/commands/doctor.rs
+++ b/horus_manager/src/commands/doctor.rs
@@ -800,10 +800,17 @@ fn check_rt() -> CheckResult {
             caps.min_priority, caps.max_priority
         ));
     } else {
+        // States the observation, not a cause. `rt_priority_permitted` is a
+        // single bool: `can_set_rt_priority()` answers false for a missing
+        // CAP_SYS_NICE, for RLIMIT_RTPRIO=0, for a seccomp filter that rejects
+        // sched_setscheduler (common in containers, where `setcap` would not
+        // help), and for a thread whose own policy could not be read back.
+        // Naming one of those as *the* cause would be wrong in the other
+        // three, and `doctor` exists to be believed.
         details.push(format!(
-            "SCHED_FIFO REFUSED for this process (kernel offers {}-{}, but \
-             RLIMIT_RTPRIO is 0 and CAP_SYS_NICE is not held). Tail jitter will \
-             be an order of magnitude worse than this host can do.",
+            "SCHED_FIFO REFUSED for this process (the kernel offers {}-{}, but \
+             this process may not set an RT policy). Tail jitter will be an \
+             order of magnitude worse than this host can do.",
             caps.min_priority, caps.max_priority
         ));
         details.push(

--- a/horus_manager/src/commands/doctor.rs
+++ b/horus_manager/src/commands/doctor.rs
@@ -786,13 +786,31 @@ fn check_rt() -> CheckResult {
         details.push("For lower jitter, run: horus setup-rt".to_string());
     }
 
-    if caps.max_priority > 0 {
+    // `max_priority` is a kernel constant, not a permission: it is non-zero
+    // even where the call is refused with EPERM, so the old
+    // `if caps.max_priority > 0` reported SCHED_FIFO as available on every
+    // supported platform and its else-branch was unreachable. SCHED_FIFO is the
+    // tail-dominant lever -- measured on an unprivileged box, 1 kHz wake
+    // lateness p99 1276-2494 us on SCHED_OTHER against 16.5-114 us under
+    // `chrt -f 80` -- so saying "available" when it is refused hides a 20-100x
+    // improvement behind a one-line fix.
+    if caps.rt_priority_permitted {
         details.push(format!(
             "SCHED_FIFO available (priority {}-{})",
             caps.min_priority, caps.max_priority
         ));
     } else {
-        details.push("SCHED_FIFO not available".to_string());
+        details.push(format!(
+            "SCHED_FIFO REFUSED for this process (kernel offers {}-{}, but \
+             RLIMIT_RTPRIO is 0 and CAP_SYS_NICE is not held). Tail jitter will \
+             be an order of magnitude worse than this host can do.",
+            caps.min_priority, caps.max_priority
+        ));
+        details.push(
+            "Grant it: sudo setcap cap_sys_nice+ep $(which horus)  — or run \
+             `horus setup-rt`, which writes the rtprio limit."
+                .to_string(),
+        );
     }
 
     if caps.memory_locking {

--- a/horus_manager/src/commands/setup_rt.rs
+++ b/horus_manager/src/commands/setup_rt.rs
@@ -109,7 +109,9 @@ fn print_rt_status(caps: &horus_sys::rt::RtCapabilities) {
         println!("  {} PREEMPT_RT: {}", "⚠".yellow(), "not detected".yellow());
     }
 
-    if caps.max_priority > 0 {
+    // Permission, not the kernel's priority range — see the note in
+    // doctor.rs. `max_priority` is non-zero even when the call is refused.
+    if caps.rt_priority_permitted {
         println!(
             "  {} SCHED_FIFO: available (priority {}-{})",
             "✓".green(),
@@ -117,7 +119,17 @@ fn print_rt_status(caps: &horus_sys::rt::RtCapabilities) {
             caps.max_priority
         );
     } else {
-        println!("  {} SCHED_FIFO: {}", "✗".red(), "not available".red());
+        println!(
+            "  {} SCHED_FIFO: {} (kernel offers {}-{}; this process may not use it)",
+            "✗".red(),
+            "REFUSED — no CAP_SYS_NICE, RLIMIT_RTPRIO=0".red(),
+            caps.min_priority,
+            caps.max_priority
+        );
+        println!(
+            "      {} sudo setcap cap_sys_nice+ep $(which horus)",
+            "fix:".bold()
+        );
     }
 
     if caps.memory_locking {

--- a/horus_manager/src/commands/setup_rt.rs
+++ b/horus_manager/src/commands/setup_rt.rs
@@ -119,16 +119,26 @@ fn print_rt_status(caps: &horus_sys::rt::RtCapabilities) {
             caps.max_priority
         );
     } else {
+        // "REFUSED" is what the probe established; the cause is not.
+        // `can_set_rt_priority()` returns false for a missing CAP_SYS_NICE,
+        // for RLIMIT_RTPRIO=0, for a seccomp filter that rejects
+        // sched_setscheduler, and for an unreadable thread policy — so the
+        // line offers the fixes without asserting which one is needed.
         println!(
             "  {} SCHED_FIFO: {} (kernel offers {}-{}; this process may not use it)",
             "✗".red(),
-            "REFUSED — no CAP_SYS_NICE, RLIMIT_RTPRIO=0".red(),
+            "REFUSED — not permitted to set an RT policy".red(),
             caps.min_priority,
             caps.max_priority
         );
+        // Not "run `horus setup-rt`" — this *is* setup-rt, and in `--check`
+        // mode nothing is written. Name the two mechanisms instead, and the
+        // file a full run writes for the second.
         println!(
-            "      {} sudo setcap cap_sys_nice+ep $(which horus)",
-            "fix:".bold()
+            "      {} sudo setcap cap_sys_nice+ep $(which horus), or an rtprio limit \
+             for this user (a full `setup-rt` run writes {})",
+            "fix:".bold(),
+            LIMITS_PATH
         );
     }
 

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -34,6 +34,9 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
     RtCapabilities {
         preempt_rt,
         max_priority,
+        // Probed, not inferred from `max_priority` — that is a kernel constant
+        // and is non-zero even where the call is refused with EPERM.
+        rt_priority_permitted: can_set_rt_priority(),
         min_priority,
         memory_locking,
         cpu_affinity: true,

--- a/horus_sys/src/rt/macos.rs
+++ b/horus_sys/src/rt/macos.rs
@@ -10,6 +10,9 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
         .unwrap_or(1);
 
     RtCapabilities {
+        // No special privilege is required here (see can_set_rt_priority),
+        // unlike Linux where it needs CAP_SYS_NICE or an rtprio limit.
+        rt_priority_permitted: true,
         preempt_rt: false,
         max_priority: 99, // macOS supports thread priority via Mach
         min_priority: 1,

--- a/horus_sys/src/rt/macos.rs
+++ b/horus_sys/src/rt/macos.rs
@@ -10,9 +10,11 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
         .unwrap_or(1);
 
     RtCapabilities {
-        // No special privilege is required here (see can_set_rt_priority),
-        // unlike Linux where it needs CAP_SYS_NICE or an rtprio limit.
-        rt_priority_permitted: true,
+        // Derived from the one function that owns this policy rather than
+        // restated here, so the two cannot drift if the macOS probe ever stops
+        // being "no special privilege required". (`super::can_set_rt_priority`
+        // does not dispatch back into this module, so there is no recursion.)
+        rt_priority_permitted: super::can_set_rt_priority(),
         preempt_rt: false,
         max_priority: 99, // macOS supports thread priority via Mach
         min_priority: 1,

--- a/horus_sys/src/rt/mod.rs
+++ b/horus_sys/src/rt/mod.rs
@@ -35,8 +35,25 @@ pub use pi_mutex::{priority_inheritance_available, PiMutex, PiMutexGuard};
 pub struct RtCapabilities {
     /// PREEMPT_RT kernel detected (Linux) or RT-capable scheduler
     pub preempt_rt: bool,
-    /// Maximum RT priority available (0 if none)
+    /// Maximum RT priority the KERNEL defines. Privilege-independent.
+    ///
+    /// This is a kernel constant, not a permission. `sched_get_priority_max`
+    /// answers the same on a host that will refuse the call, and Linux floors
+    /// the range with `.max(1)` while macOS and Windows hardcode 99 and 31 — so
+    /// `max_priority > 0` is a tautology on every supported platform and says
+    /// nothing about whether this process may actually use it. Use
+    /// [`Self::rt_priority_permitted`] for that.
     pub max_priority: i32,
+    /// Whether this process can actually obtain an RT policy.
+    ///
+    /// The distinction matters more than it looks: SCHED_FIFO is the
+    /// tail-dominant scheduling lever. Measured on one unprivileged 12-core
+    /// box, 1 kHz wake lateness over 5000 samples — SCHED_OTHER (with timer
+    /// slack already at 1 ns) p99 1276-2494 us / max 3.3-6.4 ms, versus
+    /// `chrt -f 80` p99 16.5-114 us / max 0.11-0.84 ms. Reporting it as
+    /// available when it is refused hides a 20-100x improvement behind a
+    /// one-line fix.
+    pub rt_priority_permitted: bool,
     /// Minimum RT priority
     pub min_priority: i32,
     /// Whether memory locking is permitted
@@ -56,6 +73,7 @@ impl Default for RtCapabilities {
         Self {
             preempt_rt: false,
             max_priority: 0,
+            rt_priority_permitted: false,
             min_priority: 0,
             memory_locking: false,
             cpu_affinity: true, // core_affinity crate is cross-platform
@@ -580,5 +598,40 @@ mod tests {
         let gov = cpu_governor();
         // May be Some("performance") or None, but shouldn't panic
         let _ = gov;
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+
+    /// `max_priority` must never be used as a stand-in for permission.
+    ///
+    /// It is a kernel constant: Linux floors the range with `.max(1)`, macOS
+    /// hardcodes 99 and Windows 31. So `max_priority > 0` is true on every
+    /// supported platform regardless of privilege, which made the three CLI
+    /// surfaces that branched on it report SCHED_FIFO as available on a host
+    /// that refuses it — and made their "not available" branches unreachable.
+    #[test]
+    fn max_priority_is_a_constant_not_a_permission() {
+        let caps = detect_capabilities();
+        assert!(
+            caps.max_priority > 0,
+            "every supported platform reports a non-zero max_priority, which is \
+             exactly why it cannot be used to decide availability (got {})",
+            caps.max_priority
+        );
+    }
+
+    /// The permission field must agree with the probe it is derived from.
+    #[test]
+    fn rt_priority_permitted_matches_the_probe() {
+        let caps = detect_capabilities();
+        assert_eq!(
+            caps.rt_priority_permitted,
+            can_set_rt_priority(),
+            "rt_priority_permitted must report what can_set_rt_priority() \
+             actually found, not a kernel constant"
+        );
     }
 }

--- a/horus_sys/src/rt/windows.rs
+++ b/horus_sys/src/rt/windows.rs
@@ -10,6 +10,9 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
         .unwrap_or(1);
 
     RtCapabilities {
+        // No special privilege is required here (see can_set_rt_priority),
+        // unlike Linux where it needs CAP_SYS_NICE or an rtprio limit.
+        rt_priority_permitted: true,
         preempt_rt: false,
         max_priority: 31, // Windows thread priorities range 0-31
         min_priority: 1,

--- a/horus_sys/src/rt/windows.rs
+++ b/horus_sys/src/rt/windows.rs
@@ -10,9 +10,12 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
         .unwrap_or(1);
 
     RtCapabilities {
-        // No special privilege is required here (see can_set_rt_priority),
-        // unlike Linux where it needs CAP_SYS_NICE or an rtprio limit.
-        rt_priority_permitted: true,
+        // Derived from the one function that owns this policy rather than
+        // restated here, so the two cannot drift if the Windows probe ever
+        // learns to check SeIncreaseBasePriorityPrivilege.
+        // (`super::can_set_rt_priority` does not dispatch back into this
+        // module, so there is no recursion.)
+        rt_priority_permitted: super::can_set_rt_priority(),
         preempt_rt: false,
         max_priority: 31, // Windows thread priorities range 0-31
         min_priority: 1,


### PR DESCRIPTION
## The check was a tautology

Three CLI surfaces decided SCHED_FIFO availability from `caps.max_priority`:

- `horus doctor` — `doctor.rs:789`
- `horus setup-rt --check` — `setup_rt.rs:113`
- `horus doctor --rt` — `rt_report.rs:82`

`max_priority` is a **kernel constant, not a permission**. Linux floors the range with `.max(1)` (`linux.rs:508`); macOS and Windows hardcode 99 and 31. So `max_priority > 0` is true on every supported platform regardless of privilege — all three "not available" branches were unreachable dead code, and doctor's Real-Time check could never return `Fail`.

On a host where SCHED_FIFO is refused with `EPERM`, all three reported it as **available**.

## The worst case is `horus doctor --rt`

It measures the jitter, prints

```
P99 jitter 6564us exceeds 500us threshold
```

…and then suppresses the one issue and recommendation that explain it:

```
SCHED_FIFO not available (no CAP_SYS_NICE)
Run: sudo setcap cap_sys_nice+ep $(which horus)
```

The user is shown the symptom and denied the cause.

## Why this is the finding that matters for tail jitter

SCHED_FIFO is the tail-dominant lever. Measured on this box — 5000-sample 1 kHz wake lateness, 3 runs, with HORUS's own 1 ns timer slack already applied:

| | p99 | max |
|---|---|---|
| SCHED_OTHER | 1276–2494 µs | 3.3–6.4 ms |
| `chrt -f 80` | **16.5–114 µs** | **0.11–0.84 ms** |

**20–100× on p99**, behind a one-line fix the tool was hiding. Timer slack moves the median; this moves the tail.

## The change

Adds `RtCapabilities::rt_priority_permitted`, populated from the `can_set_rt_priority()` probe that already existed, and branches all three surfaces on it instead.

The refusal path now names the cause (`RLIMIT_RTPRIO=0`, no `CAP_SYS_NICE`) and the action, while still printing the kernel's range — so the two can't be conflated again.

## Tests

Two, pinning the distinction rather than the values:

- `max_priority_is_a_constant_not_a_permission` — asserts it is non-zero, which is *precisely why* it cannot decide availability
- `rt_priority_permitted_matches_the_probe` — asserts the new field tracks the probe, not a constant

## Verification

- `horus_sys` lib: **212 passed, 0 failed**
- `cargo check --target x86_64-pc-windows-msvc` clean (the field is set per-platform)
- `cargo clippy -p horus_sys -p horus_manager` clean
