### PR TITLE
fix(rt): stop rewriting host IRQ affinity from a container's view of the CPUs

### DIFF
--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -366,31 +366,95 @@ pub(super) fn set_cpu_governor(cpu_id: usize, governor: &str) -> anyhow::Result<
 
 /// Move hardware interrupts off the specified CPU cores.
 ///
-/// Iterates `/proc/irq/*/smp_affinity` and clears the bits for the given cores.
-/// Returns the number of IRQs whose affinity was successfully changed.
-/// Requires root or CAP_SYS_ADMIN.
+/// Rewrites `/proc/irq/*/smp_affinity` for every IRQ on the machine, so it is
+/// host-global and irreversible within this process. Requires root or
+/// CAP_SYS_ADMIN; without them every write fails and this returns 0.
+///
+/// # What it refuses to do
+///
+/// The mask used to be built from `available_parallelism()`, which reports the
+/// CPUs *this process* may run on, not the CPUs the machine has. A count is not
+/// a CPU set, and conflating them made the function reconfigure the whole host
+/// from a container's-eye view:
+///
+///   * under `taskset -c 0-3` with `rt_cpus = [2, 3]` it produced mask `3` and
+///     herded every host interrupt onto CPUs 0-1 — including the interrupts of
+///     cores it had never heard of;
+///   * under `taskset -c 8-11` it produced `f`, naming CPUs 0-3, which this
+///     process cannot even run on;
+///   * at 64 or more CPUs it produced `u64::MAX`, confining every IRQ to CPUs
+///     0-63, while the `cpu < 64` guard below silently declined to clear the RT
+///     cores it was called for — failing its whole purpose and clobbering the
+///     machine anyway.
+///
+/// So the mask now comes from `/sys/devices/system/cpu/online`, the machine's
+/// actual CPU set, and the function REFUSES to act when this process cannot see
+/// the whole machine. A process confined to a cpuset has no business rewriting
+/// the interrupt routing of cores outside it, and in a container that is the
+/// normal case, not an edge case.
+///
+/// Returns the number of IRQs whose affinity was changed.
 pub(super) fn move_irqs_off_cpus(cpus: &[usize]) -> anyhow::Result<usize> {
     let irq_dir = std::path::Path::new("/proc/irq");
     if !irq_dir.exists() {
         return Ok(0);
     }
-    let total_cpus = std::thread::available_parallelism()
+
+    // The machine's CPUs, not this process's share of them.
+    let online = std::fs::read_to_string("/sys/devices/system/cpu/online")
+        .map(|s| super::parse_cpu_list(s.trim()))
+        .unwrap_or_default();
+    if online.is_empty() {
+        anyhow::bail!(
+            "cannot read /sys/devices/system/cpu/online, so the machine's CPU set \
+             is unknown; refusing to rewrite host IRQ affinity from a guess"
+        );
+    }
+
+    // If this process is confined, it is not entitled to reroute the host.
+    let visible = std::thread::available_parallelism()
         .map(|p| p.get())
         .unwrap_or(1);
-    // Build mask with RT cores cleared
-    let mut mask: u64 = if total_cpus >= 64 {
-        u64::MAX
-    } else {
-        (1u64 << total_cpus) - 1
-    };
+    if visible < online.len() {
+        anyhow::bail!(
+            "this process sees {visible} of the machine's {} CPUs (cpuset or \
+             taskset), so it cannot compute a correct host-wide IRQ mask; \
+             refusing rather than rerouting interrupts for cores it cannot see",
+            online.len()
+        );
+    }
+
+    // Above 63 CPUs a single u64 cannot name the set, and `smp_affinity` wants
+    // comma-separated 32-bit groups anyway. Refuse rather than write a mask
+    // that silently confines every interrupt to the low 64 CPUs.
+    let highest = online.iter().copied().max().unwrap_or(0);
+    if highest >= 64 {
+        anyhow::bail!(
+            "machine has CPUs up to index {highest}; a 64-bit affinity mask \
+             cannot name them and writing one would confine every interrupt to \
+             CPUs 0-63. Refusing; set IRQ affinity out of band."
+        );
+    }
+
+    let mut mask: u64 = 0;
+    for &cpu in &online {
+        mask |= 1u64 << cpu;
+    }
     for &cpu in cpus {
-        if cpu < 64 {
-            mask &= !(1u64 << cpu);
+        // Every RT core is cleared, or the call did not do what it says. The
+        // old `if cpu < 64` guard skipped high cores silently.
+        if cpu > highest {
+            anyhow::bail!(
+                "asked to clear CPU {cpu}, which is not in the machine's online \
+                 set (highest is {highest})"
+            );
         }
+        mask &= !(1u64 << cpu);
     }
     if mask == 0 {
-        return Ok(0); // can't clear all cores
+        return Ok(0); // every CPU is an RT core; nothing left to move IRQs to
     }
+
     let mask_str = format!("{:x}", mask);
     let mut moved = 0usize;
     for entry in std::fs::read_dir(irq_dir)?.flatten() {
@@ -471,6 +535,65 @@ fn check_mlockall_permitted() -> bool {
             rlim.rlim_cur == libc::RLIM_INFINITY || rlim.rlim_cur > 1024 * 1024 * 1024
         } else {
             false
+        }
+    }
+}
+
+#[cfg(test)]
+mod irq_affinity_tests {
+    use super::*;
+
+    /// The machine's CPU set is what matters, not this process's share of it.
+    ///
+    /// `available_parallelism()` honours cpuset/taskset. Building a host-global
+    /// IRQ mask from it meant a container rerouted the interrupts of cores it
+    /// could not see. This asserts the two are read from different places.
+    #[test]
+    fn online_cpu_set_is_read_from_sysfs_not_from_parallelism() {
+        let online = std::fs::read_to_string("/sys/devices/system/cpu/online")
+            .map(|s| super::super::parse_cpu_list(s.trim()))
+            .unwrap_or_default();
+        if online.is_empty() {
+            eprintln!("no /sys/devices/system/cpu/online here; nothing to check");
+            return;
+        }
+        let visible = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(1);
+        assert!(
+            !online.is_empty(),
+            "the online set must come from sysfs so it describes the machine"
+        );
+        // Not an equality assert: on an unconfined host these agree, and that is
+        // fine. The point is that the function consults the sysfs set at all.
+        eprintln!("online={} visible={visible}", online.len());
+    }
+
+    /// Asking to clear a CPU the machine does not have is a caller error and
+    /// must be reported, not silently skipped.
+    ///
+    /// The old code guarded with `if cpu < 64` and skipped anything higher, so
+    /// on a large machine it wrote a mask while declining to clear the very
+    /// cores it was called for.
+    #[test]
+    fn clearing_a_nonexistent_cpu_is_an_error_not_a_silent_skip() {
+        // 4096 is beyond any plausible online set here.
+        let r = move_irqs_off_cpus(&[4096]);
+        match r {
+            Err(e) => {
+                let m = e.to_string();
+                assert!(
+                    m.contains("online set") || m.contains("cannot name") || m.contains("refusing"),
+                    "expected a refusal naming the reason, got: {m}"
+                );
+            }
+            Ok(n) => {
+                // Only acceptable outcome without /proc/irq present.
+                assert_eq!(
+                    n, 0,
+                    "clearing a CPU that does not exist must not report IRQs moved"
+                );
+            }
         }
     }
 }

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -364,11 +364,63 @@ pub(super) fn set_cpu_governor(cpu_id: usize, governor: &str) -> anyhow::Result<
     })
 }
 
