### PR TITLE
ci: stop gating on chaos suites that 2 vCPUs cannot run reliably

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -197,7 +197,19 @@ jobs:
       # that is heavy oversubscription and their timing assumptions stop holding.
       # Pinned to two cores locally, chaos_cross_process failed 1 of 4 once and
       # production_validation exceeded 900s once, while both passed cleanly on a
-      # calmer pass. The step went red on one PR and green on main inside an hour.
+      # calmer pass.
+      #
+      # The CI failure that prompted this was NOT that, and is worse:
+      # multi_scheduler_matrix::deterministic_alongside_normal_scheduler dies
+      # with SIGBUS. Reproduced locally 2 runs in 5 on a 12-core box on current
+      # main, so it is not a runner artifact. gdb puts it in
+      # `dispatch::send_shm_mp_pod::<CmdVel>` -> `Scheduler::tick_once`: the MPSC
+      # POD send dereferences `local.cached_header_ptr`, and SIGBUS means that
+      # page is mapped but no longer backed -- the region was recreated or
+      # truncated under an in-flight send. `epoch_guard_send!` only compares
+      # `process_epoch`, so it does not cover a region swapped by another party.
+      # That suite is advisory below until the fault is fixed; the fix belongs
+      # in the topic layer, not in CI config.
       #
       # An intermittently-red REQUIRED check is worse than no check: it blocks
       # unrelated PRs at random. That is the same reasoning this file already
@@ -207,7 +219,7 @@ jobs:
         timeout-minutes: 25
         run: |
           for suite in ipc_torture chaos_monkey message_type_matrix \
-                       multi_scheduler_matrix hardware_emulation \
+                       hardware_emulation \
                        params_intent log_system_tests \
                        rust_python_full_matrix rust_python_matrix \
                        humanoid_stress matrix_sweep; do
@@ -233,7 +245,8 @@ jobs:
         timeout-minutes: 25
         run: |
           for suite in chaos_cross_process production_validation \
-                       chaos_xp_schedulers production_fanout_battle; do
+                       chaos_xp_schedulers production_fanout_battle \
+                       multi_scheduler_matrix; do
             echo "::group::$suite"
             cargo test -p horus_core --release --test "$suite" -- \
               --ignored --test-threads=1 --nocapture

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -188,15 +188,52 @@ jobs:
       #
       # Measured locally at ~5 min for the 55 tests, all passing, with no
       # /dev/shm growth across the run.
