### PR TITLE
perf(rt): drop timer slack to 1ns on the RT thread

### DIFF
--- a/horus_core/src/core/rt_config.rs
+++ b/horus_core/src/core/rt_config.rs
@@ -228,6 +228,38 @@ impl RtConfig {
             }
         }
 
+        // Drop timer slack to 1 ns.
+        //
+        // Linux gives every thread 50 us of slack by default and may delay any
+        // timed wait by up to that much. The RT executor sleeps to an absolute
+        // deadline with `clock_nanosleep(TIMER_ABSTIME)` and then guard-spins
+        // the last stretch, so 50 us of slack does not just add 50 us -- it
+        // overshoots the point where the guard spin was supposed to take over,
+        // and the spin cannot recover time already lost.
+        //
+        // The kernel gives SCHED_FIFO/RR threads zero slack already, so this is
+        // a no-op once the priority request below succeeds. It is aimed at the
+        // case where that request FAILS -- CAP_SYS_NICE is not granted to a
+        // plain `cargo test`, an unprivileged container, or a dev box -- and
+        // HORUS deliberately continues at normal priority. That fallback path
+        // is the one most users are actually on.
+        //
+        // Measured, 3000 iterations of a 1 kHz absolute-deadline sleep loop,
+        // wake lateness: p50 55.8 us -> 4.3 us, p90 63.8 us -> 16.7 us.
+        if has_rt_features {
+            if let Err(e) = horus_sys::rt::set_timer_slack(1) {
+                // Not a degradation entry: slack is an optimisation, and a
+                // kernel without PR_SET_TIMERSLACK still schedules correctly.
+                if self.warn_on_degradation {
+                    crate::terminal::print_line(&format!(
+                        "Warning: could not reduce timer slack ({}). Timed waits \
+                         may be delayed by the kernel default (typically 50us).",
+                        e
+                    ));
+                }
+            }
+        }
+
         // Apply memory locking via horus_sys
         if self.memory_locked {
             if let Err(e) = horus_sys::rt::lock_memory() {

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -1645,6 +1645,33 @@ impl RtExecutor {
             }
         }
 
+        // Drop timer slack, and do it HERE rather than wherever the process
+        // configured itself, because PR_SET_TIMERSLACK is PER-THREAD. Setting
+        // it on the thread that built the scheduler does nothing for this one.
+        //
+        // Linux hands every thread 50 us of slack by default and may delay any
+        // timed wait by up to that much. `CyclicWaiter` below sleeps to an
+        // absolute deadline and then guard-spins the last stretch of the
+        // period; the guard is a fraction of the period (20 us at 1 kHz), so
+        // 50 us of slack overshoots the point the spin was meant to take over
+        // and the spin cannot recover time already gone.
+        //
+        // The kernel gives SCHED_FIFO/RR threads zero slack, so when
+        // `rt_policy_active` is true this changes nothing. It is for the branch
+        // directly above, where the priority request was refused for want of
+        // CAP_SYS_NICE and the thread stayed SCHED_OTHER -- a plain
+        // `cargo test`, an unprivileged container, most developer machines.
+        if !rt_policy_active {
+            if let Err(e) = horus_sys::rt::set_timer_slack(1) {
+                if monitors.verbose {
+                    print_line(&format!(
+                        "[RT-thread] Could not reduce timer slack: {e} (timed waits \
+                         may be delayed by the kernel default, typically 50us)"
+                    ));
+                }
+            }
+        }
+
         // `rt_cpus` arrives already resolved: `start_pool` applied the `.core(n)`
         // override and the round-robin assignment together, because only it can
         // see every chain at once and therefore only it can detect two chains

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -47,6 +47,51 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
     }
 }
 
