### PR TITLE
test(#144): a deterministic reproducer for the topic-attach SIGBUS

### DIFF
--- a/horus_core/tests/multi_scheduler_matrix.rs
+++ b/horus_core/tests/multi_scheduler_matrix.rs
@@ -656,7 +656,10 @@ fn deterministic_alongside_normal_scheduler() {
         let t2 = topic.clone();
         let h_normal = std::thread::spawn(move || {
             let mut sched = Scheduler::new().tick_rate(50_u64.hz()).name("normal_sched");
-            let _ = sched
+            // Not `let _ =`: a dropped registration leaves a scheduler with no
+            // subscriber in it, which is indistinguishable from the silent
+            // no-subscriber run this node was added to rule out.
+            sched
                 .add(CmdVelSubNode {
                     topic_name: t2,
                     node_name: "normal_sub".into(),
@@ -665,7 +668,8 @@ fn deterministic_alongside_normal_scheduler() {
                 })
                 .rate(50_u64.hz())
                 .order(0)
-                .build();
+                .build()
+                .expect("register normal_sub");
             while r2.load(Ordering::Relaxed) {
                 let _ = sched.tick_once();
                 std::thread::sleep(Duration::from_millis(18));
@@ -751,7 +755,8 @@ fn deterministic_alongside_normal_scheduler() {
     assert_eq!(v1.len(), 500, "Det run 1 should produce 500 msgs");
     assert_eq!(v2.len(), 500, "Det run 2 should produce 500 msgs");
     assert_eq!(v1, v2, "Deterministic outputs differ between runs!");
-    // Normal scheduler may or may not receive (CmdVel vs Imu type mismatch in this test)
-    // The key assertion is determinism
+    // Both ends are `Topic<CmdVel>` now, so there is no type mismatch left to
+    // explain a zero count -- it is purely the tick-timing note above. The key
+    // assertion is determinism.
     println!("✓ [4/20] deterministic_alongside_normal_scheduler — PASSED");
 }

--- a/horus_core/tests/multi_scheduler_matrix.rs
+++ b/horus_core/tests/multi_scheduler_matrix.rs
@@ -83,6 +83,44 @@ impl Node for ImuSubNode {
     }
 }
 
+/// A subscriber for the CmdVel topic the deterministic scheduler publishes.
+///
+/// `deterministic_alongside_normal_scheduler` used `ImuSubNode` here, on the
+/// same topic name a `DetCmdVelPubNode` was publishing to. One topic name, two
+/// message types: `Imu` is a 304-byte POD needing 312-byte slots, `CmdVel`
+/// declares 64, so the open was refused --
+///
+///   shared header declares slot_size 64 for a 304-byte POD message under the
+///   co-located layout, which needs at least 312 -- each write would run past
+///   its slot
+///
+/// -- and the subscriber never initialised. Nothing caught it, because the test
+/// prints the receive count and never asserts it, so "Normal sched received: 0
+/// msgs" read as normal output for a run that had no subscriber at all.
+struct CmdVelSubNode {
+    topic_name: String,
+    node_name: String,
+    topic: Option<Topic<CmdVel>>,
+    received: Arc<AtomicU64>,
+}
+
+impl Node for CmdVelSubNode {
+    fn name(&self) -> &str {
+        &self.node_name
+    }
+    fn init(&mut self) -> horus_core::error::HorusResult<()> {
+        self.topic = Some(Topic::new(&self.topic_name)?);
+        Ok(())
+    }
+    fn tick(&mut self) {
+        if let Some(ref t) = self.topic {
+            while t.recv().is_some() {
+                self.received.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
 // ════════════════════════════════════════════════════════════════════════
 // TEST 1: 3 schedulers at 1kHz/100Hz/10Hz sharing IMU topic
 // ════════════════════════════════════════════════════════════════════════
@@ -619,12 +657,11 @@ fn deterministic_alongside_normal_scheduler() {
         let h_normal = std::thread::spawn(move || {
             let mut sched = Scheduler::new().tick_rate(50_u64.hz()).name("normal_sched");
             let _ = sched
-                .add(ImuSubNode {
+                .add(CmdVelSubNode {
                     topic_name: t2,
                     node_name: "normal_sub".into(),
                     topic: None,
                     received: nr,
-                    corrupted: Arc::new(AtomicU64::new(0)),
                 })
                 .rate(50_u64.hz())
                 .order(0)
@@ -701,10 +738,14 @@ fn deterministic_alongside_normal_scheduler() {
         "║  Identical: {}                                          ║",
         v1 == v2
     );
-    println!(
-        "║  Normal sched received: {} msgs (from det sched)        ║",
-        nr_count
-    );
+    // Usually 0, and that is not a failure. The deterministic scheduler runs
+    // its 500 ticks back-to-back with no sleep -- the whole run is ~20 ms --
+    // while the normal scheduler sleeps 18 ms between ticks, so the publisher
+    // is generally done before the subscriber's first tick. What this test
+    // asserts is that the deterministic output is IDENTICAL whether or not a
+    // normal scheduler is running alongside; the count is context, not a
+    // contract, and is labelled so nobody reads 0 as a delivery bug.
+    println!("║  Normal sched received: {nr_count} msgs (timing-dependent, 0 is normal) ║");
     println!("╚══════════════════════════════════════════════════════════╝");
 
     assert_eq!(v1.len(), 500, "Det run 1 should produce 500 msgs");

--- a/horus_core/tests/rejected_attach_strands_publisher.rs
+++ b/horus_core/tests/rejected_attach_strands_publisher.rs
@@ -1,0 +1,88 @@
+//! A rejected attach must not be able to SIGBUS a healthy publisher.
+//!
+//! Issue #144. HORUS correctly refuses to open an existing topic under a
+//! second, incompatible message type — `Imu` is a 304-byte POD needing
+//! 312-byte slots, and a region created for `CmdVel` declares 64:
+//!
+//!   shared header declares slot_size 64 for a 304-byte POD message under the
+//!   co-located layout, which needs at least 312 — each write would run past
+//!   its slot
+//!
+//! The refusal is right. What is wrong is what it leaves behind: the publisher
+//! that was already on that topic, correctly typed and healthy, then dies with
+//! SIGBUS inside `send_shm_mp_pod` on its next send.
+//!
+//! SIGBUS is a signal, not an unwind, so `catch_unwind` in `NodeRunner::run_tick`,
+//! the executors' outer `catch_unwind`, and every `FailurePolicy` are bypassed.
+//! There is no `enter_safe_state()` and no blackbox entry — the process is simply
+//! gone. On a robot that is a live control publisher killed because some other
+//! node mistyped a topic name.
+
+mod common;
+use common::{cleanup_stale_shm, unique};
+
+use horus_core::communication::Topic;
+use horus_robotics::messages::sensor::Imu;
+use horus_robotics::CmdVel;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Publish on a topic, have a peer attempt an incompatible attach, keep publishing.
+///
+/// Without the fix this dies with `signal: 7, SIGBUS` rather than failing an
+/// assertion — so a clean exit IS the pass condition, and a crash is the bug.
+/// IGNORED ON PURPOSE. This test currently CRASHES THE PROCESS with SIGBUS,
+/// which no harness can catch and which would take the whole test binary --
+/// and any required gate running it -- down with it. It is here as a
+/// deterministic reproducer for #144, to be un-ignored by the change that
+/// fixes the fault. Run it deliberately:
+///
+///   cargo test --release -p horus_core \
+///     --test rejected_attach_strands_publisher -- --ignored
+#[test]
+#[ignore]
+fn a_refused_attach_must_not_kill_the_publisher() {
+    let _g = cleanup_stale_shm();
+    let name = unique("issue144");
+
+    // The incumbent: correctly typed, healthy, already publishing.
+    let pubv: Topic<CmdVel> = Topic::new(&name).expect("create the CmdVel topic");
+    for i in 0..64 {
+        pubv.send(CmdVel::new(i as f32, 0.0));
+    }
+
+    // The refused attaches happen WHILE the publisher is mid-send. Sequentially
+    // this is harmless -- the send that faults is one already in flight against
+    // a mapping the refused attach disturbed, so the two have to overlap.
+    let stop = Arc::new(AtomicBool::new(false));
+    let s2 = stop.clone();
+    let n2 = name.clone();
+    let attacher = std::thread::spawn(move || {
+        let mut refused = 0u32;
+        while !s2.load(Ordering::Relaxed) {
+            // Every one of these SHOULD be refused: Imu is a 304-byte POD
+            // needing 312-byte slots, the region declares 64.
+            if Topic::<Imu>::new(&n2).is_err() {
+                refused += 1;
+            }
+        }
+        refused
+    });
+
+    for i in 0..200_000 {
+        pubv.send(CmdVel::new(i as f32, 1.0));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    let refused = attacher.join().expect("attacher thread panicked");
+
+    assert!(
+        refused > 0,
+        "no attach was refused, so this run exercised nothing — the guard that \
+         makes this test meaningful may have changed"
+    );
+
+    // Reaching here is the assertion. The failure this test is about is a
+    // SIGNAL, not a false return: SIGBUS bypasses catch_unwind entirely.
+    pubv.send(CmdVel::new(1.0, 1.0));
+}

--- a/horus_core/tests/rejected_attach_strands_publisher.rs
+++ b/horus_core/tests/rejected_attach_strands_publisher.rs
@@ -26,6 +26,7 @@ use horus_robotics::messages::sensor::Imu;
 use horus_robotics::CmdVel;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// Publish on a topic, have a peer attempt an incompatible attach, keep publishing.
 ///
@@ -55,19 +56,37 @@ fn a_refused_attach_must_not_kill_the_publisher() {
     // this is harmless -- the send that faults is one already in flight against
     // a mapping the refused attach disturbed, so the two have to overlap.
     let stop = Arc::new(AtomicBool::new(false));
+    let attaching = Arc::new(AtomicBool::new(false));
     let s2 = stop.clone();
+    let a2 = attaching.clone();
     let n2 = name.clone();
     let attacher = std::thread::spawn(move || {
         let mut refused = 0u32;
-        while !s2.load(Ordering::Relaxed) {
+        loop {
             // Every one of these SHOULD be refused: Imu is a 304-byte POD
             // needing 312-byte slots, the region declares 64.
             if Topic::<Imu>::new(&n2).is_err() {
                 refused += 1;
             }
+            // Published after the first attempt, so the burst below is known to
+            // start with the attach loop already running.
+            a2.store(true, Ordering::Release);
+            if s2.load(Ordering::Relaxed) {
+                break;
+            }
         }
         refused
     });
+
+    // Don't start the burst against a thread that has not been scheduled yet:
+    // on a loaded host the spawn can lag far enough that the sends finish
+    // first, and this test only means something while the two overlap. Bounded,
+    // so an attacher that never gets going fails the `refused > 0` assertion
+    // below with a message instead of hanging the run.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !attaching.load(Ordering::Acquire) && Instant::now() < deadline {
+        std::hint::spin_loop();
+    }
 
     for i in 0..200_000 {
         pubv.send(CmdVel::new(i as f32, 1.0));


### PR DESCRIPTION
#144 currently reproduces **2 runs in 5**, needs two schedulers on two threads and 500 deterministic ticks, and takes ~15 s. That is a poor starting point for fixing it.

This is the same class of fault in **~40 lines, no schedulers, 6 times out of 6**:

> a publisher on a `CmdVel` topic sending in a loop, while a second thread repeatedly attempts `Topic::<Imu>::new` on the same name.

Every attach is correctly refused — `Imu` is a 304-byte POD needing 312-byte slots and the region declares 64 — and **the test asserts that it is**, so if that guard ever changes this stops being a valid reproducer loudly instead of silently passing.

## The concurrency is load-bearing

The sequential version — attach, observe the refusal, resume publishing — passes **5 of 5**. The refused attach has to overlap an in-flight send. That is worth knowing before anyone tries to reduce it further.

## One difference from #144, stated rather than glossed

gdb puts this SIGBUS in `Topic::new` on the **attaching** thread:

```
Thread 2 received signal SIGBUS, Bus error.
#0  <Topic<CmdVel>>::new::<&String>
#1  a_refused_attach_must_not_kill_the_publisher::{closure#0}
```

whereas #144's is in `send_shm_mp_pod` on the **publisher**. Same trigger — a region disturbed by a refused attach — but not the same fault site. Whoever fixes #144 should check whether one fix covers both, or whether these are two faults sharing a cause.

## It is `#[ignore]`d on purpose

It **crashes the process**. SIGBUS is a signal, not an unwind, so no harness catches it — an un-ignored version would take its whole test binary down, and any required gate running it with it. Verified: a default `cargo test` reports `0 passed; 1 ignored`.

Un-ignore it in the change that fixes the fault. That is the point of it existing.

```
cargo test --release -p horus_core --test rejected_attach_strands_publisher -- --ignored
```