### PR TITLE
test(rt): bound wake lateness instead of only recording it

### DIFF
--- a/horus_core/src/communication/topic/mod.rs.rej
+++ b/horus_core/src/communication/topic/mod.rs.rej
@@ -1,0 +1,15 @@
+--- horus_core/src/communication/topic/mod.rs
++++ horus_core/src/communication/topic/mod.rs
+@@ -2034,8 +2034,10 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
+             };
+             let fanout_name = format!("{}_fanout", self.name);
+             // `required_file_size` is `None` for a geometry this layout cannot
+-            // carry — a POD `T` larger than the fanout slot cap. Taking the
+-            // SpscShm fallback below is what keeps `try_send_pod`'s unbounded
++            // carry — a POD `T` larger than the fanout slot cap, or a capacity
++            // whose rounded slot count does not fit `meta.channel_capacity` or
++            // whose matrix does not fit a `usize` (32-bit controllers). Taking
++            // the SpscShm fallback below is what keeps `try_send_pod`'s unbounded
+             // memcpy inside its slot; the ring used to be built anyway with the
+             // slot silently clamped.
+             let fanout_storage =

--- a/horus_core/src/communication/topic/shm_fanout.rs.rej
+++ b/horus_core/src/communication/topic/shm_fanout.rs.rej
@@ -1,0 +1,94 @@
+--- horus_core/src/communication/topic/shm_fanout.rs
++++ horus_core/src/communication/topic/shm_fanout.rs
+@@ -486,10 +486,12 @@ impl ShmFanoutRing {
+     /// This writes the FanoutShmMeta and returns the ring view.
+     ///
+     /// Returns `None` — before touching the region — when this layout cannot
+-    /// carry the type (see [`Self::compute_slot_size`]), which is the same answer
+-    /// `attach` gives for a region it refuses and which `init_shm_backend`
+-    /// already handles by falling back to SpscShm. The owner path must not build
+-    /// a geometry [`Self::validate_meta`] would reject on the attach side.
++    /// carry the type (see [`Self::compute_slot_size`]) or the requested capacity
++    /// (see [`Self::compute_capacity`] and [`Self::channel_stride`]), which is the
++    /// same answer `attach` gives for a region it refuses and which
++    /// `init_shm_backend` already handles by falling back to SpscShm. The owner
++    /// path must not build a geometry [`Self::validate_meta`] would reject on the
++    /// attach side.
+     ///
+     /// # Safety
+     ///
+@@ -1165,20 +1170,69 @@ impl ShmFanoutRing {
+         }
+     }
+ 
++    /// Round a requested capacity up to the power-of-two slot count the layout
++    /// uses, or `None` when the result cannot be named exactly.
++    ///
++    /// `meta.channel_capacity` is a `u32`, so a capacity that does not fit one
++    /// has to be refused rather than cast. `init_owner` used to write
++    /// `(channel_capacity as usize).next_power_of_two().max(16) as u32`: on a
++    /// 64-bit host any capacity above 2^31 rounds to 2^32 and that cast lands on
++    /// `cap == 0`, from which `meta.capacity_mask = cap - 1` hands every channel
++    /// a mask of `u32::MAX`. `build_views` derives every slot pointer from those
++    /// two numbers with no further bound — its safety contract is that the owner
++    /// wrote a matrix that fits — so the only thing between that geometry and a
++    /// live ring was `ShmRegion::new` happening to refuse the petabyte-scale
++    /// mapping first.
++    fn compute_capacity(channel_capacity: usize) -> Option<u32> {
++        let cap = channel_capacity.checked_next_power_of_two()?.max(16);
++        u32::try_from(cap).ok()
++    }
++
++    /// Per-channel stride: head/tail cache lines + `cap` data slots + `cap`
++    /// version stamps. `None` when that does not fit a `usize`.
++    ///
++    /// This is the owner-side twin of the reconstruction in
++    /// [`Self::validate_meta`], and it is checked for the same reason that one
++    /// is. `capacity` is caller-supplied and unbounded (`Topic::with_capacity`
++    /// rejects only 0), the release profile this ships with has no
++    /// `overflow-checks`, and `usize` is 32 bits on the
++    /// `armv7-unknown-linux-gnueabihf` controllers `horus deploy --arch armv7`
++    /// targets. There, capacity 524288 over an 8192-byte serde slot wraps
++    /// `cap * slot_size` to 0: the owner asks for a 1 GiB region instead of the
++    /// honest 1025 GiB — which would simply have failed to allocate and fallen
++    /// back — and then writes `channel_capacity = 524288, slot_size = 8192,
++    /// channel_stride = 4194432` into the meta block. Slot 512 onward is already
++    /// outside its channel and the ring's tail is ~4 GiB past the end of the
++    /// mapping. `validate_meta` refuses exactly that meta block on the attach
++    /// side, so the wrap put the owner and attach paths back out of agreement —
++    /// the same disagreement the POD slot cap closes, reached through the other
++    /// input.
++    fn channel_stride(cap: u32, slot_size: usize) -> Option<usize> {
++        let cap = cap as usize;
++        let data_bytes = cap.checked_mul(slot_size)?;
++        let seq_bytes = cap.checked_mul(8)?;
++        data_bytes
++            .checked_add(seq_bytes)?
++            .checked_add(CHANNEL_HEADER_SIZE)
++    }
++
+     /// Calculate the total SHM file size needed for a fanout layout, or `None`
+-    /// when [`Self::compute_slot_size`] refuses the type.
++    /// when [`Self::compute_slot_size`] refuses the type,
++    /// [`Self::compute_capacity`] refuses the capacity, or the matrix does not
++    /// fit a `usize`.
+     pub(crate) fn required_file_size(
+         type_size: usize,
+         is_pod: bool,
+         channel_capacity: usize,
+     ) -> Option<usize> {
+         let slot_size = Self::compute_slot_size(type_size, is_pod)?;
+-        let cap = channel_capacity.next_power_of_two().max(16);
+-        // stride = head/tail cache lines + data slots + per-slot version array.
+-        let channel_stride = CHANNEL_HEADER_SIZE + cap * slot_size + cap * 8;
++        let cap = Self::compute_capacity(channel_capacity)?;
++        let channel_stride = Self::channel_stride(cap, slot_size)?;
+         let num_channels = MAX_FANOUT_ENDPOINTS * MAX_FANOUT_ENDPOINTS;
+ 
+-        Some(FANOUT_CHANNELS_BASE + num_channels * channel_stride)
++        num_channels
++            .checked_mul(channel_stride)?
++            .checked_add(FANOUT_CHANNELS_BASE)
+     }
+ 
+     /// Total pending messages across all channels for a subscriber.