+/// Set this thread's timer slack, in nanoseconds.
+///
+/// Linux gives every thread 50 us of timer slack by default (see
+/// `/proc/self/timerslack_ns`). The kernel is then free to delay any
+/// `nanosleep`, `clock_nanosleep`, `futex` timeout or poll wake by up to that
+/// much, so it can batch wakeups and save power. For a periodic control loop
+/// that is a 50 us error added to every single wake.
+///
+/// It applies to SCHED_OTHER threads. A SCHED_FIFO/RR thread already gets zero
+/// slack from the kernel, so this call is a no-op for a fully privileged RT
+/// deployment -- and exactly what is needed for the one that could not get
+/// SCHED_FIFO, which is the common case (it needs CAP_SYS_NICE, and a plain
+/// `cargo test` or an unprivileged container does not have it). HORUS
+/// deliberately continues at normal priority when that happens, and this is
+/// what makes that fallback behave.
+///
+/// Measured on an idle 12-core box, 3000 iterations of a 1 kHz
+/// `clock_nanosleep(TIMER_ABSTIME)` loop, wake lateness:
+///
+/// ```text
+///   50000 ns slack (default):  p50 55.8 us   p90 63.8 us   p99 101-271 us
+///       1 ns slack:            p50  4.3 us   p90 16.7 us   p99  25-116 us
+/// ```
+pub(super) fn set_timer_slack(nanoseconds: u64) -> anyhow::Result<()> {
+    // SAFETY: PR_SET_TIMERSLACK takes a single unsigned long argument and
+    // affects only the calling thread. A value of 0 means "restore the
+    // default", which is why the caller is expected to pass >= 1.
+    let result = unsafe { libc::prctl(libc::PR_SET_TIMERSLACK, nanoseconds as libc::c_ulong) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+            .map_err(|e| anyhow::anyhow!("prctl(PR_SET_TIMERSLACK, {}) failed: {}", nanoseconds, e))
+    }
+}
+
+/// This thread's current timer slack in nanoseconds, if it can be read.
+pub(super) fn timer_slack_ns() -> Option<u64> {
+    std::fs::read_to_string("/proc/self/timerslack_ns")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
 /// Set SCHED_FIFO priority for the current thread.
 pub(super) fn set_realtime_priority(priority: i32) -> anyhow::Result<()> {
     // SAFETY: pid 0 = current thread; sched_param is properly initialized

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -49,11 +49,19 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
 
 /// Set this thread's timer slack, in nanoseconds.
 ///
-/// Linux gives every thread 50 us of timer slack by default (see
-/// `/proc/self/timerslack_ns`). The kernel is then free to delay any
-/// `nanosleep`, `clock_nanosleep`, `futex` timeout or poll wake by up to that
-/// much, so it can batch wakeups and save power. For a periodic control loop
-/// that is a 50 us error added to every single wake.
+/// A thread starts with 50 us of timer slack: 50000 ns is the value the kernel
+/// gives `init_task`, and every task inherits its parent's current slack as its
+/// own default across both fork and exec, so 50 us is what anything launched
+/// from an ordinary shell begins with. It is inherited rather than fixed, so a
+/// process started under something that had already lowered its own slack
+/// starts lower. The kernel is then free to delay any `nanosleep`,
+/// `clock_nanosleep`, `futex` timeout or poll wake by up to that much, so it can
+/// batch wakeups and save power. For a periodic control loop that is a 50 us
+/// error added to every single wake.
+///
+/// `nanoseconds` of 0 is not "no slack": the kernel reads a non-positive
+/// argument as "restore this thread's inherited default" and puts the 50 us
+/// back. That is why the callers in this workspace pass 1.
 ///
 /// It applies to SCHED_OTHER threads. A SCHED_FIFO/RR thread already gets zero
 /// slack from the kernel, so this call is a no-op for a fully privileged RT
@@ -71,10 +79,22 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
 ///       1 ns slack:            p50  4.3 us   p90 16.7 us   p99  25-116 us
 /// ```
 pub(super) fn set_timer_slack(nanoseconds: u64) -> anyhow::Result<()> {
+    // The prctl argument is an `unsigned long`, which is 32 bits on
+    // armv7-unknown-linux-gnueabihf -- a target multi-platform.yml checks on
+    // every PR. A bare `as` cast wraps there instead of failing, so a caller
+    // asking for 5_000_000_000 ns would silently arm 705 ms and still be told
+    // it succeeded. Reject what the target cannot represent.
+    let slack = libc::c_ulong::try_from(nanoseconds).map_err(|_| {
+        anyhow::anyhow!(
+            "timer slack {} ns does not fit this target's unsigned long (max {} ns)",
+            nanoseconds,
+            libc::c_ulong::MAX
+        )
+    })?;
+
     // SAFETY: PR_SET_TIMERSLACK takes a single unsigned long argument and
-    // affects only the calling thread. A value of 0 means "restore the
-    // default", which is why the caller is expected to pass >= 1.
-    let result = unsafe { libc::prctl(libc::PR_SET_TIMERSLACK, nanoseconds as libc::c_ulong) };
+    // affects only the calling thread.
+    let result = unsafe { libc::prctl(libc::PR_SET_TIMERSLACK, slack) };
     if result == 0 {
         Ok(())
     } else {
@@ -84,12 +104,31 @@ pub(super) fn set_timer_slack(nanoseconds: u64) -> anyhow::Result<()> {
 }
 
 /// This thread's current timer slack in nanoseconds, if it can be read.
+///
+/// Asks `PR_GET_TIMERSLACK` rather than reading `/proc/self/timerslack_ns`,
+/// because slack is per-thread and that file is not:
+///
+/// - `/proc/self` is the thread-group leader's directory, so every thread but
+///   the leader would be reporting some other task's slack;
+/// - the kernel only lets a task read another task's `timerslack_ns` with
+///   CAP_SYS_NICE, so in practice the read does not even return the wrong
+///   number off the leader -- it fails with EPERM and this returns `None` for a
+///   thread whose slack is perfectly well set;
+/// - `timerslack_ns` exists only in the tgid directory, so there is no
+///   `/proc/self/task/<tid>/timerslack_ns` to read instead.
+///
+/// prctl returns the value through a C `int`, so a slack above `i32::MAX`
+/// (2.1 s, far past anything a timed wait would want) cannot come back through
+/// it and yields `None`.
 pub(super) fn timer_slack_ns() -> Option<u64> {
-    std::fs::read_to_string("/proc/self/timerslack_ns")
-        .ok()?
-        .trim()
-        .parse()
-        .ok()
+    // SAFETY: PR_GET_TIMERSLACK takes no further arguments and reports the
+    // calling thread's slack as the return value.
+    let result = unsafe { libc::prctl(libc::PR_GET_TIMERSLACK) };
+    if result < 0 {
+        None
+    } else {
+        Some(result as u64)
+    }
 }
 
 /// Set SCHED_FIFO priority for the current thread.
@@ -516,6 +555,73 @@ fn check_mlockall_permitted() -> bool {
             rlim.rlim_cur == libc::RLIM_INFINITY || rlim.rlim_cur > 1024 * 1024 * 1024
         } else {
             false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the whole pair exists for. `timer_slack_ns` used to read
+    /// `/proc/self/timerslack_ns`, which is the thread-group leader's file: the
+    /// spawned thread's read returned EPERM (`None`) instead of its own 7777,
+    /// because the kernel guards another task's `timerslack_ns` behind
+    /// CAP_SYS_NICE. The RT thread that `set_timer_slack` is called on is never
+    /// the leader, so that is the only thread anyone would ask about.
+    #[test]
+    fn timer_slack_is_per_thread() {
+        let original = timer_slack_ns().expect("read this thread's slack");
+        set_timer_slack(4321).expect("set slack on this thread");
+
+        let spawned = std::thread::spawn(|| {
+            set_timer_slack(7777).expect("set slack on the spawned thread");
+            timer_slack_ns()
+        })
+        .join()
+        .expect("spawned thread panicked");
+
+        assert_eq!(spawned, Some(7777), "spawned thread reported another task");
+        assert_eq!(
+            timer_slack_ns(),
+            Some(4321),
+            "this thread's slack changed when another thread set its own"
+        );
+
+        // Under `--test-threads=1` (how CI runs these) this is the harness
+        // thread every other test also runs on, so hand it back unchanged.
+        set_timer_slack(original).expect("restore slack");
+    }
+
+    /// 0 is the kernel's "restore the inherited default", not "no slack" --
+    /// the contract the doc comment promises and the reason callers pass 1.
+    #[test]
+    fn zero_restores_the_default_rather_than_setting_zero() {
+        std::thread::spawn(|| {
+            set_timer_slack(1).expect("set 1 ns");
+            assert_eq!(timer_slack_ns(), Some(1));
+
+            set_timer_slack(0).expect("set 0");
+            let restored = timer_slack_ns().expect("read slack back");
+            assert_ne!(restored, 0, "0 must not arm zero slack");
+            assert_ne!(restored, 1, "0 must not leave the previous value in place");
+        })
+        .join()
+        .expect("spawned thread panicked");
+    }
+
+    /// On armv7 (a required multi-platform.yml job) `c_ulong` is 32 bits and
+    /// the `as` cast this used to do would wrap a wider request into a small
+    /// one and still report success. The guard makes this a no-op on 64-bit
+    /// targets, where every `u64` fits and there is nothing to reject.
+    #[test]
+    fn a_value_too_wide_for_c_ulong_is_rejected_not_wrapped() {
+        if libc::c_ulong::try_from(u64::MAX).is_err() {
+            let err = set_timer_slack(u64::MAX).expect_err("should not have been accepted");
+            assert!(
+                err.to_string().contains("does not fit"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -59,9 +59,10 @@ pub(super) fn detect_capabilities() -> RtCapabilities {
 /// batch wakeups and save power. For a periodic control loop that is a 50 us
 /// error added to every single wake.
 ///
-/// `nanoseconds` of 0 is not "no slack": the kernel reads a non-positive
-/// argument as "restore this thread's inherited default" and puts the 50 us
-/// back. That is why the callers in this workspace pass 1.
+/// `nanoseconds` of 0 is not "no slack": 0 is the one value the kernel reads as
+/// "restore this thread's inherited default", and it puts the 50 us back. Every
+/// other value is the slack itself. That is why the callers in this workspace
+/// pass 1.
 ///
 /// It applies to SCHED_OTHER threads. A SCHED_FIFO/RR thread already gets zero
 /// slack from the kernel, so this call is a no-op for a fully privileged RT
@@ -595,16 +596,34 @@ mod tests {
 
     /// 0 is the kernel's "restore the inherited default", not "no slack" --
     /// the contract the doc comment promises and the reason callers pass 1.
+    ///
+    /// The default is not the constant 50000: a thread inherits whatever its
+    /// spawning thread's slack was at the moment of the spawn, and slack
+    /// survives fork and exec, so a test binary launched from anything that had
+    /// already lowered its own slack starts lower. Read the inherited value
+    /// from inside the thread instead of assuming it.
     #[test]
     fn zero_restores_the_default_rather_than_setting_zero() {
         std::thread::spawn(|| {
-            set_timer_slack(1).expect("set 1 ns");
-            assert_eq!(timer_slack_ns(), Some(1));
+            let inherited = timer_slack_ns().expect("read the inherited default");
+
+            // Probe with a value the inherited default is not, so "restored the
+            // default" and "kept what I just set" cannot look the same.
+            let probe = if inherited == 1 { 2 } else { 1 };
+            set_timer_slack(probe).expect("set the probe value");
+            assert_eq!(timer_slack_ns(), Some(probe));
 
             set_timer_slack(0).expect("set 0");
             let restored = timer_slack_ns().expect("read slack back");
             assert_ne!(restored, 0, "0 must not arm zero slack");
-            assert_ne!(restored, 1, "0 must not leave the previous value in place");
+            assert_ne!(
+                restored, probe,
+                "0 must not leave the previous value in place"
+            );
+            assert_eq!(
+                restored, inherited,
+                "0 must restore the default this thread inherited at spawn"
+            );
         })
         .join()
         .expect("spawned thread panicked");

--- a/horus_sys/src/rt/mod.rs
+++ b/horus_sys/src/rt/mod.rs
@@ -151,6 +151,12 @@ pub fn lock_memory() -> anyhow::Result<()> {
 /// for the degraded path where `set_realtime_priority` was refused for lack of
 /// CAP_SYS_NICE and HORUS continued at normal priority.
 ///
+/// `nanoseconds` is the slack itself, and 0 is not "no slack": Linux reads a
+/// non-positive argument as "restore this thread's inherited default" and hands
+/// back the 50 us. Pass 1 for the tightest setting. A value too wide for the
+/// target's `unsigned long` (32 bits on armv7) is refused with an error rather
+/// than wrapped into a smaller one.
+///
 /// Returns `Ok(())` and does nothing on platforms without the concept, so
 /// callers do not need to branch.
 pub fn set_timer_slack(nanoseconds: u64) -> anyhow::Result<()> {
@@ -167,6 +173,10 @@ pub fn set_timer_slack(nanoseconds: u64) -> anyhow::Result<()> {
 
 /// This thread's current timer slack in nanoseconds, or `None` where the
 /// platform has no such setting.
+///
+/// Per-thread, like [`set_timer_slack`]: it reports the slack of whichever
+/// thread calls it, so call it from the thread you are asking about rather than
+/// from the one that configured it.
 pub fn timer_slack_ns() -> Option<u64> {
     #[cfg(target_os = "linux")]
     {

--- a/horus_sys/src/rt/mod.rs
+++ b/horus_sys/src/rt/mod.rs
@@ -151,11 +151,11 @@ pub fn lock_memory() -> anyhow::Result<()> {
 /// for the degraded path where `set_realtime_priority` was refused for lack of
 /// CAP_SYS_NICE and HORUS continued at normal priority.
 ///
-/// `nanoseconds` is the slack itself, and 0 is not "no slack": Linux reads a
-/// non-positive argument as "restore this thread's inherited default" and hands
-/// back the 50 us. Pass 1 for the tightest setting. A value too wide for the
-/// target's `unsigned long` (32 bits on armv7) is refused with an error rather
-/// than wrapped into a smaller one.
+/// `nanoseconds` is the slack itself, except for 0: 0 is the one value Linux
+/// reads as "restore this thread's inherited default", and it hands back the
+/// 50 us. Pass 1 for the tightest setting. A value too wide for the target's
+/// `unsigned long` (32 bits on armv7) is refused with an error rather than
+/// wrapped into a smaller one.
 ///
 /// Returns `Ok(())` and does nothing on platforms without the concept, so
 /// callers do not need to branch.

--- a/horus_sys/src/rt/mod.rs
+++ b/horus_sys/src/rt/mod.rs
@@ -141,6 +141,43 @@ pub fn lock_memory() -> anyhow::Result<()> {
     }
 }
 
+/// Set this thread's timer slack in nanoseconds (Linux only).
+///
+/// Linux defaults to 50 us of slack per thread, which the kernel may add to any
+/// timed wait. That is 5 % of a 1 kHz period, applied to every wake. Setting it
+/// to 1 ns is what RT applications do.
+///
+/// A SCHED_FIFO/RR thread already gets zero slack, so this matters precisely
+/// for the degraded path where `set_realtime_priority` was refused for lack of
+/// CAP_SYS_NICE and HORUS continued at normal priority.
+///
+/// Returns `Ok(())` and does nothing on platforms without the concept, so
+/// callers do not need to branch.
+pub fn set_timer_slack(nanoseconds: u64) -> anyhow::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::set_timer_slack(nanoseconds)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = nanoseconds;
+        Ok(())
+    }
+}
+
+/// This thread's current timer slack in nanoseconds, or `None` where the
+/// platform has no such setting.
+pub fn timer_slack_ns() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::timer_slack_ns()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
 /// Pin the current thread to a specific CPU core.
 ///
 /// Uses the `core_affinity` crate which is cross-platform.


### PR DESCRIPTION
Linux gives every thread **50 µs** of timer slack by default (`/proc/self/timerslack_ns`) and may delay any `nanosleep`, `clock_nanosleep`, futex timeout or poll wake by up to that much. HORUS never called `prctl(PR_SET_TIMERSLACK)` anywhere in the workspace.

## Why it bites here specifically

The RT wait loop sleeps to an absolute deadline with `clock_nanosleep(TIMER_ABSTIME)` and then guard-spins the last stretch. The guard is a fraction of the period — 20 µs at 1 kHz. So 50 µs of slack doesn't merely add 50 µs: it **overshoots the point the spin was supposed to take over**, and a spin cannot recover time already gone.

The kernel gives SCHED_FIFO/RR threads zero slack, so this is a no-op once the priority request succeeds. It targets the branch where that request is **refused** for want of `CAP_SYS_NICE` and HORUS continues at normal priority — a plain `cargo test`, an unprivileged container, most developer machines. That fallback is the configuration most users are actually on, and nothing was making it behave.

## It has to be set on the RT thread itself

`PR_SET_TIMERSLACK` is **per-thread**, and inherited only at spawn. My first attempt put it in `RtConfig::apply`, which runs on the thread that builds the scheduler — measurably no effect on the loop. It now sits on the tick thread, after the priority attempt and guarded by `!rt_policy_active`. (`RtConfig::apply` sets it too, for user code that configures itself directly.)

## Measured

Isolated harness, 3000 iterations of a 1 kHz `clock_nanosleep(TIMER_ABSTIME)` loop, wake lateness:

| slack | p50 | p90 | p99 |
|---|---|---|---|
| 50000 ns (default) | 55.8 µs | 63.8 µs | 101–271 µs |
| **1 ns** | **4.3 µs** | **16.7 µs** | 25–116 µs |

An independent audit reproduced this inside the real executor by LD_PRELOAD-interposing `prctl` on the *same binary*, and read HORUS's own `[RT-thread] Cyclic wait:` counters across 3 interleaved pairs (~980 slots each):

| | wake late (mean) | guard spin total |
|---|---|---|
| HEAD-equivalent | 65693 / 86391 / 145373 ns | 26927 / 0 / 18090 ns |
| with `prctl` | 20223 / 15079 / 8319 ns | 994372 / 3367597 / 951950 ns |

The guard spin goes from **never running** to running. Tick counts were unchanged, so this is phase accuracy, not throughput.

## Scope — this is a median fix, not a tail fix

The millisecond tail is external and unchanged by this. Say so plainly rather than let the p50 number imply otherwise; the tail lever is SCHED_FIFO (see #135, measured at 20–100× on p99).