+/// Build the `smp_affinity` mask naming `online` with every CPU in `rt_cpus`
+/// cleared.
+///
+/// Split out of [`move_irqs_off_cpus`] so the arithmetic that decides where
+/// every host interrupt lands can be tested on synthetic CPU sets, rather than
+/// on whatever machine happens to be running the suite.
+fn irq_affinity_mask(online: &[usize], rt_cpus: &[usize]) -> anyhow::Result<u64> {
+    let Some(highest) = online.iter().copied().max() else {
+        anyhow::bail!("the machine's online CPU set is empty; no IRQ mask to build");
+    };
+
+    // Above 63 CPUs a single u64 cannot name the set, and `smp_affinity` wants
+    // comma-separated 32-bit groups anyway. Refuse rather than write a mask
+    // that silently confines every interrupt to the low 64 CPUs.
+    if highest >= 64 {
+        anyhow::bail!(
+            "machine has CPUs up to index {highest}; a 64-bit affinity mask \
+             cannot name them and writing one would confine every interrupt to \
+             CPUs 0-63. Refusing; set IRQ affinity out of band."
+        );
+    }
+
+    let mut mask: u64 = 0;
+    for &cpu in online {
+        mask |= 1u64 << cpu;
+    }
+    for &cpu in rt_cpus {
+        // Membership, not `cpu <= highest`: an online set has holes whenever a
+        // CPU is offlined (1 offline while 3 is online), and an upper bound
+        // would accept CPU 1 there while the error text claims the set was
+        // consulted. Every RT core is cleared or the call did not do what it
+        // says; the original `if cpu < 64` guard skipped high cores silently.
+        if !online.contains(&cpu) {
+            anyhow::bail!(
+                "asked to clear CPU {cpu}, which is not in the machine's online \
+                 set {online:?}"
+            );
+        }
+        mask &= !(1u64 << cpu);
+    }
+    Ok(mask)
+}
+
 /// Move hardware interrupts off the specified CPU cores.
 ///
 /// Rewrites `/proc/irq/*/smp_affinity` for every IRQ on the machine, so it is
 /// host-global and irreversible within this process. Requires root or
