### PR TITLE
ci(autopilot): re-arm auto-merge after updating, and fail loudly

### DIFF
--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -206,7 +206,14 @@ jobs:
           # help land changes to what executes inside CI with nobody reading
           # them. Excluding bot authors keeps this job out of that loop entirely;
           # dependabot's own workflow is unaffected either way.
-          # ONE PR per run, the oldest.
+          # A failed `gh pr list` prints nothing and exits non-zero, which
+          # without this reads as "the queue is empty": the job logs exactly
+          # that and reports success. Silent no-op is the worst failure mode for
+          # an unattended job — an auth expiry would be indistinguishable from a
+          # healthy queue while every PR starved.
+          set -euo pipefail
+
+          # ONE PR per run, the lowest-numbered.
           #
           # Updating every behind branch at once looks faster and is not: main
           # takes one merge at a time, and that merge puts every other branch
@@ -234,6 +241,22 @@ jobs:
 
           gh pr update-branch "$front" --repo "$GITHUB_REPOSITORY" \
             || echo "::warning::could not update #$front"
+
+          # Re-arm auto-merge. Updating a branch CLEARS it, and this job selects
+          # candidates BY auto-merge being enabled — so without this line every
+          # PR the convoy helps drops out of the convoy's own queue permanently
+          # and is never looked at again. That is the starvation this job exists
+          # to prevent, caused by the job.
+          #
+          # Measured on the live repo: `gh pr update-branch 124` left it
+          # `autoMergeRequest=null`, and seven PRs updated or pushed to earlier
+          # were all sitting disarmed (#98 #96 #107 #109 #121 #122 #123).
+          #
+          # Re-arming only restores the state the PR was selected for. It cannot
+          # arm a PR that did not already have auto-merge on, so the
+          # human-intent guard in the selection filter is unchanged.
+          gh pr merge "$front" --repo "$GITHUB_REPOSITORY" --auto --squash \
+            || echo "::warning::could not re-arm auto-merge on #$front"
 
           if [ "$total" -gt 1 ]; then
             # paste joins with a single separator and no trailing one; `tr`

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -11,7 +11,9 @@ name: Autopilot
 #             RECUR. Most red CI here is the runner, not the code.
 #   convoy  — main requires branches be up to date, and GitHub's auto-merge does
 #             not update them, so queued PRs starve. This updates ONE. It calls
-#             `gh pr update-branch` and nothing else.
+#             `gh pr update-branch`, then `gh pr merge --auto` to put back the
+#             auto-merge that updating a branch clears — arming the same flag
+#             the PR was selected for, never merging anything itself.
 
 on:
   schedule:
@@ -239,8 +241,12 @@ jobs:
           printf '%s queued PR(s) behind; updating #%s, rest wait.\n' \
             "$total" "$front"
 
-          gh pr update-branch "$front" --repo "$GITHUB_REPOSITORY" \
-            || echo "::warning::could not update #$front"
+          if gh pr update-branch "$front" --repo "$GITHUB_REPOSITORY"; then
+            updated=1
+          else
+            updated=0
+            echo "::warning::could not update #$front"
+          fi
 
           # Re-arm auto-merge. Updating a branch CLEARS it, and this job selects
           # candidates BY auto-merge being enabled — so without this line every
@@ -255,8 +261,28 @@ jobs:
           # Re-arming only restores the state the PR was selected for. It cannot
           # arm a PR that did not already have auto-merge on, so the
           # human-intent guard in the selection filter is unchanged.
