### PR TITLE
fix(topic): stop publishing over-aligned POD messages through a misaligned typed store

### DIFF
--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -113,9 +113,16 @@
 //!    write and read of each slot. CAS operations use `AcqRel` for read-modify-
 //!    write consistency.
 //!
-//! 6. **SIMD operations**: `simd_aware_read`/`simd_aware_write` require aligned,
-//!    non-overlapping source/dest within the data region. The SHM layout ensures
-//!    slot alignment to `mem::align_of::<T>()` via `slot_size` rounding.
+//! 6. **SIMD operations**: `simd_aware_read`/`simd_aware_write` require
+//!    non-overlapping source/dest within the data region. They do NOT require
+//!    alignment, and must not: no `slot_size` rounding to `mem::align_of::<T>()`
+//!    exists anywhere in the layout — this invariant claimed one for years and
+//!    there was none. A split slot sits at `640 + capacity * 8 + i *
+//!    size_of::<T>()` and a colo payload at `640 + i * stride + 8`, so a
+//!    16-aligned message is 8 mod 16 in a colo region and in a capacity-1 split
+//!    one. Both helpers therefore copy bytes; a typed `ptr::read`/`ptr::write`
+//!    on a slot is UB and, for the shapes LLVM vectorises, a `movaps` fault in
+//!    release that debug builds do not reproduce.
 
 use std::sync::atomic::{fence, Ordering};
 
@@ -1341,8 +1348,8 @@ pub(super) fn send_shm_sp_pod<T: Clone + Send + Sync + Serialize + DeserializeOw
 
     // SAFETY: cached_data_ptr points to SHM data region. index < capacity (mask).
     // cached_seq_ptr points to the per-slot ready-flag array (set unconditionally