-/// CAP_SYS_ADMIN; without them every write fails and this returns 0.
+/// CAP_SYS_ADMIN.
+///
+/// # What it returns
+///
+/// `Ok(n)` counts the IRQs whose affinity was actually rewritten. `n` is 0, not
+/// an error, in the three cases where there is nothing to do or nothing may be
+/// done: `/proc/irq` does not exist, every online CPU is an RT core so the mask
+/// would be empty, or the process lacks root/CAP_SYS_ADMIN and every write
+/// fails. Missing privilege is only that last one: the refusals below are
+/// `Err`, returned before a single byte is written.
 ///
 /// # What it refuses to do
 ///
@@ -383,7 +435,7 @@ pub(super) fn set_cpu_governor(cpu_id: usize, governor: &str) -> anyhow::Result<
 ///   * under `taskset -c 8-11` it produced `f`, naming CPUs 0-3, which this
 ///     process cannot even run on;
 ///   * at 64 or more CPUs it produced `u64::MAX`, confining every IRQ to CPUs
-///     0-63, while the `cpu < 64` guard below silently declined to clear the RT
+///     0-63, while its `cpu < 64` guard silently declined to clear the RT
 ///     cores it was called for — failing its whole purpose and clobbering the
 ///     machine anyway.
 ///
@@ -391,23 +443,32 @@ pub(super) fn set_cpu_governor(cpu_id: usize, governor: &str) -> anyhow::Result<
 /// actual CPU set, and the function REFUSES to act when this process cannot see
 /// the whole machine. A process confined to a cpuset has no business rewriting
 /// the interrupt routing of cores outside it, and in a container that is the
-/// normal case, not an edge case.
-///
-/// Returns the number of IRQs whose affinity was changed.
+/// normal case, not an edge case. The mask arithmetic itself lives in
+/// [`irq_affinity_mask`], where it is unit-tested on synthetic CPU sets.
 pub(super) fn move_irqs_off_cpus(cpus: &[usize]) -> anyhow::Result<usize> {
     let irq_dir = std::path::Path::new("/proc/irq");
     if !irq_dir.exists() {
         return Ok(0);
     }
 
-    // The machine's CPUs, not this process's share of them.
-    let online = std::fs::read_to_string("/sys/devices/system/cpu/online")
-        .map(|s| super::parse_cpu_list(s.trim()))
-        .unwrap_or_default();
+    // The machine's CPUs, not this process's share of them. A file that cannot
+    // be read and a file that parses to nothing are different diagnoses, so
+    // they get different errors and the read error is carried through:
+    // collapsing both into "cannot read" sends the operator chasing a file that
+    // was in fact read fine.
+    const ONLINE: &str = "/sys/devices/system/cpu/online";
+    let online_raw = std::fs::read_to_string(ONLINE).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot read {ONLINE} ({e}), so the machine's CPU set is unknown; \
+             refusing to rewrite host IRQ affinity from a guess"
+        )
+    })?;
+    let online = super::parse_cpu_list(online_raw.trim());
     if online.is_empty() {
         anyhow::bail!(
-            "cannot read /sys/devices/system/cpu/online, so the machine's CPU set \
-             is unknown; refusing to rewrite host IRQ affinity from a guess"
+            "{ONLINE} holds {:?}, which names no CPUs, so the machine's CPU set \
+             is unknown; refusing to rewrite host IRQ affinity from a guess",
+            online_raw.trim()
         );
     }
 
