### PR TITLE
feat(types): give camera frames a capture timestamp distinct from publish

### DIFF
--- a/horus_core/src/memory/depth_image.rs
+++ b/horus_core/src/memory/depth_image.rs
@@ -276,6 +276,28 @@ impl std::fmt::Debug for DepthImage {
     }
 }
 
+impl DepthImage {
+    /// Instant the sensor SAMPLED this frame, nanoseconds since the UNIX epoch.
+    ///
+    /// `0` means unknown. Distinct from [`timestamp_ns`](Self::timestamp_ns),
+    /// which is stamped at publish; for a camera the two differ by exposure plus
+    /// transfer plus driver latency, routinely 10-30 ms.
+    #[inline]
+    pub fn capture_ns(&self) -> u64 {
+        self.descriptor.capture_ns()
+    }
+
+    /// Record the instant the sensor sampled this frame.
+    ///
+    /// Drivers call this. HORUS never sets it, because only the driver knows
+    /// its own pipeline latency.
+    #[inline]
+    pub fn set_capture_ns(&mut self, ts: u64) -> &mut Self {
+        self.descriptor.set_capture_ns(ts);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/horus_core/src/memory/image.rs
+++ b/horus_core/src/memory/image.rs
@@ -250,6 +250,28 @@ impl std::fmt::Debug for Image {
     }
 }
 
+impl Image {
+    /// Instant the sensor SAMPLED this frame, nanoseconds since the UNIX epoch.
+    ///
+    /// `0` means unknown. Distinct from [`timestamp_ns`](Self::timestamp_ns),
+    /// which is stamped at publish; for a camera the two differ by exposure plus
+    /// transfer plus driver latency, routinely 10-30 ms.
+    #[inline]
+    pub fn capture_ns(&self) -> u64 {
+        self.descriptor.capture_ns()
+    }
+
+    /// Record the instant the sensor sampled this frame.
+    ///
+    /// Drivers call this. HORUS never sets it, because only the driver knows
+    /// its own pipeline latency.
+    #[inline]
+    pub fn set_capture_ns(&mut self, ts: u64) -> &mut Self {
+        self.descriptor.set_capture_ns(ts);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/horus_core/src/types/depth_image_descriptor.rs
+++ b/horus_core/src/types/depth_image_descriptor.rs
@@ -27,7 +27,7 @@ use super::tensor::Tensor;
 /// min_depth:    u16          (2 bytes)
 /// max_depth:    u16          (2 bytes)
 /// frame_id:     [u8; 32]     (32 bytes)
-/// _reserved:    [u8; 8]      (8 bytes)
+/// capture_ns:   u64          (8 bytes)
 /// Total:                      224 bytes
 /// ```
 #[repr(C)]
@@ -45,8 +45,17 @@ pub struct DepthImageDescriptor {
     max_depth: u16,
     /// Frame ID (camera identifier, null-terminated)
     frame_id: [u8; 32],
-    #[serde(skip)]
-    _reserved: [u8; 8],
+    /// Instant the sensor SAMPLED this frame, nanoseconds since the UNIX epoch.
+    /// `0` means unknown. See [`impl_capture_ns_field`] for why this is not
+    /// `timestamp_ns`.
+    ///
+    /// Occupies what were 8 reserved bytes, so the wire layout is unchanged and
+    /// a peer built before this reads them as the zeroed reserved bytes it
+    /// already ignored. The topic type hash is derived from the type NAME
+    /// (`fnv1a_type_hash(type_name::<T>())`), not the field layout, so old and
+    /// new peers still bind. `serde(default)` keeps older recordings loadable.
+    #[serde(default)]
+    capture_ns: u64,
 }
 
 // Safety: DepthImage is repr(C), all fields are Pod, no implicit padding.
@@ -63,7 +72,7 @@ impl Default for DepthImageDescriptor {
             min_depth: 200,   // 20cm
             max_depth: 10000, // 10m
             frame_id: [0; 32],
-            _reserved: [0; 8],
+            capture_ns: 0,
         }
     }
 }
@@ -140,6 +149,7 @@ impl DepthImageDescriptor {
 
     crate::impl_tensor_accessors!();
     crate::impl_timestamp_field!();
+    crate::impl_capture_ns_field!();
     crate::impl_frame_id_field!();
 }
 

--- a/horus_core/src/types/image_descriptor.rs
+++ b/horus_core/src/types/image_descriptor.rs
@@ -27,7 +27,7 @@ use super::tensor::Tensor;
 /// encoding_raw: u8           (1 byte, ImageEncoding discriminant)
 /// _pad:         [u8; 3]      (3 bytes)
 /// frame_id:     [u8; 32]     (32 bytes)
-/// _reserved:    [u8; 8]      (8 bytes)
+/// capture_ns:   u64          (8 bytes)
 /// Total:                      224 bytes
 /// ```
 #[repr(C)]
@@ -55,8 +55,17 @@ pub struct ImageDescriptor {
     _pad: [u8; 3],
     /// Frame ID (camera identifier, null-terminated)
     frame_id: [u8; 32],
-    #[serde(skip)]
-    _reserved: [u8; 8],
+    /// Instant the sensor SAMPLED this frame, nanoseconds since the UNIX epoch.
+    /// `0` means unknown. See [`impl_capture_ns_field`] for why this is not
+    /// `timestamp_ns`.
+    ///
+    /// Occupies what were 8 reserved bytes, so the wire layout is unchanged and
+    /// a peer built before this reads them as the zeroed reserved bytes it
+    /// already ignored. The topic type hash is derived from the type NAME
+    /// (`fnv1a_type_hash(type_name::<T>())`), not the field layout, so old and
+    /// new peers still bind. `serde(default)` keeps older recordings loadable.
+    #[serde(default)]
+    capture_ns: u64,
 }
 
 /// Serde bridge for the raw encoding byte.
@@ -93,7 +102,7 @@ impl Default for ImageDescriptor {
             encoding_raw: ImageEncoding::Rgb8 as u8,
             _pad: [0; 3],
             frame_id: [0; 32],
-            _reserved: [0; 8],
+            capture_ns: 0,
         }
     }
 }