-    // in ensure_role). index*8 is within bounds. simd_aware_write handles alignment
-    // (slot_size is rounded to align_of::<T>()).
+    // in ensure_role). index*8 is within bounds. simd_aware_write copies bytes, so
+    // the slot needs no alignment — nothing rounds slot_size to align_of::<T>().
     unsafe {
         let base = local.cached_data_ptr as *mut T;
         simd_aware_write(base.add(index), msg);
@@ -1883,7 +1890,8 @@ pub(super) fn recv_shm_spsc_pod<T: Clone + Send + Sync + Serialize + Deserialize
 
     // SAFETY: cached_data_ptr points to SHM data region. index < capacity (mask).
     // The producer's Release store on sequence_or_head was observed via our Acquire load.
-    // simd_aware_read handles alignment (slot_size rounded to align_of::<T>()).
+    // simd_aware_read copies bytes, so the slot needs no alignment — nothing
+    // rounds slot_size to align_of::<T>().
     let msg = unsafe {
         let base = local.cached_data_ptr as *const T;
         simd_aware_read(base.add((tail & mask) as usize))

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -536,7 +536,7 @@ impl TopicHeader {
         // lives — the disagreement mode that made the horus_net offset drift
         // a silent corruption instead of a loud failure.
         self.layout_kind.store(
-            if layout::colo_eligible(is_pod, type_size as usize) {
+            if layout::colo_eligible(is_pod, type_size as usize, type_align as usize) {
                 layout::LAYOUT_COLO
             } else {
                 layout::LAYOUT_SPLIT

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -604,8 +604,25 @@ impl From<SendBlockingError> for crate::error::HorusError {
 
 /// Write a message to a ring buffer slot, using SIMD streaming stores for large POD types.
 ///
+/// Byte copy, never `ptr::write::<T>`, for the same reason
+/// `simd_aware_read_uninit` reads bytes rather than a `T`: a slot is untyped
+/// shared memory at an address the *layout* picked, not memory the compiler
+/// aligned for `T`. `colo_eligible` now keeps types stricter than
+/// `COLO_PAYLOAD_OFF` off the colo geometry, but the split geometry is not
+/// aligned either — its data region starts at `640 + capacity * 8`, which is
+/// 8 mod 16 for `capacity == 1` — and rounding that up would move an offset
+/// `horus_net`'s `ShmRingWriter` and `header::read_slot_inner` each compute
+/// independently. A typed store is what turned that into a fault: LLVM
+/// vectorised `ptr::write` of a 16-byte `#[repr(align(16))]` message into
+/// `movaps %xmm0,(%rax)` and the first `send` took SIGSEGV in release while
+/// passing in debug.
+///
+/// `mem::forget` drops nothing that needed dropping: every caller is a
+/// `dispatch::send_shm_*_pod` path, and `is_pod` implies `!needs_drop::<T>()`.
+///
 /// # Safety
-/// `dst` must be valid for writes of `size_of::<T>()` bytes and properly aligned.
+/// `dst` must be valid for writes of `size_of::<T>()` bytes. Alignment is NOT
+/// required.
 #[inline(always)]
 unsafe fn simd_aware_write<T>(dst: *mut T, msg: T) {
     if mem::size_of::<T>() >= SIMD_COPY_THRESHOLD {
@@ -614,16 +631,21 @@ unsafe fn simd_aware_write<T>(dst: *mut T, msg: T) {
             dst as *mut u8,
             mem::size_of::<T>(),
         );
-        mem::forget(msg);
     } else {
-        std::ptr::write(dst, msg);
+        std::ptr::copy_nonoverlapping(
+            &msg as *const T as *const u8,
+            dst as *mut u8,
+            mem::size_of::<T>(),
+        );
     }
+    mem::forget(msg);
 }
 
 /// Read a message from a ring buffer slot, using SIMD prefetched reads for large POD types.
 ///
 /// # Safety
-/// `src` must be valid for reads of `size_of::<T>()` bytes and properly aligned.
+/// `src` must be valid for reads of `size_of::<T>()` bytes, and must hold a
+/// valid `T`. Alignment is not required — the copy underneath is byte-wise.
 #[inline(always)]
 unsafe fn simd_aware_read<T>(src: *const T) -> T {
     simd_aware_read_uninit(src).assume_init()
@@ -642,9 +664,10 @@ unsafe fn simd_aware_read<T>(src: *const T) -> T {
 /// bytes are dropped as raw memory and never become a `T`.
 ///
 /// # Safety
-/// `src` must be valid for reads of `size_of::<T>()` bytes and properly aligned.
-/// The caller must only `assume_init()` the result once it has established that
-/// the bytes are a valid, fully-written `T`.
+/// `src` must be valid for reads of `size_of::<T>()` bytes. Alignment is not
+/// required — the copy is byte-wise. The caller must only `assume_init()` the
+/// result once it has established that the bytes are a valid, fully-written
+/// `T`.
 #[inline(always)]
 unsafe fn simd_aware_read_uninit<T>(src: *const T) -> mem::MaybeUninit<T> {
     let mut msg = mem::MaybeUninit::<T>::uninit();
@@ -1006,7 +1029,7 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
         // horus_py contains no slot-size computation at all (nor does
         // horus_cpp) — both are FFI wrappers over this same Rust code, so
         // there is only one side.
-        let colo = layout::colo_eligible(is_pod, type_size as usize);
+        let colo = layout::colo_eligible(is_pod, type_size as usize, type_align as usize);
         let actual_slot_size = if is_pod {
             let ts = type_size as usize;
             if colo {
@@ -2759,6 +2782,11 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
                 // SAFETY: cached_data_ptr points into the topic's SHM ring data region; the index is
                 // masked to ring capacity, so it is always in bounds. The capacity check above
                 // ensures the slot is not occupied (no unconsumed data will be overwritten).
+                // `simd_aware_write` rather than `ptr::write`, on both branches,
+                // for the reason given at its definition: a slot address is
+                // whatever the layout put it at, and a typed store to one that
+                // is not `align_of::<T>()`-aligned is UB — a `movaps` fault in
+                // release for the shapes LLVM vectorises.
                 unsafe {
                     let idx = (head & local.cached_capacity_mask) as usize;
                     let (stamp, data) = dispatch::slot_ptrs::<T>(local, idx);
@@ -2770,10 +2798,10 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
                         // path could previously skip stamping entirely.
                         let seq = head.wrapping_add(1);
                         (*stamp).store(seq | layout::SLOT_WRITING, Ordering::Release);
-                        std::ptr::write(data, msg);
+                        simd_aware_write(data, msg);
                         (*stamp).store(seq, Ordering::Release);
                     } else {
-                        std::ptr::write(data, msg);
+                        simd_aware_write(data, msg);
                     }
                 }
                 local.local_head = head.wrapping_add(1);
@@ -3176,12 +3204,15 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
                 // SAFETY: cached_data_ptr points into the topic's SHM ring data region; the index is
                 // masked to ring capacity, so it is always in bounds. The head-tail check above
                 // ensures the slot contains a valid, initialized message written by send().
+                // `simd_aware_read` and not `ptr::read`, mirroring the write
+                // side: the slot carries no alignment guarantee for `T`, and a
+                // typed load from one is UB.
                 let msg = unsafe {
                     let (_, data) = dispatch::slot_ptrs::<T>(
                         local,
                         (tail & local.cached_capacity_mask) as usize,
                     );
-                    std::ptr::read(data as *const T)
+                    simd_aware_read(data as *const T)
                 };
                 local.local_tail = tail.wrapping_add(1);
                 local.msg_counter = local.msg_counter.wrapping_add(1);

--- a/horus_core/src/communication/topic/shm_layout.rs
+++ b/horus_core/src/communication/topic/shm_layout.rs
@@ -220,8 +220,15 @@ pub const COLO_MAX_PAYLOAD: usize = CACHE_LINE - COLO_PAYLOAD_OFF;
 /// on the first `send`, while debug builds emitted two 8-byte stores and
 /// passed.
 ///
-/// Such a type falls back to the split layout, whose data region starts at
-/// `640 + capacity * 8` — aligned for it at every capacity but 1.
+/// Such a type falls back to the split layout, which is not unconditionally
+/// aligned either. Its data region starts at `data_region_offset(capacity)` =
+/// `640 + capacity * 8`, so it satisfies `type_align` exactly when
+/// `data_region_offset(capacity) % type_align == 0` — for align 16 that is
+/// every capacity but 1; for align 32, every capacity but 1 and 2; for align
+/// 256 it is no capacity at all, since 640 is not a multiple of 256. The gate
+/// is therefore only half the fix: `simd_aware_write` and `simd_aware_read`
+/// copy bytes on every branch, so a slot that is misaligned for `T` is still
+/// written and read legally.
 #[inline]
 pub const fn colo_eligible(is_pod: bool, type_size: usize, type_align: usize) -> bool {
     is_pod

--- a/horus_core/src/communication/topic/shm_layout.rs
+++ b/horus_core/src/communication/topic/shm_layout.rs
@@ -202,13 +202,35 @@ pub const COLO_PAYLOAD_OFF: usize = 8;
 /// eligibility rule, not a soft preference.
 pub const COLO_MAX_PAYLOAD: usize = CACHE_LINE - COLO_PAYLOAD_OFF;
 
-/// Whether a topic of `type_size` bytes should use the colo layout.
+/// Whether a topic of `type_size` bytes and `type_align` alignment should use
+/// the colo layout.
 ///
 /// POD only: a serde topic carries its own in-slot length word and variable
 /// payload, so there is no fixed geometry to co-locate.
+///
+/// Alignment is a hard gate, not a preference, and it is the reason this
+/// function takes an alignment at all. A colo payload starts `COLO_PAYLOAD_OFF`
+/// bytes into a slot that itself starts on a cache line, so its address is
+/// `8 mod 16` in **every** slot of **every** colo region, and nothing anywhere
+/// rounds a slot up to `align_of::<T>()`. Selecting colo on `type_size` alone
+/// therefore handed a 16-byte, 16-aligned message (`#[repr(align(16))]`, a
+/// `u128` field, an SSE vector) a home it cannot legally occupy: a release
+/// build vectorised the 16-byte publish into `movaps %xmm0,(%rax)` with `rax`
+/// ending in 0x288 — 648, `HEADER_SIZE + COLO_PAYLOAD_OFF` — and took SIGSEGV
+/// on the first `send`, while debug builds emitted two 8-byte stores and
+/// passed.
+///
+/// Such a type falls back to the split layout, whose data region starts at
+/// `640 + capacity * 8` — aligned for it at every capacity but 1.
 #[inline]
-pub const fn colo_eligible(is_pod: bool, type_size: usize) -> bool {
-    is_pod && type_size > 0 && type_size <= COLO_MAX_PAYLOAD
+pub const fn colo_eligible(is_pod: bool, type_size: usize, type_align: usize) -> bool {
+    is_pod
+        && type_size > 0
+        && type_size <= COLO_MAX_PAYLOAD
+        // `is_multiple_of` rather than `%`: `align_of` is never 0, but this is a
+        // `pub` predicate, and a 0 answers "not eligible" here instead of
+        // dividing by zero.
+        && COLO_PAYLOAD_OFF.is_multiple_of(type_align)
 }
 
 /// Bytes per colo slot: stamp + payload, rounded up to whole cache lines.

--- a/horus_core/tests/pod_ring_slot_geometry.rs
+++ b/horus_core/tests/pod_ring_slot_geometry.rs
@@ -37,7 +37,7 @@
 //!
 //! Run: `cargo test -p horus_core --test pod_ring_slot_geometry -- --test-threads=1`
 
-use std::mem::size_of;
+use std::mem::{align_of, size_of};
 
 use horus_core::communication::topic::shm_layout;
 use horus_core::communication::Topic;
@@ -69,6 +69,18 @@ horus_core::message! {
         g: u64,
         h: u64,
     }
+}
+
+// 16 bytes like GeomProbe, and 16-aligned. `#[repr(align(16))]`, a `u128`
+// field and an SSE vector all produce this shape, and `is_pod` classifies it
+// POD like any other `!needs_drop` type. Colo cannot hold it: the payload sits
+// `COLO_PAYLOAD_OFF` bytes into a cache-line-aligned slot, so its address is
+// 8 mod 16 in every slot of every colo region.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[repr(C, align(16))]
+struct OverAlignedProbe {
+    tag: u64,
+    echo: u64,
 }
 
 const CAPACITY: u32 = 8;
@@ -217,6 +229,66 @@ fn a_large_pod_type_stays_on_the_split_layout() {
     );
 }
 
+/// A POD type aligned more strictly than the colo payload offset keeps the
+/// split layout.
+///
+/// The second control, and the one that is about soundness rather than about
+/// the size of a cache line. Colo pins every payload at `HEADER_SIZE + i *
+/// slot_size + COLO_PAYLOAD_OFF` — 648, 712, 776 … — all of them 8 mod 16, and
+/// no rounding to `align_of::<T>()` happens anywhere in the geometry. The
+/// eligibility rule was written on `type_size` alone, so a 16-byte,
+/// 16-aligned message was colo-eligible and every publish stored it through a
+/// misaligned `*mut T`. Debug builds survived that; a release build vectorised
+/// the 16-byte store in `send_shm_mp_pod` into `movaps %xmm0,(%rax)` with
+/// `rax` ending in 0x288 — 648, slot 0's payload — and took SIGSEGV on the
+/// first send.
+#[test]
+fn an_over_aligned_pod_type_stays_on_the_split_layout() {
+    assert!(
+        size_of::<OverAlignedProbe>() <= shm_layout::COLO_MAX_PAYLOAD,
+        "this test only means anything for a type colo would otherwise take"
+    );
+    assert!(
+        align_of::<OverAlignedProbe>() > shm_layout::COLO_PAYLOAD_OFF,
+        "and only for one the colo payload offset cannot satisfy"
+    );
+
+    let name = unique("overaligned");
+    let tx: Topic<OverAlignedProbe> =
+        Topic::with_capacity(&name, CAPACITY, None).expect("create over-aligned POD topic");
+    tx.send(OverAlignedProbe {
+        tag: tag_of(0),
+        echo: !tag_of(0),
+    });
+    let region = read_region(&name);
+
+    assert_eq!(
+        region[shm_layout::OFF_LAYOUT_KIND],
+        shm_layout::LAYOUT_SPLIT,
+        "a {}-aligned payload cannot start {} bytes into a slot",
+        align_of::<OverAlignedProbe>(),
+        shm_layout::COLO_PAYLOAD_OFF
+    );
+
+    // And the layout it fell back to does hold the payload at an address the
+    // type is allowed to live at. The region is a fresh mmap, so its base is
+    // page-aligned and an offset divisible by `align_of::<T>()` is an address
+    // that is too.
+    let capacity = u32_at(&region, shm_layout::OFF_CAPACITY) as usize;
+    let type_size = u32_at(&region, shm_layout::OFF_TYPE_SIZE) as usize;
+    let payload_off = shm_layout::data_slot_offset(capacity, 0, type_size);
+    assert_eq!(
+        u64_at(&region, payload_off),
+        tag_of(0),
+        "split payload must live at the split offset"
+    );
+    assert_eq!(
+        payload_off % align_of::<OverAlignedProbe>(),
+        0,
+        "payload offset {payload_off} is not a multiple of the type's alignment"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // The geometry the writer actually uses
 // ---------------------------------------------------------------------------
@@ -355,6 +427,53 @@ fn colo_has_no_sequence_array_and_no_over_allocation() {
 // ---------------------------------------------------------------------------
 // Reader and writer agree
 // ---------------------------------------------------------------------------
+
+/// Publishing works even where the geometry cannot give the type its natural
+/// alignment.
+///
+/// The split layout is not aligned either — it just misses more rarely. Its
+/// data region starts at `640 + capacity * 8`, which is 8 mod 16 for
+/// `capacity == 1` (the only power of two that is odd), so a 16-aligned
+/// message is stored misaligned there no matter which layout it gets. Rounding
+/// the data region up would move the offset `horus_net`'s `ShmRingWriter` and
+/// `header::read_slot_inner` compute independently, so the publish path copies
+/// bytes instead — `simd_aware_write` never forms a typed store, exactly as
+/// `simd_aware_read_uninit` never forms a typed load.
+///
+/// The teeth of this test are in `--release`: with a typed store back in
+/// place, this send is the `movaps` to an address ending in 0x288 that
+/// SIGSEGVs. In debug it is a regression guard for the bytes, not the fault.
+#[test]
+fn an_over_aligned_pod_type_publishes_at_a_misaligned_slot() {
+    let name = unique("overaligned_cap1");
+    let tx: Topic<OverAlignedProbe> =
+        Topic::with_capacity(&name, 1, None).expect("create capacity-1 topic");
+    tx.send(OverAlignedProbe {
+        tag: tag_of(0),
+        echo: !tag_of(0),
+    });
+    let region = read_region(&name);
+
+    let capacity = u32_at(&region, shm_layout::OFF_CAPACITY) as usize;
+    let payload_off = shm_layout::data_slot_offset(capacity, 0, size_of::<OverAlignedProbe>());
+    assert_eq!(capacity, 1, "capacity 1 is the case being covered");
+    assert_ne!(
+        payload_off % align_of::<OverAlignedProbe>(),
+        0,
+        "this test is only a test while offset {payload_off} is misaligned for \
+         the type — if the data region gained alignment rounding, delete it"
+    );
+    assert_eq!(
+        u64_at(&region, payload_off),
+        tag_of(0),
+        "the published payload must land at the slot whole and in the right place"
+    );
+    assert_eq!(
+        u64_at(&region, payload_off + size_of::<u64>()),
+        !tag_of(0),
+        "both halves of the message, not just the first word"
+    );
+}
 
 /// A consumer reads back exactly what the producer wrote, in order.
 #[test]


### PR DESCRIPTION
`colo_eligible` picked the co-located slot geometry on `type_size` alone. A
colo payload starts `COLO_PAYLOAD_OFF` (8) bytes into a cache-line-aligned
slot, so its address is 8 mod 16 in every slot of every colo region, and
nothing anywhere rounds a slot up to `align_of::<T>()`. A 16-byte, 16-aligned
message (`#[repr(align(16))]`, a `u128` field, an SSE vector) was therefore
colo-eligible and every publish stored it through a misaligned `*mut T`.

Reproduced on a plain `Topic::with_capacity` + `send` loop, no unsafe in the
program: passes in debug, SIGSEGV in release. gdb on the release binary:

    Program received signal SIGSEGV
    #0 core::ptr::write<Align16> (dst=0x7ffff7fb2288)
    #1 horus_core::communication::topic::simd_aware_write<Align16> (mod.rs:619)
    #2 ...::dispatch::send_shm_mp_pod<Align16> (dispatch.rs:1443)
    => movaps %xmm0,(%rax)      rax = 0x7ffff7fb2288

0x288 is 648 — `HEADER_SIZE` 640 + `COLO_PAYLOAD_OFF` 8. The crash is
codegen-dependent (`#[repr(C)] struct { x: u128 }` gets scalar stores and does
not fault); the UB is not.

Two parts, both needed:

1. `colo_eligible` now takes `type_align` and requires
   `COLO_PAYLOAD_OFF.is_multiple_of(type_align)`, so anything stricter than
   8-aligned falls back to the split layout. Both derivation sites
   (`RingTopic::with_capacity_and_kind`, `TopicHeader::init`) pass it; nothing
   else in the workspace calls the function.

2. `simd_aware_write` copies bytes on both branches instead of
   `ptr::write::<T>`, mirroring `simd_aware_read_uninit`, and the two bare
   typed accesses on the role=Both fast path (`ptr::write`, `ptr::read`) go
   through the helpers. The split geometry is not aligned either — its data
   region starts at `640 + capacity * 8`, which is 8 mod 16 at `capacity == 1`
   — and rounding that up would move an offset `horus_net`'s `ShmRingWriter`
   and `header::read_slot_inner` each compute independently. With the gate
   alone in place, a capacity-1 topic still SIGSEGVs.

Also corrects dispatch's safety invariant 6 and the two comments that claimed
`slot_size` is rounded to `align_of::<T>()`. No such rounding has ever
existed.

## Ablation

```
TWO ablations, because the production change has two halves and each carries
its own weight.

--- Ablation 1: whole production change reverted (`git checkout --` the four
    src files), tests kept, debug ---

$ cargo test -p horus_core --test pod_ring_slot_geometry -- --test-threads=1

running 9 tests
test a_large_pod_type_stays_on_the_split_layout ... ok
test an_over_aligned_pod_type_publishes_at_a_misaligned_slot ... ok
test an_over_aligned_pod_type_stays_on_the_split_layout ... FAILED
test colo_has_no_sequence_array_and_no_over_allocation ... ok
test every_payload_lands_at_its_colo_slot ... ok
test header_declares_the_colo_layout_for_a_small_pod_type ... ok
test no_two_slots_share_a_cache_line ... ok
test pod_reader_and_writer_agree_on_the_stride ... ok
test the_stamp_shares_a_cache_line_with_its_payload ... ok

failures:

---- an_over_aligned_pod_type_stays_on_the_split_layout stdout ----

thread 'an_over_aligned_pod_type_stays_on_the_split_layout' (1692366) panicked at horus_core/tests/pod_ring_slot_geometry.rs:265:5:
assertion `left == right` failed: a 16-aligned payload cannot start 8 bytes into a slot
  left: 1
 right: 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    an_over_aligned_pod_type_stays_on_the_split_layout

test result: FAILED. 8 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

error: test failed, to rerun pass `-p horus_core --test pod_ring_slot_geometry`

(left: 1 == LAYOUT_COLO, right: 0 == LAYOUT_SPLIT. Restored, then all 9 pass.)

--- Ablation 2: only the byte copy in `simd_aware_write` reverted to
    `std::ptr::write(dst, msg)`, the `colo_eligible` alignment gate KEPT,
    release ---

Debug cannot show this one — a misaligned `ptr::write` is UB the compiler does
not check at -O0 — so it is run through a standalone release binary
(/tmp/.../scratchpad/alignrepro) doing `Topic::<Align16>::with_capacity(name,
cap, None)` + `send`, where `Align16` is `#[repr(C, align(16))] { a: u64, b:
u64 }`. This is the same code path
`an_over_aligned_pod_type_publishes_at_a_misaligned_slot` exercises.

$ alignrepro 8      # gate active -> split at 704, 16-aligned
cap=8: sent 8 messages without faulting
done
exit=0

$ alignrepro 1      # gate active, but split at 640 + 1*8 = 648, 8 mod 16
size=16 align=16
Segmentation fault (core dumped)
exit=139

$ gdb -batch -ex run -ex "info registers rax" -ex "x/1i $pc" --args alignrepro 1
Program received signal SIGSEGV, Segmentation fault.
0x00005555555a988e in core::ptr::write<alignrepro::Align16> (dst=0x7ffff7fb2288, src=...) at .../core/src/ptr/mod.rs:1933
rax            0x7ffff7fb2288      140737353818760
=> 0x5555555a988e <..._10horus_core13communication5topic8dispatch15send_shm_mp_pod...+190>:	movaps %xmm0,(%rax)

With the byte copy restored, both `alignrepro 8` and `alignrepro 1` exit 0 and
round-trip every value.

--- Pre-fix confirmation (before any change, unmodified worktree, release) ---

$ alignrepro 8
size=16 ali
```

## Tests

```
All from /home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-1.

cargo test -p horus_core --test pod_ring_slot_geometry -- --test-threads=1
  before fix: 8 passed, 1 failed
  after fix:  9 passed, 0 failed, 0 ignored (2 of the 9 are new)

cargo test -p horus_core --lib
  run 1: 2494 passed, 1 failed, 4 ignored, 72.68s
         failure was scheduling::scheduler::tests::test_ready_dispatch_graph_
         rebuild_after_tick_one — "Both nodes should tick, got pub=0 sub=0"
  re-run of that test alone: 1 passed, 0 failed
  run 2 (whole suite again): 2495 passed, 0 failed, 4 ignored, 41.20s
  => a load-dependent flake in a scheduler tick test (the box had 3 other
     cargo builds running), not this change; it touches no topic slot code.

cargo test -p horus_core --test <each>:
  acceptance_topic            16 passed, 0 failed, 1 ignored
  message_layout_contract     10 passed, 0 failed
  topic_lifecycle              6 passed, 0 failed
  topic_type_safety            3 passed, 0 failed
  cross_process_fanout_shm     3 passed, 0 failed
  cross_process_ipc           10 passed, 0 failed (60.01s)
  shm_cleanup_verification     4 passed, 0 failed
  topic_intent                 4 passed, 0 failed

cargo fmt --all -- --check          clean
cargo clippy -p horus_core --lib --tests   clean (0 warnings; the first pass
  flagged manual_is_multiple_of on my new `%`, now written as
  COLO_PAYLOAD_OFF.is_multiple_of(type_align) — const-stable since 1.87,
  workspace MSRV is 1.90)
cargo check -p horus_net --all-targets     clean (it is the out-of-crate
  consumer of shm_layout)

NOT run: the other ~165 horus_core integration test files, and the rest of the
workspace's test suites. The box ran out of disk (/ hit 100%, 0 bytes free)
partway through — see notes.
```

## Notes from the implementer

CONFIRMED THE FINDING FIRST, INDEPENDENTLY. Built a standalone release binary
against this worktree's horus_core (plain `Topic::with_capacity` + `send`, no
unsafe in the program) with `#[repr(C, align(16))] struct Align16 { a: u64, b:
u64 }`. Debug passes, release SIGSEGVs, and gdb puts the fault at exactly the
instruction the finding named: `movaps %xmm0,(%rax)`, rax = 0x7ffff7fb2288,
inside `core::ptr::write<Align16>` from `simd_aware_write` (mod.rs:619) from
`send_shm_mp_pod` (dispatch.rs:1443). 0x288 = 648 = HEADER_SIZE 640 +
COLO_PAYLOAD_OFF 8.

ONE JUDGMENT CALL FOR THE REVIEWER — a public signature change.
`shm_layout::colo_eligible` is `pub` in a `pub` module (the module doc says it
exists for out-of-crate consumers), and I changed its arity from
`(is_pod, type_size)` to `(is_pod, type_size, type_align)`. Nothing in the
workspace calls it but the two in-crate derivation sites — horus_net uses
`shm_layout` but not this function. I judged the break worth taking because the
predicate's answer was simply wrong and an additive `colo_align_ok(align)`
helper would leave the wrong one standing as the obvious call. If you would
rather not break it: keep the 2-arg form, add
`pub const fn colo_align_ok(type_align: usize) -> bool`, and call
`colo_eligible(..) && colo_align_ok(..)` at mod.rs:1032 and header.rs:539. The
rest of the diff is unaffected.

WHY THE FIX HAS TWO HALVES. The finding's suggested gate alone is not
sufficient. The split geometry is not aligned either: its data region starts at
`640 + capacity * 8`, which is 8 mod 16 when `capacity == 1` (the only odd
power of two) and worse for align 32 (`capacity` 1 or 2). Ablation 2 above
shows the capacity-1 case still SIGSEGVs in release with the gate in place. The
alternative — rounding `data_region_offset` up to `align_of::<T>()` — moves a
wire offset that `horus_net::ShmRingWriter` and `header::read_slot_inner`
compute independently, which is the exact drift `shm_layout` exists to prevent,
so I did not touch it. Making the slot access byte-wise (which is what the read
path already did) is the smaller and complete fix.

WHAT I DELIBERATELY DID NOT DO. The finding also suggests validating the
header's `type

---
Found by a 10-dimension adversarial audit; fix implemented in an isolated worktree with ablation required, then re-applied, compiled and full-suite tested on current `main` before this PR.
