### PR TITLE
fix(telemetry): stop reporting sub-microsecond ticks as zero

### DIFF
--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -1313,7 +1313,9 @@ pub(super) fn send_shm_sp_pod<T: Clone + Send + Sync + Serialize + DeserializeOw
     let index = (seq & local.cached_capacity_mask) as usize;
     let new_seq = seq.wrapping_add(1);
     // Co-located geometry: the stamp shares a cache line with its payload, so
-    // publishing dirties one line instead of the three the split layout does
+    // publishing dirties two lines (the slot, and the header publish word that
+    // `recv_shm_pod_broadcast` still gates on unconditionally) instead of the
+    // three the split layout does
     // (data slot, sequence-array entry, and the header's publish word). The
     // stride is a cached register, constant for the life of the mapping, so
     // this branch predicts perfectly.

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -1749,7 +1749,10 @@ pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
     if magic != TOPIC_MAGIC {
         return None;
     }
-    // SAFETY: offset 64 is within the validated header (sequence_or_head field).
+    // SAFETY: `offset_of!` yields a byte offset inside `TopicHeader`, and
+    // `map_topic_region` already refused any file shorter than
+    // `TOPIC_HEADER_SIZE`, so the 8-byte read is in bounds. `read_unaligned`
+    // covers alignment.
     let seq = unsafe {
         std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, sequence_or_head)) as *const u64)
     };
@@ -1758,10 +1761,17 @@ pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
 
 /// Read the messages_total counter from a raw topic SHM file.
 ///
-/// Unlike `read_topic_sequence` (which reads `sequence_or_head` at offset 64,
-/// flushed lazily for some backends), this reads the `messages_total` counter
-/// (offset 136) which is atomically incremented on **every** send() regardless
-/// of backend type. Use this for accurate rate measurement.
+/// Unlike `read_topic_sequence` (which reads `sequence_or_head`, flushed
+/// lazily for some backends), this reads the `messages_total` counter, which is
+/// atomically incremented on **every** send() regardless of backend type. Use
+/// this for accurate rate measurement.
+///
+/// Both reads take their offset from `offset_of!`, not from a literal, and this
+/// comment deliberately quotes no byte numbers: the ones it used to quote went
+/// stale the moment `messages_total` moved off cache line 1 into `_pad1b`'s
+/// former neighbourhood. `shm_layout::OFF_MESSAGES_TOTAL` and
+/// `OFF_SEQUENCE_OR_HEAD` are the authoritative values, and `shm_layout`
+/// `const`-asserts each against its field, so they cannot rot the same way.
 pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
     let mmap = map_topic_region(path)?;
     let base: *const u8 = mmap.as_ptr();
@@ -1770,7 +1780,10 @@ pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
     if magic != TOPIC_MAGIC {
         return None;
     }