-          gh pr merge "$front" --repo "$GITHUB_REPOSITORY" --auto --squash \
-            || echo "::warning::could not re-arm auto-merge on #$front"
+          #
+          # A failed re-arm is fatal only when the update SUCCEEDED, and that
+          # asymmetry is the whole point:
+          #   update failed  -> auto-merge was never cleared, the PR is still a
+          #                     candidate, and the next run retries it. That is
+          #                     self-healing, so a warning is the honest report.
+          #   update worked  -> auto-merge is gone and nothing else puts it
+          #                     back. The PR has left this job's candidate list
+          #                     for good, and a warning on a green run is
+          #                     exactly the silent no-op the `set -e` above
+          #                     exists to stop.
+          if ! gh pr merge "$front" --repo "$GITHUB_REPOSITORY" --auto --squash
+          then
+            if [ "$updated" -eq 1 ]; then
+              echo "::error::#$front was updated but could not be re-armed, so"
+              echo "::error::its auto-merge is now OFF and this job will not see"
+              echo "::error::it again. Re-arm with: gh pr merge $front --auto --squash"
+              exit 1
+            fi
+            echo "::warning::could not re-arm auto-merge on #$front; its update"
+            echo "::warning::also failed, so auto-merge was never cleared"
+          fi
 
           if [ "$total" -gt 1 ]; then
             # paste joins with a single separator and no trailing one; `tr`