@@ -424,33 +485,7 @@ pub(super) fn move_irqs_off_cpus(cpus: &[usize]) -> anyhow::Result<usize> {
         );
     }
 
-    // Above 63 CPUs a single u64 cannot name the set, and `smp_affinity` wants
-    // comma-separated 32-bit groups anyway. Refuse rather than write a mask
-    // that silently confines every interrupt to the low 64 CPUs.
-    let highest = online.iter().copied().max().unwrap_or(0);
-    if highest >= 64 {
-        anyhow::bail!(
-            "machine has CPUs up to index {highest}; a 64-bit affinity mask \
-             cannot name them and writing one would confine every interrupt to \
-             CPUs 0-63. Refusing; set IRQ affinity out of band."
-        );
-    }
-
-    let mut mask: u64 = 0;
-    for &cpu in &online {
-        mask |= 1u64 << cpu;
-    }
-    for &cpu in cpus {
-        // Every RT core is cleared, or the call did not do what it says. The
-        // old `if cpu < 64` guard skipped high cores silently.
-        if cpu > highest {
-            anyhow::bail!(
-                "asked to clear CPU {cpu}, which is not in the machine's online \
-                 set (highest is {highest})"
-            );
-        }
-        mask &= !(1u64 << cpu);
-    }
+    let mask = irq_affinity_mask(&online, cpus)?;
     if mask == 0 {
         return Ok(0); // every CPU is an RT core; nothing left to move IRQs to
     }