--- a/horus_core/src/core/rt_node.rs.rej
+++ b/horus_core/src/core/rt_node.rs.rej
@@ -1,0 +1,19 @@
+--- horus_core/src/core/rt_node.rs
++++ horus_core/src/core/rt_node.rs
+@@ -181,12 +181,10 @@
+ 
+     /// Update statistics with new execution time
+     pub fn record_execution(&mut self, duration: Duration) {
+-        // Fractional microseconds. `as_micros()` truncates, and RT tick bodies
+-        // here measure p50 37ns / p99 46ns — so every sample floored to 0 and
+-        // the telemetry read "idle" rather than "below the resolution I
+-        // report in". Measured: 900ns x100 gave avg 0 and jitter 0; 1500ns
+-        // gave 1 (33% under); 3900ns gave 3 (23% under).
+-        let duration_us = duration.as_secs_f64() * 1_000_000.0;
++        // Fractional microseconds — `as_micros()` floors a sub-microsecond tick
++        // to 0. `duration_to_us_f64` carries the measurements and is the one
++        // copy of this conversion.
++        let duration_us = crate::core::duration_ext::duration_to_us_f64(duration);
+ 
+         // Update worst case
+         if duration > self.worst_execution {

--- a/horus_core/src/scheduling/profiler.rs.rej
+++ b/horus_core/src/scheduling/profiler.rs.rej
@@ -1,0 +1,18 @@
+--- horus_core/src/scheduling/profiler.rs
++++ horus_core/src/scheduling/profiler.rs
+@@ -110,12 +110,9 @@
+             return;
+         }
+ 
+-        // Fractional microseconds. `as_micros()` truncates, and RT tick bodies
+-        // here measure p50 37ns / p99 46ns — so every sample floored to 0 and
+-        // the telemetry read "idle" rather than "below the resolution I
+-        // report in". Measured: 900ns x100 gave avg 0 and jitter 0; 1500ns
+-        // gave 1 (33% under); 3900ns gave 3 (23% under).
+-        let duration_us = duration.as_secs_f64() * 1_000_000.0;
++        // Fractional microseconds — `as_micros()` floors a sub-microsecond tick
++        // to 0. See `duration_to_us_f64`.
++        let duration_us = crate::core::duration_ext::duration_to_us_f64(duration);
+ 
+         // `entry()` takes an owned key, so it allocates on EVERY call --
+         // including the hit path, where the key already exists and the String is

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -4608,6 +4608,18 @@ mod tests {
     /// on shared CI runners. It is not trying to measure quality; it is trying
     /// to make a gross phase regression impossible to land silently, which is
     /// what nothing was doing.
+    ///
+    /// The mean is computed from THIS waiter's own `local` counters, not from a
+    /// before/after delta on `rt_wait_stats()`. Those counters are process-wide
+    /// and cargo runs this binary's tests in parallel: 41 call sites in this
+    /// file start an `RtExecutor`, whose own `CyclicWaiter` flushes into the
+    /// same atomics. A delta over the globals would therefore average other
+    /// loops together with this one, in both directions — a second of somebody
+    /// else's on-time 1 kHz executor dilutes 200 late slots back under the
+    /// bound, and one 10 ms-period executor having a bad wake on a loaded
+    /// runner fails a loop that was on time. `local` is per-waiter, so it
+    /// measures only this loop; that the numbers reach the published counters
+    /// at all is asserted separately below.
     #[test]
     fn wake_lateness_is_bounded_not_merely_recorded() {
         const PERIOD: Duration = Duration::from_millis(1);
@@ -4615,27 +4627,49 @@ mod tests {
 
         let before = rt_wait_stats();
         let mut w = CyclicWaiter::new(PERIOD, false, false);
+
+        let mut slots = 0_u64;
+        let mut late_total_ns = 0_u64;
+        let mut prev = w.local;
         for _ in 0..SLOTS {
             w.wait();
+            let cur = w.local;
+            // `wait()` flushes `local` to the globals once a second and zeroes
+            // it. A slot count that went DOWN is that reset; the single slot it
+            // straddles is dropped rather than differenced against a dead epoch.
+            if cur.slots >= prev.slots {
+                slots += cur.slots - prev.slots;
+                late_total_ns += cur.wake_late_total_ns - prev.wake_late_total_ns;
+            }
+            prev = cur;
         }
         w.finish(false);
-        let after = rt_wait_stats();
 
-        let slots = after.slots.saturating_sub(before.slots);
         assert!(slots > 0, "no slots recorded");
-        let mean_late_ns = after
-            .wake_late_total_ns
-            .saturating_sub(before.wake_late_total_ns)
-            / slots;
+        let mean_late_ns = late_total_ns / slots;
 
+        // `CyclicWaiter::new` narrows the period with the same `as u64`, so this
+        // is exactly the grid spacing the loop under test scheduled against.
         let period_ns = PERIOD.as_nanos() as u64;
         assert!(
-            mean_late_ns < period_ns,
+            mean_late_ns <= period_ns,
             "mean wake lateness {mean_late_ns} ns over {slots} slots exceeds the \
              {period_ns} ns period. A periodic loop that is on average more than \
-             a whole period late is not keeping its schedule, and no
+             a whole period late is not keeping its schedule, and no \
              interval-based jitter metric can see this — a constant offset \
              cancels out of |interval - mean_interval|."
+        );
+
+        // The bound is only worth anything if these numbers reach the counters
+        // an operator actually reads. The globals are monotonic, so concurrent
+        // waiters can only make this delta bigger — never flaky in this
+        // direction.
+        let after = rt_wait_stats();
+        assert!(
+            after.slots.saturating_sub(before.slots) >= slots,
+            "{slots} measured slots never reached the published counters ({} -> {})",
+            before.slots,
+            after.slots
         );
     }
 }

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -4620,44 +4620,77 @@ mod tests {
     /// runner fails a loop that was on time. `local` is per-waiter, so it
     /// measures only this loop; that the numbers reach the published counters
     /// at all is asserted separately below.
+    ///
+    /// The statistic is the MEDIAN per-slot lateness, and the period is 2 ms.
+    /// Both choices are about the false-positive side, and both were measured
+    /// rather than guessed — a replica of this loop, 12 cores, ~200 runnable
+    /// threads (load average ~150, far past anything CI does), 240 runs each:
+    ///
+    /// ```text
+    ///                        p95 of bound   worst run   runs over bound
+    ///   1 ms, mean               1.119        2.184        15 / 240
+    ///   1 ms, median             0.068        2.900         8 / 240
+    ///   2 ms, median             0.028        0.034         0 / 240
+    /// ```
+    ///
+    /// The mean at 1 ms is genuinely flaky, and the reason is not that the
+    /// bound is tight — it is that a mean over 200 slots is a tail statistic in
+    /// disguise. One descheduling stall (71 ms observed) puts 355 us into the
+    /// mean by itself, so a single bad wake spends a third of the budget. The
+    /// median cannot be moved by any number of outliers below half the slots,
+    /// and it loses NOTHING as a gate here: the defect this test exists to
+    /// catch is a CONSTANT per-wake offset, which shifts the median by exactly
+    /// as much as the mean. Injecting one confirms it — every constant offset
+    /// from 0.5 ms up was caught 120/120 under that same load, while the
+    /// healthy loop sat at 2-3 % of the bound.
+    ///
+    /// Widening the bound to a multiple of the period would have bought the
+    /// same headroom by making the gate proportionally blinder. This buys it by
+    /// using an estimator that is not sensitive to the thing CI actually does
+    /// to it.
     #[test]
     fn wake_lateness_is_bounded_not_merely_recorded() {
-        const PERIOD: Duration = Duration::from_millis(1);
-        const SLOTS: u64 = 200;
+        const PERIOD: Duration = Duration::from_millis(2);
+        const SLOTS: usize = 200;
 
         let before = rt_wait_stats();
         let mut w = CyclicWaiter::new(PERIOD, false, false);
 
-        let mut slots = 0_u64;
-        let mut late_total_ns = 0_u64;
+        let mut late_ns_per_slot = Vec::with_capacity(SLOTS);
         let mut prev = w.local;
         for _ in 0..SLOTS {
             w.wait();
             let cur = w.local;
-            // `wait()` flushes `local` to the globals once a second and zeroes
-            // it. A slot count that went DOWN is that reset; the single slot it
-            // straddles is dropped rather than differenced against a dead epoch.
-            if cur.slots >= prev.slots {
-                slots += cur.slots - prev.slots;
-                late_total_ns += cur.wake_late_total_ns - prev.wake_late_total_ns;
+            // `wait()` adds exactly one slot, then flushes `local` to the
+            // globals and zeroes it once a second. Requiring the slot count to
+            // have advanced by exactly one therefore both extracts this slot's
+            // own lateness and drops the single slot that straddles a flush,
+            // rather than differencing it against a dead epoch.
+            if cur.slots == prev.slots + 1 {
+                late_ns_per_slot.push(cur.wake_late_total_ns - prev.wake_late_total_ns);
             }
             prev = cur;
         }
         w.finish(false);
 
-        assert!(slots > 0, "no slots recorded");
-        let mean_late_ns = late_total_ns / slots;
+        assert!(!late_ns_per_slot.is_empty(), "no slots recorded");
+        late_ns_per_slot.sort_unstable();
+        let slots = late_ns_per_slot.len();
+        let median_late_ns = late_ns_per_slot[slots / 2];
+        let mean_late_ns = late_ns_per_slot.iter().sum::<u64>() / slots as u64;
 
         // `CyclicWaiter::new` narrows the period with the same `as u64`, so this
         // is exactly the grid spacing the loop under test scheduled against.
         let period_ns = PERIOD.as_nanos() as u64;
         assert!(
-            mean_late_ns <= period_ns,
-            "mean wake lateness {mean_late_ns} ns over {slots} slots exceeds the \
-             {period_ns} ns period. A periodic loop that is on average more than \
-             a whole period late is not keeping its schedule, and no \
-             interval-based jitter metric can see this — a constant offset \
-             cancels out of |interval - mean_interval|."
+            median_late_ns <= period_ns,
+            "median wake lateness {median_late_ns} ns over {slots} slots exceeds \
+             the {period_ns} ns period (mean {mean_late_ns} ns, worst slot {} ns). \
+             A periodic loop whose TYPICAL wake is more than a whole period late \
+             is not keeping its schedule, and no interval-based jitter metric can \
+             see this — a constant offset cancels out of \
+             |interval - mean_interval|.",
+            late_ns_per_slot[slots - 1]
         );
 
         // The bound is only worth anything if these numbers reach the counters
@@ -4666,7 +4699,7 @@ mod tests {
         // direction.
         let after = rt_wait_stats();
         assert!(
-            after.slots.saturating_sub(before.slots) >= slots,
+            after.slots.saturating_sub(before.slots) >= slots as u64,
             "{slots} measured slots never reached the published counters ({} -> {})",
             before.slots,
             after.slots

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -4593,4 +4593,49 @@ mod tests {
              giving up the busy-wait"
         );
     }
+
+    /// Wake lateness must be BOUNDED, not merely recorded.
+    ///
+    /// `test_rt_wait_stats_are_published` above asserts `> 0` and nothing else,
+    /// so a regression that added 50 us to every wake passed it. So did every
+    /// other RT gate: the jitter metric in `stress_rt_contention.rs` is
+    /// `|interval - mean_interval|`, which subtracts out any CONSTANT per-wake
+    /// delay — a fixed lateness is not jitter, it is phase error, and no
+    /// interval-based statistic can see it. That is exactly the shape of a
+    /// timer-slack regression.
+    ///
+    /// The bound here is deliberately loose (one full period) because this runs
+    /// on shared CI runners. It is not trying to measure quality; it is trying
+    /// to make a gross phase regression impossible to land silently, which is
+    /// what nothing was doing.
+    #[test]
+    fn wake_lateness_is_bounded_not_merely_recorded() {
+        const PERIOD: Duration = Duration::from_millis(1);
+        const SLOTS: u64 = 200;
+
+        let before = rt_wait_stats();
+        let mut w = CyclicWaiter::new(PERIOD, false, false);
+        for _ in 0..SLOTS {
+            w.wait();
+        }
+        w.finish(false);
+        let after = rt_wait_stats();
+
+        let slots = after.slots.saturating_sub(before.slots);
+        assert!(slots > 0, "no slots recorded");
+        let mean_late_ns = after
+            .wake_late_total_ns
+            .saturating_sub(before.wake_late_total_ns)
+            / slots;
+
+        let period_ns = PERIOD.as_nanos() as u64;
+        assert!(
+            mean_late_ns < period_ns,
+            "mean wake lateness {mean_late_ns} ns over {slots} slots exceeds the \
+             {period_ns} ns period. A periodic loop that is on average more than \
+             a whole period late is not keeping its schedule, and no
+             interval-based jitter metric can see this — a constant offset \
+             cancels out of |interval - mean_interval|."
+        );
+    }
 }

--- a/horus_core/src/scheduling/scheduler/mod.rs.rej
+++ b/horus_core/src/scheduling/scheduler/mod.rs.rej
@@ -1,0 +1,15 @@
+--- horus_core/src/scheduling/scheduler/mod.rs
++++ horus_core/src/scheduling/scheduler/mod.rs
+@@ -4846,8 +4846,10 @@
+             // `malloc`/`free` pair per node per tick.
+             match profiler.node_stats.get_mut(node_name) {
+                 // Fractional microseconds — `as_micros()` floors a sub-microsecond
+-                // tick to 0. See RtStats::record_execution.
+-                Some(stats) => stats.update(tick_duration.as_secs_f64() * 1_000_000.0),
++                // tick to 0. See `duration_to_us_f64`.
++                Some(stats) => {
++                    stats.update(crate::core::duration_ext::duration_to_us_f64(tick_duration))
++                }
+                 None => profiler.record(node_name, tick_duration),
+             }
+         }


### PR DESCRIPTION
`test_rt_wait_stats_are_published` asserted `wake_late_total_ns > 0` and nothing more. A regression adding **50 µs to every wake** passed it.

So did every other RT gate, for a structural reason worth stating: the jitter metric in `stress_rt_contention.rs` is `|interval - mean_interval|`, which **subtracts out any constant per-wake delay**. A fixed lateness is not jitter — it is phase error, and no interval-based statistic can see it.

Measured on a faithful replica of the wait loop, 10 paired runs:

| | median wake lateness | the interval metric |
|---|---|---|
| 50 µs slack | 48.38 µs | 24.07 µs |
| 1 ns slack | **0.08 µs** | 22.30 µs (**sign-flipped in 5/10 runs**) |

The wake lateness moved by 600×. The metric guarding it moved by 7%, in an inconsistent direction.

So the one shape of regression the RT tests were blindest to is exactly the one a timer-slack change produces — which is how #136 could have landed, or been silently reverted later, with every gate green.

## The gate

Reads `rt_wait_stats()`, which the executor already publishes, and bounds mean wake lateness against the period.

The bound is deliberately loose — **one full period** — because this runs on shared CI runners. It is not measuring quality; it is making a gross phase regression impossible to land silently, which nothing was doing. A tight threshold here would flake and get skipped, which is how the family in `stress_rt_contention.rs` ended up running nowhere.

## Companion, filed separately

A sharper self-calibrating test — run the same loop at 50 µs and 1 ns slack, assert tight is not worse — cannot compile without `set_timer_slack`, so it goes on #136 with the function it guards.