+      # Split by how much CPU the suite actually needs, which #126 got wrong.
+      #
+      # #126 enabled these as one blocking step on the strength of them passing
+      # in ~5 min on a 12-core box. That was the wrong measurement: a hosted
+      # runner has 2 vCPUs, and several of these spawn REAL child processes --
+      # chaos_cross_process runs five, xp_10_processes_chaos runs ten. At 2 vCPUs
+      # that is heavy oversubscription and their timing assumptions stop holding.
+      # Pinned to two cores locally, chaos_cross_process failed 1 of 4 once and
+      # production_validation exceeded 900s once, while both passed cleanly on a
+      # calmer pass. The step went red on one PR and green on main inside an hour.
+      #
+      # An intermittently-red REQUIRED check is worse than no check: it blocks
+      # unrelated PRs at random. That is the same reasoning this file already
+      # applies to stress_rt_* above -- "what such a number is evidence of is
+      # neighbours, not a regression in HORUS".
       - name: Run cross-process and chaos suites (#[ignore]d)
         timeout-minutes: 25
         run: |
-          for suite in chaos_cross_process ipc_torture production_validation \
-                       chaos_monkey message_type_matrix multi_scheduler_matrix \
-                       hardware_emulation chaos_xp_schedulers \
-                       production_fanout_battle params_intent log_system_tests \
+          for suite in ipc_torture chaos_monkey message_type_matrix \
+                       multi_scheduler_matrix hardware_emulation \
+                       params_intent log_system_tests \
                        rust_python_full_matrix rust_python_matrix \
                        humanoid_stress matrix_sweep; do
+            echo "::group::$suite"
+            cargo test -p horus_core --release --test "$suite" -- \
+              --ignored --test-threads=1 --nocapture
+            echo "::endgroup::"
+          done
+        env:
+          RUST_BACKTRACE: 1
+          PYTHONPATH: ${{ github.workspace }}/horus_py
+
+      # The heavy-process suites still RUN -- dropping them would put them back
+      # in the dark #126 found them in -- but they do not gate, because on this
+      # hardware a failure does not distinguish a HORUS regression from a busy
+      # runner. A real regression shows up as a persistent red across runs.
+      #
+      # To promote one back to blocking: show it green across ~20 consecutive
+      # 2-vCPU runs, or move it to dedicated hardware where its process count is
+      # not oversubscribed.
+      - name: Heavy multi-process suites (advisory, not a gate)
+        continue-on-error: true
+        timeout-minutes: 25
+        run: |
+          for suite in chaos_cross_process production_validation \
+                       chaos_xp_schedulers production_fanout_battle; do
             echo "::group::$suite"
             cargo test -p horus_core --release --test "$suite" -- \
               --ignored --test-threads=1 --nocapture

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -216,7 +216,7 @@ jobs:
       # unrelated PRs at random. That is the same reasoning this file already
       # applies to stress_rt_* above -- "what such a number is evidence of is
       # neighbours, not a regression in HORUS".
-      - name: Single-process #[ignore]d suites (gating)
+      - name: "Single-process #[ignore]d suites (gating)"
         timeout-minutes: 25
         run: |
           for suite in ipc_torture chaos_monkey message_type_matrix \
@@ -286,7 +286,7 @@ jobs:
       # Kept running, and kept SEPARATE, so the day it stops dying is visible.
       # It goes back to gating when the topic-layer fix lands -- not when a
       # runner happens to be quiet.
-      - name: multi_scheduler_matrix (advisory — known SIGBUS, see #140)
+      - name: "multi_scheduler_matrix (advisory — known SIGBUS, see #140)"
         continue-on-error: true
         timeout-minutes: 15
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -193,7 +193,8 @@ jobs:
       # #126 enabled these as one blocking step on the strength of them passing
       # in ~5 min on a 12-core box. That was the wrong measurement: a hosted
       # runner has 2 vCPUs, and several of these spawn REAL child processes --
-      # chaos_cross_process runs five, xp_10_processes_chaos runs ten. At 2 vCPUs
+      # chaos_cross_process spawns five, and its own xp_10_processes_chaos test
+      # spawns ten. At 2 vCPUs
       # that is heavy oversubscription and their timing assumptions stop holding.
       # Pinned to two cores locally, chaos_cross_process failed 1 of 4 once and
       # production_validation exceeded 900s once, while both passed cleanly on a
@@ -215,7 +216,7 @@ jobs:
       # unrelated PRs at random. That is the same reasoning this file already
       # applies to stress_rt_* above -- "what such a number is evidence of is
       # neighbours, not a regression in HORUS".
-      - name: Run cross-process and chaos suites (#[ignore]d)
+      - name: Single-process #[ignore]d suites (gating)
         timeout-minutes: 25
         run: |
           for suite in ipc_torture chaos_monkey message_type_matrix \
@@ -240,18 +241,57 @@ jobs:
       # To promote one back to blocking: show it green across ~20 consecutive
       # 2-vCPU runs, or move it to dedicated hardware where its process count is
       # not oversubscribed.
-      - name: Heavy multi-process suites (advisory, not a gate)
+      - name: Oversubscribed multi-process suites (advisory, not a gate)
         continue-on-error: true
         timeout-minutes: 25
         run: |
+          # `|| status=1` per suite, not a bare invocation. Actions runs this
+          # with `bash -e`, so the FIRST failing suite would otherwise end the
+          # step and the rest would never run -- an advisory step that reports
+          # one failure and hides four is worse than no advisory step, because
+          # the silence reads as "the others passed".
+          status=0
           for suite in chaos_cross_process production_validation \
-                       chaos_xp_schedulers production_fanout_battle \
-                       multi_scheduler_matrix; do
+                       chaos_xp_schedulers production_fanout_battle; do
             echo "::group::$suite"
             cargo test -p horus_core --release --test "$suite" -- \
-              --ignored --test-threads=1 --nocapture
+              --ignored --test-threads=1 --nocapture || {
+                status=1
+                echo "::warning::$suite failed (advisory)"
+              }
             echo "::endgroup::"
           done
+          exit $status
+        env:
+          RUST_BACKTRACE: 1
+          PYTHONPATH: ${{ github.workspace }}/horus_py
+
+      # multi_scheduler_matrix is advisory for a DIFFERENT reason than the step
+      # above, and merging the two would bury it. The suites above are advisory
+      # because 2 vCPUs cannot schedule five or ten real child processes to
+      # their timing assumptions -- an environment limit. This one is advisory
+      # because it exposes a correctness fault:
+      #
+      #   deterministic_alongside_normal_scheduler
+      #   (signal: 7, SIGBUS: access to undefined memory)
+      #
+      # reproduced 2 runs in 5 on a 12-core box on main, so it is not a runner
+      # artifact. gdb puts it in `dispatch::send_shm_mp_pod::<CmdVel>` ->
+      # `Scheduler::tick_once`: the MPSC POD send dereferences
+      # `local.cached_header_ptr` and the page is mapped but no longer backed --
+      # the region was recreated or truncated under an in-flight send.
+      # `epoch_guard_send!` compares only `process_epoch`, so it does not cover
+      # a region swapped by another party.
+      #
+      # Kept running, and kept SEPARATE, so the day it stops dying is visible.
+      # It goes back to gating when the topic-layer fix lands -- not when a
+      # runner happens to be quiet.
+      - name: multi_scheduler_matrix (advisory — known SIGBUS, see #140)
+        continue-on-error: true
+        timeout-minutes: 15
+        run: |
+          cargo test -p horus_core --release --test multi_scheduler_matrix -- \
+            --ignored --test-threads=1 --nocapture
         env:
           RUST_BACKTRACE: 1
           PYTHONPATH: ${{ github.workspace }}/horus_py


### PR DESCRIPTION
**Corrects my own #126.**

#126 enabled fourteen previously-dark suites as one **blocking** step, on the
strength of them passing in ~5 minutes on a 12-core box. That was the wrong
measurement.

A hosted runner has **2 vCPUs**, and several of these spawn *real child
processes* — `chaos_cross_process` runs five, `xp_10_processes_chaos` runs ten.
At 2 vCPUs that is heavy oversubscription and their timing assumptions stop
holding.

Pinned to two cores locally:

| | result |
|---|---|
| `chaos_cross_process` | failed **1 of 4** once, clean on retry |
| `production_validation` | exceeded **900 s** once, 57 s on a calmer pass |
| all fourteen, calm pass | green, 543 s total |

In CI the step went **red on one PR and green on main inside the same hour**.

An intermittently-red *required* check is worse than no check: it blocks
unrelated PRs at random — precisely the complaint that started this work. It is
also the same reasoning this file already applies to `stress_rt_*`:

> what such a number is evidence of is neighbours, not a regression in HORUS

I made that argument for the timing gate in #130 and then failed to apply it to
my own step.

**The verification gap was specific:** I pinned the *Python* suite to 2 cores
before gating it, and never did the same for these. The measurement I skipped is
exactly the one that would have caught this.

## What changes

- **Ten suites keep gating** — `ipc_torture`, `chaos_monkey`,
  `message_type_matrix`, `multi_scheduler_matrix`, `hardware_emulation`,
  `params_intent`, `log_system_tests`, `rust_python_full_matrix`,
  `rust_python_matrix`, `humanoid_stress`, `matrix_sweep`.
- **Four heavy multi-process suites move to `continue-on-error`** —
  `chaos_cross_process`, `production_validation`, `chaos_xp_schedulers`,
  `production_fanout_battle`.

They still **run**. Dropping them would put them back in the dark #126 found
them in. They just cannot fail an unrelated PR. A real regression there shows as
a persistent red across runs rather than a coin flip, and the comment states what
it takes to promote one back to blocking: ~20 consecutive green 2-vCPU runs, or
dedicated hardware where the process count isn't oversubscribed.

---

## Corrections after review

**Count and classification.** This moves **five** suites off the gate, not four, and `multi_scheduler_matrix` does **not** remain gating — an earlier revision of this description said both. It is now in a step of its own, because it is advisory for a different reason than the rest: the others are limited by 2 vCPUs scheduling five or ten real child processes, while this one exposes the SIGBUS. An environment limit and a memory-safety fault should not share a heading, or the day the fault stops firing is invisible.

**A real defect the review caught.** The advisory loop ran under Actions' default `bash -e`, so the first failing suite ended the step and the remaining four never ran. An advisory step that reports one failure and silently skips four is worse than no advisory step — the silence reads as "the others passed". Each suite now records into `status`, emits a `::warning::` annotation on failure, and the step exits with the accumulated value; `continue-on-error` is the only thing making it non-gating.

**Step names.** The gating step was still called "Run cross-process and chaos suites" after the cross-process suites moved out of it, and the rationale named `xp_10_processes_chaos` alongside `chaos_cross_process` as though they were two suites — it is a test *inside* that suite (`chaos_cross_process.rs:537`).

## One thing worth folding in

`generate_namespace()` gives every test binary its own SHM namespace, with the comment *"Test binaries get their own, so a test run cannot corrupt another test run."* An explicit `HORUS_NAMESPACE` **overrides** that — and this job sets one job-wide, so all suites share a tree and the isolation is off exactly where these suites need it. Appending `_${suite}` restores it. I had this on #128 and dropped it to avoid two PRs editing the same step; it belongs here if you want it.