@@ -543,30 +578,47 @@ fn check_mlockall_permitted() -> bool {
 mod irq_affinity_tests {
     use super::*;
 
-    /// The machine's CPU set is what matters, not this process's share of it.
+    /// The mask names exactly the online CPUs, minus the RT cores.
     ///
-    /// `available_parallelism()` honours cpuset/taskset. Building a host-global
-    /// IRQ mask from it meant a container rerouted the interrupts of cores it
-    /// could not see. This asserts the two are read from different places.
+    /// Synthetic sets, so this says the same thing on a 2-core CI runner as on
+    /// a 96-core host.
     #[test]
-    fn online_cpu_set_is_read_from_sysfs_not_from_parallelism() {
-        let online = std::fs::read_to_string("/sys/devices/system/cpu/online")
-            .map(|s| super::super::parse_cpu_list(s.trim()))
-            .unwrap_or_default();
-        if online.is_empty() {
-            eprintln!("no /sys/devices/system/cpu/online here; nothing to check");
-            return;
-        }
-        let visible = std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or(1);
+    fn mask_is_the_online_set_minus_the_rt_cores() {
+        // The ordinary case: four online, two handed to RT.
+        assert_eq!(irq_affinity_mask(&[0, 1, 2, 3], &[2, 3]).unwrap(), 0b0011);
+        // Holes stay holes. CPU 1 is offline, so it is absent from the mask
+        // even though nobody asked for it to be cleared.
+        assert_eq!(irq_affinity_mask(&[0, 2, 3], &[3]).unwrap(), 0b0101);
+        // Nothing to clear leaves the online set intact.
+        assert_eq!(irq_affinity_mask(&[0, 2, 3], &[]).unwrap(), 0b1101);
+        // Every online CPU is an RT core: empty mask, which the caller turns
+        // into Ok(0) rather than writing "0" to every IRQ.
+        assert_eq!(irq_affinity_mask(&[0, 1], &[0, 1]).unwrap(), 0);
+    }
+
+    /// An offline CPU inside the index range is still not a CPU to clear.
+    ///
+    /// The check is membership, not `cpu <= highest`: with 1 offline and 3
+    /// online, an upper bound accepts CPU 1 while the error text claims the
+    /// online set was consulted.
+    #[test]
+    fn an_offline_cpu_below_the_highest_index_is_refused() {
+        let err = irq_affinity_mask(&[0, 2, 3], &[1]).unwrap_err().to_string();
         assert!(
-            !online.is_empty(),
-            "the online set must come from sysfs so it describes the machine"
+            err.contains("not in the machine's online set"),
+            "expected a refusal naming the online set, got: {err}"
         );
-        // Not an equality assert: on an unconfined host these agree, and that is
-        // fine. The point is that the function consults the sysfs set at all.
-        eprintln!("online={} visible={visible}", online.len());
+    }
+
+    /// Past index 63 a u64 cannot name the set, so refuse instead of truncating.
+    #[test]
+    fn cpu_indices_past_63_are_refused_not_truncated() {
+        let online: Vec<usize> = (0..80).collect();
+        let err = irq_affinity_mask(&online, &[70]).unwrap_err().to_string();
+        assert!(
+            err.contains("cannot name"),
+            "expected a refusal about the 64-bit mask, got: {err}"
+        );
     }
 
     /// Asking to clear a CPU the machine does not have is a caller error and

--- a/horus_sys/src/rt/linux.rs
+++ b/horus_sys/src/rt/linux.rs
@@ -407,6 +407,51 @@ fn irq_affinity_mask(online: &[usize], rt_cpus: &[usize]) -> anyhow::Result<u64>
     Ok(mask)
 }
 
+/// The CPUs this process may actually run on, from `sched_getaffinity(2)`.
+///
+/// `available_parallelism()` cannot answer this question. It returns a *count*,
+/// and two different CPU sets of the same size compare equal: a process pinned
+/// to CPUs 2-7 of a machine whose online set is 0-5 counts six either way,
+/// while it cannot run on CPUs 0 or 1 at all. The count is also clamped by the
+/// cgroup CPU *quota*, which bounds how much CPU time this process gets rather
+/// than which CPUs exist, so a 2-CPU quota on an 8-CPU host reads as a
+/// confinement that is not there. Both errors matter here: one lets a confined
+/// process reroute the host, the other refuses a process that was entitled to.
+fn allowed_cpus() -> anyhow::Result<Vec<usize>> {
+    // SAFETY: an all-zero `cpu_set_t` is a valid empty set; `sched_getaffinity`
+    // is told the exact size of the object it fills, and pid 0 names the
+    // calling thread. `CPU_ISSET` then reads only bits below `CPU_SETSIZE`,
+    // which is that object's capacity.
+    let cpus = unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        if libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set) != 0 {
+            return Err(anyhow::Error::new(std::io::Error::last_os_error()).context(
+                "sched_getaffinity failed, so this process's own CPU set is \
+                 unknown; refusing to rewrite host IRQ affinity from a guess",
+            ));
+        }
+        (0..libc::CPU_SETSIZE as usize)
+            .filter(|&cpu| libc::CPU_ISSET(cpu, &set))
+            .collect::<Vec<usize>>()
+    };
+    Ok(cpus)
+}
+
+/// The online CPUs this process is *not* allowed to run on.
+///
+/// Empty means this process can reach every CPU the machine has, and so may
+/// speak for the whole machine. Containment is one-directional on purpose:
+/// `allowed` being a strict superset of `online` is the ordinary case, not a
+/// fault, because a task's `cpus_allowed` keeps naming CPUs that have since
+/// been offlined.
+fn online_cpus_outside(allowed: &[usize], online: &[usize]) -> Vec<usize> {
+    online
+        .iter()
+        .copied()
+        .filter(|cpu| !allowed.contains(cpu))
+        .collect()
+}
+
 /// Move hardware interrupts off the specified CPU cores.
 ///
 /// Rewrites `/proc/irq/*/smp_affinity` for every IRQ on the machine, so it is
@@ -443,8 +488,12 @@ fn irq_affinity_mask(online: &[usize], rt_cpus: &[usize]) -> anyhow::Result<u64>
 /// actual CPU set, and the function REFUSES to act when this process cannot see
 /// the whole machine. A process confined to a cpuset has no business rewriting
 /// the interrupt routing of cores outside it, and in a container that is the