--- a/horus_core/src/scheduling/rt_executor.rs.rej
+++ b/horus_core/src/scheduling/rt_executor.rs.rej
@@ -1,0 +1,107 @@
+--- horus_core/src/scheduling/rt_executor.rs
++++ horus_core/src/scheduling/rt_executor.rs
+@@ -4620,44 +4620,77 @@ mod tests {
+     /// runner fails a loop that was on time. `local` is per-waiter, so it
+     /// measures only this loop; that the numbers reach the published counters
+     /// at all is asserted separately below.
++    ///
++    /// The statistic is the MEDIAN per-slot lateness, and the period is 2 ms.
++    /// Both choices are about the false-positive side, and both were measured
++    /// rather than guessed — a replica of this loop, 12 cores, ~200 runnable
++    /// threads (load average ~150, far past anything CI does), 240 runs each:
++    ///
++    /// ```text
++    ///                        p95 of bound   worst run   runs over bound
++    ///   1 ms, mean               1.119        2.184        15 / 240
++    ///   1 ms, median             0.068        2.900         8 / 240
++    ///   2 ms, median             0.028        0.034         0 / 240
++    /// ```
++    ///
++    /// The mean at 1 ms is genuinely flaky, and the reason is not that the
++    /// bound is tight — it is that a mean over 200 slots is a tail statistic in
++    /// disguise. One descheduling stall (71 ms observed) puts 355 us into the
++    /// mean by itself, so a single bad wake spends a third of the budget. The
++    /// median cannot be moved by any number of outliers below half the slots,
++    /// and it loses NOTHING as a gate here: the defect this test exists to
++    /// catch is a CONSTANT per-wake offset, which shifts the median by exactly
++    /// as much as the mean. Injecting one confirms it — every constant offset
++    /// from 0.5 ms up was caught 120/120 under that same load, while the
++    /// healthy loop sat at 2-3 % of the bound.
++    ///
++    /// Widening the bound to a multiple of the period would have bought the
++    /// same headroom by making the gate proportionally blinder. This buys it by
++    /// using an estimator that is not sensitive to the thing CI actually does
++    /// to it.
+     #[test]
+     fn wake_lateness_is_bounded_not_merely_recorded() {
+-        const PERIOD: Duration = Duration::from_millis(1);
+-        const SLOTS: u64 = 200;
++        const PERIOD: Duration = Duration::from_millis(2);
++        const SLOTS: usize = 200;
+ 
+         let before = rt_wait_stats();
+         let mut w = CyclicWaiter::new(PERIOD, false, false);
+ 
+-        let mut slots = 0_u64;
+-        let mut late_total_ns = 0_u64;
++        let mut late_ns_per_slot = Vec::with_capacity(SLOTS);
+         let mut prev = w.local;
+         for _ in 0..SLOTS {
+             w.wait();
+             let cur = w.local;
+-            // `wait()` flushes `local` to the globals once a second and zeroes
+-            // it. A slot count that went DOWN is that reset; the single slot it
+-            // straddles is dropped rather than differenced against a dead epoch.
+-            if cur.slots >= prev.slots {
+-                slots += cur.slots - prev.slots;
+-                late_total_ns += cur.wake_late_total_ns - prev.wake_late_total_ns;
++            // `wait()` adds exactly one slot, then flushes `local` to the
++            // globals and zeroes it once a second. Requiring the slot count to
++            // have advanced by exactly one therefore both extracts this slot's
++            // own lateness and drops the single slot that straddles a flush,
++            // rather than differencing it against a dead epoch.
++            if cur.slots == prev.slots + 1 {
++                late_ns_per_slot.push(cur.wake_late_total_ns - prev.wake_late_total_ns);
+             }
+             prev = cur;
+         }
+         w.finish(false);
+ 
+-        assert!(slots &gt; 0, "no slots recorded");
+-        let mean_late_ns = late_total_ns / slots;
++        assert!(!late_ns_per_slot.is_empty(), "no slots recorded");
++        late_ns_per_slot.sort_unstable();
++        let slots = late_ns_per_slot.len();
++        let median_late_ns = late_ns_per_slot[slots / 2];
++        let mean_late_ns = late_ns_per_slot.iter().sum::&lt;u64&gt;() / slots as u64;
+ 
+         // `CyclicWaiter::new` narrows the period with the same `as u64`, so this
+         // is exactly the grid spacing the loop under test scheduled against.
+         let period_ns = PERIOD.as_nanos() as u64;
+         assert!(
+-            mean_late_ns &lt;= period_ns,
+-            "mean wake lateness {mean_late_ns} ns over {slots} slots exceeds the \
+-             {period_ns} ns period. A periodic loop that is on average more than \
+-             a whole period late is not keeping its schedule, and no \
+-             interval-based jitter metric can see this — a constant offset \
+-             cancels out of |interval - mean_interval|."
++            median_late_ns &lt;= period_ns,
++            "median wake lateness {median_late_ns} ns over {slots} slots exceeds \
++             the {period_ns} ns period (mean {mean_late_ns} ns, worst slot {} ns). \
++             A periodic loop whose TYPICAL wake is more than a whole period late \
++             is not keeping its schedule, and no interval-based jitter metric can \
++             see this — a constant offset cancels out of \
++             |interval - mean_interval|.",
++            late_ns_per_slot[slots - 1]
+         );
+ 
+         // The bound is only worth anything if these numbers reach the counters
+@@ -4666,7 +4699,7 @@ mod tests {
+         // direction.
+         let after = rt_wait_stats();
+         assert!(
+-            after.slots.saturating_sub(before.slots) &gt;= slots,
++            after.slots.saturating_sub(before.slots) &gt;= slots as u64,
+             "{slots} measured slots never reached the published counters ({} -&gt; {})",
+             before.slots,
+             after.slots


### PR DESCRIPTION
The front-of-queue and push-trigger changes landed. These two did not, and the first is the load-bearing one.

## The convoy was disarming every PR it helped

It selects candidates **by auto-merge being enabled** — and `gh pr update-branch` **clears** auto-merge. So every PR the convoy updates drops out of the convoy's own candidate list permanently and is never looked at again.

That is the exact starvation this job exists to prevent, caused by the job.

Measured on the live repo:

```
gh pr update-branch 124   →  autoMergeRequest = null
```

and seven PRs updated or pushed to earlier were all found sitting disarmed: **#98 #96 #107 #109 #121 #122 #123**.

Re-arming restores only the state the PR was selected for. It cannot arm a PR that did not already have auto-merge on, so the human-intent guard in the selection filter is untouched.

## Strict mode

A failed `gh pr list` prints nothing and exits non-zero — and the script read that as *"the queue is empty"*, logged exactly that, and reported success.

For an unattended job that is the worst failure mode: an auth expiry is indistinguishable from a healthy empty queue, while every PR starves.

## Verified both ways

Extracted the step from the YAML and ran it:

```
GITHUB_REPOSITORY=softmata/horus  →  8 queued PR(s) behind; updating #128, rest wait.
                                     DRYRUN-update 128 --repo softmata/horus
                                     DRYRUN-rearm  128 --repo softmata/horus --auto --squash
                                     Still waiting: 131 133 135 136 138 139 141
                                     exit 0

GITHUB_REPOSITORY=nope/nope-xyz   →  exit 1
```

Also corrects the comment — the code sorts by PR number, so "the oldest" is "the lowest-numbered".