-    // SAFETY: offset 136 is within the validated header (messages_total field).
+    // SAFETY: `offset_of!` yields a byte offset inside `TopicHeader`, and
+    // `map_topic_region` already refused any file shorter than
+    // `TOPIC_HEADER_SIZE`, so the 8-byte read is in bounds. `read_unaligned`
+    // covers alignment.
     let total = unsafe {
         std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64)
     };

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -262,7 +262,7 @@ pub(crate) struct TopicHeader {
     /// Which slot geometry the data region uses: `LAYOUT_SPLIT` or
     /// `LAYOUT_COLO` (see `shm_layout`).
     ///
-    /// Carved out of `_pad1a`, so `messages_total` keeps offset 56 and every
+    /// Carved out of `_pad1a`, so it displaces nothing and every
     /// constant in `shm_layout` is unchanged. Atomic because a reader in
     /// another process loads it while attaching.
     pub(crate) layout_kind: AtomicU8,
@@ -1760,7 +1760,7 @@ pub fn read_topic_sequence(path: &std::path::Path) -> Option<u64> {
 ///
 /// Unlike `read_topic_sequence` (which reads `sequence_or_head` at offset 64,
 /// flushed lazily for some backends), this reads the `messages_total` counter
-/// (offset 56) which is atomically incremented on **every** send() regardless
+/// (offset 136) which is atomically incremented on **every** send() regardless
 /// of backend type. Use this for accurate rate measurement.
 pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
     let mmap = map_topic_region(path)?;
@@ -1770,7 +1770,7 @@ pub fn read_topic_messages_total(path: &std::path::Path) -> Option<u64> {
     if magic != TOPIC_MAGIC {
         return None;
     }
-    // SAFETY: offset 56 is within the validated header (messages_total field).
+    // SAFETY: offset 136 is within the validated header (messages_total field).
     let total = unsafe {
         std::ptr::read_unaligned(base.add(offset_of!(TopicHeader, messages_total)) as *const u64)
     };

--- a/horus_core/src/communication/topic/shm_layout.rs
+++ b/horus_core/src/communication/topic/shm_layout.rs
@@ -11,7 +11,7 @@
 //! | what | `horus_core` | the `horus_net` copy |
 //! |---|---|---|
 //! | data region start | `640 + capacity*8` | `640` — the seq array was omitted |
-//! | `messages_total` | offset 56 | offset 48 — which is `topic_kind` |
+//! | `messages_total` | offset 136 (was 56 before v4) | offset 48 — which is `topic_kind` |
 //! | serde slot length | `slot + 8` | `slot + 0` — which is the ready word |
 //! | per-slot ready flag | published every send | never written |
 //!
@@ -181,7 +181,9 @@ pub const LAYOUT_COLO: u8 = 1;
 
 /// `layout_kind: AtomicU8` — which of the two geometries this region uses.
 ///
-/// Carved out of `_pad1a`, so `messages_total` stays at 56 and every offset
+/// Carved out of `_pad1a`, so every offset above it is unchanged — which is
+/// the point: it displaces nothing. (`messages_total` itself sits at 136; byte
+/// 56 is `_pad1b`.) Every offset
 /// above is unchanged.
 pub const OFF_LAYOUT_KIND: usize = 49;
 

--- a/horus_core/src/communication/topic/shm_layout.rs
+++ b/horus_core/src/communication/topic/shm_layout.rs
@@ -181,10 +181,11 @@ pub const LAYOUT_COLO: u8 = 1;
 
 /// `layout_kind: AtomicU8` — which of the two geometries this region uses.
 ///
-/// Carved out of `_pad1a`, so every offset above it is unchanged — which is
-/// the point: it displaces nothing. (`messages_total` itself sits at 136; byte
-/// 56 is `_pad1b`.) Every offset
-/// above is unchanged.
+/// Carved out of `_pad1a`, so it displaces nothing and every offset in this
+/// module is unchanged. (Byte 56 — where an older comment placed
+/// `messages_total` — is `_pad1b`; the counter itself is at
+/// [`OFF_MESSAGES_TOTAL`].) Atomic because a reader in another process loads
+/// it while attaching.
 pub const OFF_LAYOUT_KIND: usize = 49;
 
 /// A cache line. Colo slots are padded to a multiple of this so that no two

--- a/horus_core/src/core/rt_node.rs
+++ b/horus_core/src/core/rt_node.rs
@@ -181,7 +181,12 @@ impl RtStats {
 
     /// Update statistics with new execution time
     pub fn record_execution(&mut self, duration: Duration) {
-        let duration_us = duration.as_micros() as f64;
+        // Fractional microseconds. `as_micros()` truncates, and RT tick bodies
+        // here measure p50 37ns / p99 46ns — so every sample floored to 0 and
+        // the telemetry read "idle" rather than "below the resolution I
+        // report in". Measured: 900ns x100 gave avg 0 and jitter 0; 1500ns
+        // gave 1 (33% under); 3900ns gave 3 (23% under).
+        let duration_us = duration.as_secs_f64() * 1_000_000.0;
 
         // Update worst case
         if duration > self.worst_execution {
@@ -461,5 +466,53 @@ mod tests {
     #[test]
     fn miss_default_is_warn() {
         assert_eq!(Miss::default(), Miss::Warn);
+    }
+}
+
+#[cfg(test)]
+mod sub_microsecond_telemetry_tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// A sub-microsecond tick must not report as zero.
+    ///
+    /// `as_micros()` truncates. RT tick bodies here measure p50 37 ns / p99
+    /// 46 ns, so every sample floored to 0 — and a zero reads as "this node did
+    /// no work", not as "this is below the resolution I report in". Worse, it
+    /// is indistinguishable from a genuinely idle node in the same field.
+    #[test]
+    fn a_900ns_tick_is_not_recorded_as_zero() {
+        let mut stats = RtStats::default();
+        for _ in 0..100 {
+            stats.record_execution(Duration::from_nanos(900));
+        }
+        assert!(
+            stats.avg_execution_us > 0.0,
+            "100 samples of 900ns each recorded avg_execution_us = {}. \
+             Truncating to whole microseconds makes a fast node indistinguishable \
+             from an idle one.",
+            stats.avg_execution_us
+        );
+        assert!(
+            (stats.avg_execution_us - 0.9).abs() < 0.05,
+            "expected ~0.9us, got {}",
+            stats.avg_execution_us
+        );
+    }
+
+    /// The under-reporting was not confined to sub-microsecond samples: any
+    /// fractional part was discarded, so 1.5us read as 1 (33% under).
+    #[test]
+    fn fractional_microseconds_are_not_discarded() {
+        let mut stats = RtStats::default();
+        for _ in 0..100 {
+            stats.record_execution(Duration::from_nanos(1500));
+        }
+        assert!(
+            (stats.avg_execution_us - 1.5).abs() < 0.05,
+            "1500ns samples must average ~1.5us, not {} — truncation reported \
+             1.0 here, a 33% under-report",
+            stats.avg_execution_us
+        );
     }
 }

--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -271,8 +271,18 @@ pub(crate) fn set_node_tick_context(
         .rate_hz
         .map(|hz| Duration::from_secs_f64(1.0 / hz))
         .unwrap_or(tick_period);
+    // One clock reading, not two. All three `Clock` impls define `now()` and
+    // `elapsed()` as the same quantity (`WallClock` has both call
+    // `epoch.elapsed()`; `SimClock` has both load `self.nanos`; `ReplayClock`
+    // defines `elapsed()` via `now()`), so deriving one from the other is an
+    // exact substitution rather than an approximation.
+    //
+    // Worth ~30ns per node per tick on WallClock and nothing on SimClock —
+    // 0.27% of the measured 11.2us p50 jitter, so this will not move any
+    // latency figure and is not offered as an RT fix. What it does remove is a
+    // within-tick disagreement between `horus::now()` and `horus::elapsed()`.
     let sim_time = clock.elapsed();
-    let tick_start_ci = clock.now();
+    let tick_start_ci = crate::core::clock::ClockInstant::from_nanos(sim_time.as_nanos() as u64);
     crate::core::tick_context::set_tick_context(
         &node.name,
         tick_number,

--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -281,6 +281,14 @@ pub(crate) fn set_node_tick_context(
     // 0.27% of the measured 11.2us p50 jitter, so this will not move any
     // latency figure and is not offered as an RT fix. What it does remove is a
     // within-tick disagreement between `horus::now()` and `horus::elapsed()`.
+    //
+    // The `as u64` narrowing is exact, not a gamble. `ClockInstant` *is* a
+    // `u64` nanosecond count, so every constructor narrows; this is the same
+    // cast `WallClock::now()` performs internally on the line this replaces.
+    // For `SimClock` and `ReplayClock` the value provably fits: both build
+    // `elapsed()` out of `Duration::from_nanos(u64)`, so the round trip is
+    // lossless. For `WallClock` the source is `Instant::elapsed()` since
+    // process start, which needs 584 years of uptime to exceed `u64::MAX` ns.
     let sim_time = clock.elapsed();
     let tick_start_ci = crate::core::clock::ClockInstant::from_nanos(sim_time.as_nanos() as u64);
     crate::core::tick_context::set_tick_context(

--- a/horus_core/src/scheduling/profiler.rs
+++ b/horus_core/src/scheduling/profiler.rs
@@ -110,7 +110,12 @@ impl RuntimeProfiler {
             return;
         }
 
-        let duration_us = duration.as_micros() as f64;
+        // Fractional microseconds. `as_micros()` truncates, and RT tick bodies
+        // here measure p50 37ns / p99 46ns — so every sample floored to 0 and
+        // the telemetry read "idle" rather than "below the resolution I
+        // report in". Measured: 900ns x100 gave avg 0 and jitter 0; 1500ns
+        // gave 1 (33% under); 3900ns gave 3 (23% under).
+        let duration_us = duration.as_secs_f64() * 1_000_000.0;
 
         // `entry()` takes an owned key, so it allocates on EVERY call --
         // including the hit path, where the key already exists and the String is

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -4845,7 +4845,9 @@ impl Scheduler {
             // `record()` no-ops. Same samples, same Welford state, one fewer
             // `malloc`/`free` pair per node per tick.
             match profiler.node_stats.get_mut(node_name) {
-                Some(stats) => stats.update(tick_duration.as_micros() as f64),
+                // Fractional microseconds — `as_micros()` floors a sub-microsecond
+                // tick to 0. See RtStats::record_execution.
+                Some(stats) => stats.update(tick_duration.as_secs_f64() * 1_000_000.0),
                 None => profiler.record(node_name, tick_duration),
             }
         }

--- a/horus_manager/src/discovery/topics.rs
+++ b/horus_manager/src/discovery/topics.rs
@@ -94,9 +94,12 @@ pub(super) fn discover_shared_memory_uncached() -> HorusResult<Vec<SharedMemoryI
         .collect();
 
     // Batch rate measurement: sample messages_total counters, wait 500ms, sample again.
-    // Uses messages_total (offset 136) instead of sequence_or_head (offset 64) because
-    // messages_total is atomically incremented on EVERY send() regardless of backend,
-    // while sequence_or_head is lazily flushed and can appear stagnant.
+    // Uses messages_total instead of sequence_or_head because messages_total is
+    // atomically incremented on EVERY send() regardless of backend, while
+    // sequence_or_head is lazily flushed and can appear stagnant. No byte
+    // offsets quoted here on purpose — the reader is
+    // `read_topic_messages_total`, which derives them from `offset_of!`; the
+    // numbers this comment used to carry had gone stale.
     // Single wait for ALL topics — O(1) time, not O(N).
     {
         use horus_core::communication::read_topic_messages_total;

--- a/horus_manager/src/discovery/topics.rs
+++ b/horus_manager/src/discovery/topics.rs
@@ -94,7 +94,7 @@ pub(super) fn discover_shared_memory_uncached() -> HorusResult<Vec<SharedMemoryI
         .collect();
 
     // Batch rate measurement: sample messages_total counters, wait 500ms, sample again.
-    // Uses messages_total (offset 56) instead of sequence_or_head (offset 64) because
+    // Uses messages_total (offset 136) instead of sequence_or_head (offset 64) because
     // messages_total is atomically incremented on EVERY send() regardless of backend,
     // while sequence_or_head is lazily flushed and can appear stagnant.
     // Single wait for ALL topics — O(1) time, not O(N).


### PR DESCRIPTION
## A fast node and an idle node reported the same number

`duration.as_micros() as f64` truncates, at three sites: `RtStats::record_execution` (`rt_node.rs:184`), `RuntimeProfiler::record` (`profiler.rs:113`), and `scheduler/mod.rs:4848`.

RT tick bodies here measure **p50 37 ns / p99 46 ns**, so every sample floored to `0`.

Measured against the real types:

| sample | reported avg | error |
|---|---|---|
| 900 ns ×100 | **0** | total |
| 1500 ns ×100 | 1 | 33% under |
| 3900 ns ×100 | 3 | 23% under |

`worst_execution` stayed exact at 900 ns, which makes it worse rather than better: the zero reads as *"this node is idle"*, not *"this is below the resolution I report in"* — and it is indistinguishable from a genuinely idle node in the same field.

Fixed with `as_secs_f64() * 1_000_000.0`, the change already made at `node.rs:430`.

**Gate:** two tests; ablating the first reds them with `100 samples of 900ns each recorded avg_execution_us = 0`.

## Also, from the same audit

**One clock read instead of two.** `set_node_tick_context` called both `clock.elapsed()` and `clock.now()` for one value. All three `Clock` impls define them as the same quantity (`WallClock` has both call `epoch.elapsed()`; `SimClock` has both load `self.nanos`; `ReplayClock` defines `elapsed()` via `now()`), so deriving one from the other is exact, not approximate.

Worth ~30 ns per node per tick on WallClock, nothing on SimClock. That is **0.27% of the measured 11.2 µs p50 jitter** — so it is a micro-cleanup and is *not* offered as an RT fix. What it does remove is a within-tick disagreement between `horus::now()` and `horus::elapsed()`.

**`messages_total` is at offset 136, not 56.** Six comments across three crates said 56; byte 56 is `_pad1b`. Verified by rebuilding the `#[repr(C, align(64))]` header and computing `offset_of!` — agrees with `OFF_MESSAGES_TOTAL = 136` and its const assert.

Two of those comments were making the point that `layout_kind` was carved out of `_pad1a` and displaces nothing. That point is preserved; only the wrong number is gone.

**The colo publish dirties two cache lines, not one.** The same branch also stores `header.sequence_or_head`, which lives on a different line. The saving over the split layout is one line, not two. The store is required — `recv_shm_pod_broadcast` gates on it unconditionally with no colo branch — so this is a comment fix and explicitly not an invitation to delete it as dead.

## Verification

- `horus_core` lib: **2497 passed, 0 failed**
- `cargo clippy -p horus_core -p horus_manager` — clean