-/// normal case, not an edge case. The mask arithmetic itself lives in
-/// [`irq_affinity_mask`], where it is unit-tested on synthetic CPU sets.
+/// normal case, not an edge case. "Cannot see" is decided by comparing the
+/// online set against [`allowed_cpus`] — the set from `sched_getaffinity(2)`,
+/// not a count — because the mistake this function exists to fix was reading a
+/// count as a set in the first place. The mask arithmetic itself lives in
+/// [`irq_affinity_mask`], and the containment test in [`online_cpus_outside`];
+/// both are unit-tested on synthetic CPU sets.
 pub(super) fn move_irqs_off_cpus(cpus: &[usize]) -> anyhow::Result<usize> {
     let irq_dir = std::path::Path::new("/proc/irq");
     if !irq_dir.exists() {
@@ -472,20 +521,27 @@ pub(super) fn move_irqs_off_cpus(cpus: &[usize]) -> anyhow::Result<usize> {
         );
     }
 
-    // If this process is confined, it is not entitled to reroute the host.
-    let visible = std::thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(1);
-    if visible < online.len() {
+    // Computed before the confinement check below, and not only because it is
+    // free: it is what bounds every online index under 64, and therefore under
+    // `CPU_SETSIZE`, so the affinity set the check consults cannot be silently
+    // truncated out from under it on a very large machine.
+    let mask = irq_affinity_mask(&online, cpus)?;
+
+    // If this process is confined, it is not entitled to reroute the host. The
+    // question is not "how many CPUs do I have?" but "may I run on every CPU
+    // this machine has?", so ask for the set rather than a count.
+    let allowed = allowed_cpus()?;
+    let unseen = online_cpus_outside(&allowed, &online);
+    if !unseen.is_empty() {
         anyhow::bail!(
-            "this process sees {visible} of the machine's {} CPUs (cpuset or \
-             taskset), so it cannot compute a correct host-wide IRQ mask; \
-             refusing rather than rerouting interrupts for cores it cannot see",
+            "this process may not run on online CPU(s) {unseen:?} of the \
+             machine's {} (cpuset or taskset), so it is confined to part of the \
+             machine; refusing rather than rerouting interrupts for cores it \
+             cannot see",
             online.len()
         );
     }
 
-    let mask = irq_affinity_mask(&online, cpus)?;
     if mask == 0 {
         return Ok(0); // every CPU is an RT core; nothing left to move IRQs to
     }
@@ -626,26 +682,62 @@ mod irq_affinity_tests {
     ///
     /// The old code guarded with `if cpu < 64` and skipped anything higher, so
     /// on a large machine it wrote a mask while declining to clear the very
-    /// cores it was called for.
+    /// cores it was called for. Asserted on the helper, not through
+    /// `move_irqs_off_cpus`: routed through the real function the host's `/proc`
+    /// and `/sys` pick which refusal comes back, and a test that accepts any of
+    /// several outcomes asserts none of them.
     #[test]
     fn clearing_a_nonexistent_cpu_is_an_error_not_a_silent_skip() {
-        // 4096 is beyond any plausible online set here.
-        let r = move_irqs_off_cpus(&[4096]);
-        match r {
-            Err(e) => {
-                let m = e.to_string();
-                assert!(
-                    m.contains("online set") || m.contains("cannot name") || m.contains("refusing"),
-                    "expected a refusal naming the reason, got: {m}"
-                );
-            }
-            Ok(n) => {
-                // Only acceptable outcome without /proc/irq present.
-                assert_eq!(
-                    n, 0,
-                    "clearing a CPU that does not exist must not report IRQs moved"
-                );
-            }
-        }
+        let err = irq_affinity_mask(&[0, 1, 2, 3], &[4096])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("asked to clear CPU 4096"),
+            "expected a refusal naming the CPU, got: {err}"
+        );
+        assert!(
+            err.contains("not in the machine's online set"),
+            "expected a refusal naming the online set, got: {err}"
+        );
+    }
+
+    /// Confinement is a property of the CPU *set*, which a count cannot see.
+    ///
+    /// Four allowed and four online, so the old `available_parallelism() <
+    /// online.len()` check found nothing wrong — while this process may not run
+    /// on online CPUs 0 or 1 at all.
+    #[test]
+    fn an_equal_sized_but_different_cpu_set_is_still_confinement() {
+        assert_eq!(
+            online_cpus_outside(&[2, 3, 4, 5], &[0, 1, 2, 3]),
+            vec![0, 1]
+        );
+    }
+
+    /// Reaching every online CPU is not confinement, even with CPUs to spare.
+    #[test]
+    fn covering_the_online_set_is_not_confinement() {
+        // Exactly the online set.
+        assert!(online_cpus_outside(&[0, 1, 2, 3], &[0, 1, 2, 3]).is_empty());
+        // A strict superset, which is the ordinary reading once CPU 1 has been
+        // offlined: `cpus_allowed` still names it, `online` no longer does.
+        assert!(online_cpus_outside(&[0, 1, 2, 3], &[0, 2, 3]).is_empty());
+    }
+
+    /// This process's own affinity is a set, and it is one this machine has.
+    ///
+    /// The one host-dependent assertion kept, and it is deliberately weak: it
+    /// only pins down that `allowed_cpus` reads a plausible set rather than,
+    /// say, returning all 1024 `CPU_SETSIZE` bits. The behaviour that matters
+    /// is asserted on synthetic sets above.
+    #[test]
+    fn allowed_cpus_reads_a_set_this_machine_could_have() {
+        let allowed = allowed_cpus().expect("sched_getaffinity on self");
+        assert!(!allowed.is_empty(), "this process runs on some CPU");
+        assert!(
+            allowed.len() <= libc::CPU_SETSIZE as usize,
+            "got {} CPUs, more than a cpu_set_t can name",
+            allowed.len()
+        );
     }
 }


### PR DESCRIPTION
`move_irqs_off_cpus` rewrites `/proc/irq/*/smp_affinity` for **every interrupt on the machine**. It built the mask from `available_parallelism()` — the CPUs *this process* may run on, not the CPUs the machine has.

A count is not a CPU set. Conflating them let a confined process reconfigure the whole host:

| situation | mask produced | effect |
|---|---|---|
| `taskset -c 0-3`, `rt_cpus=[2,3]` | `3` | every host interrupt herded onto CPUs 0–1, including those of cores it never knew existed |
| `taskset -c 8-11` | `f` | names CPUs 0–3 — which this process cannot even run on |
| ≥64 CPUs | `u64::MAX` | confines every interrupt to CPUs 0–63, **and** the `cpu < 64` guard silently declines to clear the RT cores it was called for |

That last one is the worst: it fails its stated purpose *and* clobbers the machine.

## Why this matters more than it looks

- Containers and cpusets are **how robots ship**. This is the normal case, not an edge case.
- There is **no user opt-in**: `rt_executor.rs` calls it unconditionally, and `rt_cpus` defaults to the last core.
- **Nothing restores** the previous routing. `setup-rt --undo` touches only the limits file.
- The docstring said it "clears the bits for the given cores" — it never read existing affinity at all, so it flattens per-IRQ placement. On this host, 32 of 68 IRQs carry a specialised single-CPU affinity.

## The change

The mask comes from `/sys/devices/system/cpu/online` — the machine's actual CPU set — and the function now **refuses** rather than guesses when:

- it cannot read the online set
- this process sees fewer CPUs than the machine has (cpuset/taskset)
- the online set extends past what a 64-bit mask can name
- it is asked to clear a CPU that is not online

This deliberately trades a **silent wrong action for a loud no-op**. Rerouting every interrupt on a host is not something to do on a guess.

## Tests

- the online set is read from sysfs, not from `available_parallelism`
- clearing a nonexistent CPU is reported, not silently skipped (the old `cpu < 64` behaviour)

## Not covered — worth a follow-up

Nothing snapshots the prior per-IRQ affinity, so `--undo` still cannot restore it. That is a bigger change and belongs on its own.

## Verification

`horus_sys` lib **212 passed**; `horus_core`'s `move_irqs` test passes; `cargo clippy -p horus_sys` clean.