@@ -143,7 +152,7 @@ impl ImageDescriptor {
             encoding_raw: encoding as u8,
             _pad: [0; 3],
             frame_id: [0; 32],
-            _reserved: [0; 8],
+            capture_ns: 0,
         }
     }
 
@@ -204,6 +213,7 @@ impl ImageDescriptor {
 
     crate::impl_tensor_accessors!();
     crate::impl_timestamp_field!();
+    crate::impl_capture_ns_field!();
     crate::impl_frame_id_field!();
 }
 
@@ -353,5 +363,83 @@ mod tests {
         assert_eq!(recovered.encoding(), ImageEncoding::Rgb8);
         assert_eq!(recovered.frame_id(), "cam0");
         assert_eq!(recovered.timestamp_ns(), 123456789);
+    }
+}
+
+#[cfg(test)]
+mod capture_ns_tests {
+    use super::*;
+
+    /// The whole compatibility argument rests on the size not moving.
+    ///
+    /// `capture_ns` occupies what were 8 reserved bytes. If that ever stops
+    /// being true, a peer built before the change and one built after disagree
+    /// about the descriptor's length while still binding — the type hash is
+    /// derived from the type NAME, not the layout, so nothing else would catch
+    /// it. This is the thing that catches it.
+    #[test]
+    fn descriptor_is_still_224_bytes() {
+        assert_eq!(
+            std::mem::size_of::<ImageDescriptor>(),
+            224,
+            "ImageDescriptor changed size; capture_ns was supposed to reuse the \
+             8 reserved bytes, and peers built either side of this change bind \
+             on type name alone"
+        );
+    }
+
+    /// Unset means unknown, and unknown must be zero — the value an older peer
+    /// leaves in the bytes it treated as reserved.
+    #[test]
+    fn capture_ns_defaults_to_zero_meaning_unknown() {
+        let d = ImageDescriptor::default();
+        assert_eq!(d.capture_ns(), 0);
+    }
+
+    /// capture and publish are independent: setting one must not move the other.
+    /// They are different instants and the entire point of the field is that a
+    /// consumer can tell them apart.
+    #[test]
+    fn capture_and_publish_timestamps_are_independent() {
+        let mut d = ImageDescriptor::default();
+        d.set_timestamp_ns(1_000_000_000);
+        d.set_capture_ns(970_000_000); // sampled 30 ms before publish
+        assert_eq!(d.timestamp_ns(), 1_000_000_000);
+        assert_eq!(d.capture_ns(), 970_000_000);
+
+        d.set_timestamp_ns(2_000_000_000);
+        assert_eq!(
+            d.capture_ns(),
+            970_000_000,
+            "re-stamping publish time must not disturb the capture instant"
+        );
+    }
+
+    /// A recording written before this field existed has no `capture_ns` key.
+    /// It must still load, as unknown, rather than failing to deserialize.
+    #[test]
+    fn recordings_without_the_field_still_load() {
+        let mut d = ImageDescriptor::default();
+        d.set_timestamp_ns(42);
+        d.set_capture_ns(7);
+        let json = serde_json::to_string(&d).expect("serialize");
+        assert!(
+            json.contains("capture_ns"),
+            "new recordings carry the field"
+        );
+
+        // Strip it, as an older writer would have produced.
+        let mut v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        v.as_object_mut().expect("object").remove("capture_ns");
+        let legacy = serde_json::to_string(&v).expect("reserialize");
+
+        let back: ImageDescriptor =
+            serde_json::from_str(&legacy).expect("a legacy recording must still load");
+        assert_eq!(back.timestamp_ns(), 42);
+        assert_eq!(
+            back.capture_ns(),
+            0,
+            "a recording that predates the field reports unknown, not garbage"
+        );
     }
 }

--- a/horus_core/src/types/mod.rs
+++ b/horus_core/src/types/mod.rs
@@ -61,6 +61,39 @@ macro_rules! impl_timestamp_field {
     };
 }
 
+/// Generate `capture_ns()` / `set_capture_ns()` for descriptor types carrying a
+/// `capture_ns: u64` field.
+///
+/// Separate from [`impl_timestamp_field`] because the two mean different things
+/// and only sensor descriptors can answer the second. `timestamp_ns` is stamped
+/// when the descriptor is built — publish time. `capture_ns` is when the sensor
+/// actually sampled. For a camera those differ by exposure plus transfer plus
+/// driver latency, routinely 10-30 ms, and fusing on publish time aligns
+/// samples on arrival rather than on measurement.
+#[macro_export]
+macro_rules! impl_capture_ns_field {
+    () => {
+        /// Instant the sensor SAMPLED this frame, nanoseconds since the UNIX
+        /// epoch. `0` means unknown.
+        ///
+        /// Treat `0` as "fall back to `timestamp_ns` and accept the skew",
+        /// never as "sampled at the epoch".
+        #[inline]
+        pub fn capture_ns(&self) -> u64 {
+            self.capture_ns
+        }
+
+        /// Record the instant the sensor sampled this frame.
+        ///
+        /// Set by the driver — the only component that knows its own exposure
+        /// and transfer latency. HORUS never fills it in.
+        #[inline]
+        pub fn set_capture_ns(&mut self, ts: u64) {
+            self.capture_ns = ts;
+        }
+    };
+}
+
 /// Generate shared tensor accessor methods for descriptor types with an
 /// `inner: Tensor` field.
 #[macro_export]


### PR DESCRIPTION
Message timestamps could not say **when a sensor actually sampled**.

`timestamp_ns` is stamped when the descriptor is built — publish time. For a
camera that is exposure + transfer + driver latency after the shutter, routinely
**10–30 ms**. Fusing a camera against an IMU on publish stamps aligns them on
when they *arrived*, not when they were *measured*, and on a legged robot a state
estimate off by tens of milliseconds is how you fall over.

There was no way to express the difference: the type carried one timestamp and no
statement of which instant it meant.

## What changes

`ImageDescriptor` and `DepthImageDescriptor` gain `capture_ns`, with
`capture_ns()` / `set_capture_ns()` on the descriptors and on `Image` /
`DepthImage`.

`0` means **unknown** — a consumer must read that as "fall back to `timestamp_ns`
and accept the skew", never as "sampled at the epoch". HORUS never fills it in;
only a driver knows its own pipeline latency.

## Wire compatibility — the reason this is safe

- It occupies the 8 bytes that were `_reserved`, so both `ImageDescriptor` and
  `DepthImageDescriptor` stay **224 bytes** (168-byte `Tensor` + 8 + 4 + 2 + 2 +
  32 + 8). A test asserts each size, because the topic type hash is
  `fnv1a_type_hash(type_name::<T>())` —
  derived from the type **name**, not the layout — so old and new peers bind
  either way and *nothing else would catch a size change*.
- A peer built before this reads those bytes as the zeroed reserved bytes it
  already ignored. A peer built after, reading older data, sees `0` = unknown.
- `serde(default)` keeps recordings from older builds loadable. A test strips the
  field from serialized JSON and asserts it still loads, as unknown.

## Scope, deliberately narrow

Only the two camera types. `PointCloudDescriptor` has just 4 reserved bytes and
cannot carry a `u64`, so the accessors go on the two descriptors directly rather
than into `impl_tensor_backed!`, which four types share.

The sensor messages that would also want this (`Imu`, `LaserScan`) live in the
separate **horus-robotics** repo behind a pinned rev. Changing those is a
cross-repo wire-format decision, not something to slip in here.

## One test earned its place immediately

The new field inherited the `#[serde(skip)]` that sat above `_reserved`, so it
serialized to nothing. The round-trip test caught it before it shipped.

2501 lib tests pass; fmt and clippy clean under `-D warnings`.
