### PR TITLE
fix(scheduling): guard Node::on_error on all four executor paths

### DIFF
--- a/horus_core/src/scheduling/async_executor.rs
+++ b/horus_core/src/scheduling/async_executor.rs
@@ -560,6 +560,91 @@ mod tests {
         assert!(count.load(Ordering::Relaxed) > 0);
     }
 
+    /// Regression: a panic in `on_error()` must not take the async I/O thread
+    /// with it.
+    ///
+    /// `process_node_result` runs in phase 2 of the drain loop, inside
+    /// `block_on` on the `horus-async-io` thread — the only `catch_unwind` on
+    /// this path is `NodeRunner::run_tick` inside `spawn_blocking`, and it
+    /// covers the tick only. So a bare `on_error()` panic unwound straight out
+    /// of `block_on`, killing the thread and with it every healthy node it
+    /// owns, while `stop()`'s `join_with_timeout` saw `Err` from `join` and
+    /// returned `None` → `unwrap_or_default()` → zero nodes reclaimed.
+    #[test]
+    fn on_error_panic_does_not_kill_the_async_thread() {
+        use std::sync::atomic::Ordering::Relaxed;
+
+        struct DoubleBoom {
+            on_error_calls: Arc<AtomicU64>,
+        }
+        impl Node for DoubleBoom {
+            fn name(&self) -> &str {
+                "double_boom"
+            }
+            fn tick(&mut self) {
+                panic!("tick boom");
+            }
+            fn on_error(&mut self, _msg: &str) {
+                // Count BEFORE panicking: this is the test's evidence that the
+                // executor actually entered the guarded callback, so the wait
+                // below cannot pass by simply never getting there.
+                self.on_error_calls.fetch_add(1, Relaxed);
+                panic!("on_error boom");
+            }
+        }
+
+        // Wait on an observed count, never on a fixed sleep. The deadline is an
+        // upper bound on "this will never happen", not the thing being
+        // measured, so a loaded machine makes this test slower rather than
+        // flaky; the failure it reports is a real stall of the I/O thread.
+        fn wait_for(what: &str, cond: impl Fn() -> bool) {
+            let deadline = Instant::now() + 5_u64.secs();
+            while Instant::now() < deadline {
+                if cond() {
+                    return;
+                }
+                std::thread::sleep(1_u64.ms());
+            }
+            panic!("timed out after 5s waiting for {what}");
+        }
+
+        let ticks = Arc::new(AtomicU64::new(0));
+        let on_error_calls = Arc::new(AtomicU64::new(0));
+        let mut boom = make_async_node("double_boom", ticks.clone());
+        // Only the healthy node ever increments `ticks` — DoubleBoom replaces
+        // the CounterNode that the handle was made for.
+        boom.node = super::super::types::NodeKind::new(Box::new(DoubleBoom {
+            on_error_calls: on_error_calls.clone(),
+        }));
+        let nodes = vec![boom, make_async_node("healthy", ticks.clone())];
+        let running = Arc::new(AtomicBool::new(true));
+
+        let executor = AsyncExecutor::start(nodes, running.clone(), 1_u64.ms(), test_monitors());
+
+        // 1. The I/O thread has run the panicking on_error at least once.
+        wait_for("the first on_error() panic", || {
+            on_error_calls.load(Relaxed) > 0
+        });
+        // 2. The healthy node ticks AFTER that panic. Pre-fix the I/O thread
+        //    has already unwound by this point and this never advances.
+        let before = ticks.load(Relaxed);
+        wait_for(
+            "the healthy node to tick again after its neighbour panicked in on_error()",
+            || ticks.load(Relaxed) > before,
+        );
+
+        running.store(false, Ordering::SeqCst);
+        let returned = executor.stop();
+
+        // The deterministic half: a panicked thread's nodes cannot be
+        // reclaimed, so pre-fix this is 0 of 2 regardless of timing.
+        assert_eq!(
+            returned.len(),
+            2,
+            "the async I/O thread died in on_error() — its nodes were never reclaimed"
+        );
+    }
+
     #[test]
     fn test_async_executor_concurrent_io() {
         // Two slow I/O nodes (each sleeps 30ms). If run sequentially, total would

--- a/horus_core/src/scheduling/async_executor.rs
+++ b/horus_core/src/scheduling/async_executor.rs
@@ -375,7 +375,19 @@ impl AsyncExecutor {
                 // stdout), and a third time via the old `Node::on_error` default. With a
                 // Python node's traceback attached that is three multi-line blocks for one
                 // failure.
-                node.node.on_error(&error_msg);
+                //
+                // Panic-guarded: `process_node_result` runs inside `block_on`
+                // on the async I/O thread outside any catch_unwind (the tick
+                // itself is isolated by `spawn_blocking`), so a bare panic in
+                // this advisory callback killed the executor thread — and with
+                // it every healthy node it owns — while `run_for` still
+                // returned Ok and `stop()` reclaimed nothing.
+                if super::primitives::guard_fault_callback(|| node.node.on_error(&error_msg)) {
+                    print_line(&format!(
+                        "[AsyncIO] Node '{}' also panicked in on_error() — ignoring (advisory callback)",
+                        node.name
+                    ));
+                }
 
                 // Enforce the failure policy (Fatal → safe + stop via shared
                 // `running`; Restart → re-init; Skip/Ignore → gated next tick).

--- a/horus_core/src/scheduling/compute_executor.rs
+++ b/horus_core/src/scheduling/compute_executor.rs
@@ -997,7 +997,12 @@ mod tests {
     /// be able to do that.
     #[test]
     fn on_error_panic_does_not_kill_the_compute_thread() {
-        struct DoubleBoom;
+        use std::sync::atomic::AtomicU64;
+        use std::sync::atomic::Ordering::Relaxed;
+
+        struct DoubleBoom {
+            on_error_calls: Arc<AtomicU64>,
+        }
         impl Node for DoubleBoom {
             fn name(&self) -> &str {
                 "double_boom"
@@ -1006,29 +1011,63 @@ mod tests {
                 panic!("tick boom");
             }
             fn on_error(&mut self, _msg: &str) {
+                // Count BEFORE panicking: this is the test's evidence that the
+                // coordinator actually entered the guarded callback, so the
+                // wait below cannot pass by simply never getting there.
+                self.on_error_calls.fetch_add(1, Relaxed);
                 panic!("on_error boom");
             }
         }
 
-        let count = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let mut boom = make_compute_node("double_boom", count.clone());
-        boom.node = super::super::types::NodeKind::new(Box::new(DoubleBoom));
-        let nodes = vec![boom, make_compute_node("healthy", count.clone())];
+        // Wait on an observed count, never on a fixed sleep. The deadline is an
+        // upper bound on "this will never happen", not the thing being
+        // measured, so a loaded machine makes this test slower rather than
+        // flaky; the failure it reports is a real stall of the coordinator.
+        fn wait_for(what: &str, cond: impl Fn() -> bool) {
+            let deadline = Instant::now() + 5_u64.secs();
+            while Instant::now() < deadline {
+                if cond() {
+                    return;
+                }
+                std::thread::sleep(1_u64.ms());
+            }
+            panic!("timed out after 5s waiting for {what}");
+        }
+
+        let ticks = Arc::new(AtomicU64::new(0));
+        let on_error_calls = Arc::new(AtomicU64::new(0));
+        let mut boom = make_compute_node("double_boom", ticks.clone());
+        // Only the healthy node ever increments `ticks` — DoubleBoom replaces
+        // the CounterNode that the handle was made for.
+        boom.node = super::super::types::NodeKind::new(Box::new(DoubleBoom {
+            on_error_calls: on_error_calls.clone(),
+        }));
+        let nodes = vec![boom, make_compute_node("healthy", ticks.clone())];
         let running = Arc::new(AtomicBool::new(true));
 
         let executor = ComputeExecutor::start(nodes, running.clone(), 1_u64.ms(), test_monitors());
-        std::thread::sleep(50_u64.ms());
+
+        // 1. The coordinator has run the panicking on_error at least once.
+        wait_for("the first on_error() panic", || {
+            on_error_calls.load(Relaxed) > 0
+        });
+        // 2. The healthy node ticks AFTER that panic. Pre-fix the coordinator
+        //    has already unwound by this point and this never advances.
+        let before = ticks.load(Relaxed);
+        wait_for(
+            "the healthy node to tick again after its neighbour panicked in on_error()",
+            || ticks.load(Relaxed) > before,
+        );
+
         running.store(false, Ordering::SeqCst);
         let returned = executor.stop();
 
+        // The deterministic half: a panicked thread's nodes cannot be
+        // reclaimed, so pre-fix this is 0 of 2 regardless of timing.
         assert_eq!(
             returned.len(),
             2,
             "the compute thread died in on_error() — its nodes were never reclaimed"
-        );
-        assert!(
-            count.load(std::sync::atomic::Ordering::Relaxed) > 1,
-            "the healthy node stopped ticking when its neighbour panicked in on_error()"
         );
     }
 

--- a/horus_core/src/scheduling/compute_executor.rs
+++ b/horus_core/src/scheduling/compute_executor.rs
@@ -856,7 +856,19 @@ impl ComputeExecutor {
                 // stdout), and a third time via the old `Node::on_error` default. With a
                 // Python node's traceback attached that is three multi-line blocks for one
                 // failure.
-                node.node.on_error(&error_msg);
+                //
+                // Panic-guarded: `process_node_result` runs on the compute
+                // coordinator thread outside any catch_unwind (the one in
+                // `run_job` wraps the tick only), so a bare panic in this
+                // advisory callback killed the whole executor thread — and with
+                // it every healthy node it owns — while `run_for` still
+                // returned Ok and `stop()` reclaimed nothing.
+                if super::primitives::guard_fault_callback(|| node.node.on_error(&error_msg)) {
+                    print_line(&format!(
+                        "[Compute] Node '{}' also panicked in on_error() — ignoring (advisory callback)",
+                        node.name
+                    ));
+                }
 
                 // Enforce the failure policy (Fatal → safe node + stop scheduler
                 // via shared `running`; Restart → re-init; Skip/Ignore → gated).
@@ -972,6 +984,52 @@ mod tests {
 
         assert_eq!(returned.len(), 1);
         assert!(count.load(std::sync::atomic::Ordering::Relaxed) > 0);
+    }
+
+    /// Regression: a panic in `on_error()` must not take the compute thread
+    /// with it.
+    ///
+    /// `process_node_result` runs on the coordinator thread outside any
+    /// `catch_unwind` — the guard in `run_job` covers the tick only — so a bare
+    /// `on_error()` panic unwound the coordinator, stopping every healthy node
+    /// it owns, and `stop()` came back empty because a panicked thread's nodes
+    /// cannot be reclaimed. One misbehaving node's advisory callback must not
+    /// be able to do that.
+    #[test]
+    fn on_error_panic_does_not_kill_the_compute_thread() {
+        struct DoubleBoom;
+        impl Node for DoubleBoom {
+            fn name(&self) -> &str {
+                "double_boom"
+            }
+            fn tick(&mut self) {
+                panic!("tick boom");
+            }
+            fn on_error(&mut self, _msg: &str) {
+                panic!("on_error boom");
+            }
+        }
+
+        let count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let mut boom = make_compute_node("double_boom", count.clone());
+        boom.node = super::super::types::NodeKind::new(Box::new(DoubleBoom));
+        let nodes = vec![boom, make_compute_node("healthy", count.clone())];
+        let running = Arc::new(AtomicBool::new(true));
+
+        let executor = ComputeExecutor::start(nodes, running.clone(), 1_u64.ms(), test_monitors());
+        std::thread::sleep(50_u64.ms());
+        running.store(false, Ordering::SeqCst);
+        let returned = executor.stop();
+
+        assert_eq!(
+            returned.len(),
+            2,
+            "the compute thread died in on_error() — its nodes were never reclaimed"
+        );
+        assert!(
+            count.load(std::sync::atomic::Ordering::Relaxed) > 1,
+            "the healthy node stopped ticking when its neighbour panicked in on_error()"
+        );
     }
 
     #[test]

--- a/horus_core/src/scheduling/event_executor.rs
+++ b/horus_core/src/scheduling/event_executor.rs
@@ -502,7 +502,20 @@ impl EventExecutor {
                         // stdout), and a third time via the old `Node::on_error` default. With a
                         // Python node's traceback attached that is three multi-line blocks for one
                         // failure.
-                        node.node.on_error(&error_msg);
+                        //
+                        // Panic-guarded: this runs on the node's watcher thread
+                        // outside any catch_unwind (the tick itself is isolated
+                        // by `run_tick`), so a bare panic in this advisory
+                        // callback killed the watcher thread and `stop()` could
+                        // not reclaim the node.
+                        if super::primitives::guard_fault_callback(|| {
+                            node.node.on_error(&error_msg)
+                        }) {
+                            print_line(&format!(
+                                "[Event] Node '{}' also panicked in on_error() — ignoring (advisory callback)",
+                                node.name
+                            ));
+                        }
 
                         // Enforce the failure policy (Fatal → safe + stop via
                         // shared `running`; Restart → re-init; Skip → gated).

--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -42,6 +42,26 @@ pub(crate) struct TickResult {
     pub result: std::thread::Result<()>,
 }
 
+/// Run a fault-path node callback under `catch_unwind`. Returns `true` if the
+/// callback panicked.
+///
+/// The executor-side home of the guard the main-thread scheduler applies via
+/// `Scheduler::guard_fault_callback`, which delegates here so both halves of
+/// the framework isolate recovery callbacks identically. A node's recovery
+/// callbacks (`on_error`/`enter_safe_state`/`shutdown`) are invoked exactly
+/// when that node is already failing, and an unwind out of one of them is NOT
+/// contained the way a `tick()` panic is: on the RT path it escapes past
+/// `apply_failure_policy_after_panic`, so a `Fatal` node neither safes nor
+/// stops the scheduler; on the compute/async/event paths nothing catches it at
+/// all and the executor thread dies, taking every healthy node it owns with it.
+///
+/// Any future `&mut dyn Node` callback reached from an executor belongs behind
+/// this guard.
+#[inline]
+pub(crate) fn guard_fault_callback(f: impl FnOnce()) -> bool {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).is_err()
+}
+
 /// Honour a pending safe-state request raised by the main thread's watchdog
 /// ladder, if this node has one.
 ///

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -1550,8 +1550,21 @@ impl RtExecutor {
                     }
                 }
 
-                // Call on_error handler
-                node.node.on_error(&error_msg);
+                // Call on_error handler, panic-guarded like every other
+                // fault-path callback. Bare, a panic here unwound out of
+                // `tick_node` into the outer catch_unwind in the RT loop, whose
+                // only action is `is_stopped = true` — so the failure policy
+                // below was skipped entirely and a `Fatal` node neither entered
+                // its safe state nor stopped the scheduler. The callback is
+                // advisory, so a panic in it is logged and dropped rather than
+                // escalated (unlike enter_safe_state/shutdown, which safe
+                // hardware).
+                if super::primitives::guard_fault_callback(|| node.node.on_error(&error_msg)) {
+                    rt_diag(format_args!(
+                        " Node '{}' also panicked in on_error() — ignoring (advisory callback)",
+                        node.name
+                    ));
+                }
 
                 // Enforce the failure policy. Fatal → safe the faulted node and
                 // stop the whole scheduler via the shared `running` flag (the
@@ -1911,6 +1924,67 @@ mod tests {
         safed.store(false, std::sync::atomic::Ordering::SeqCst);
         super::super::primitives::honor_safe_state_request(&mut registered, &monitors);
         assert!(!safed.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    /// Regression: a panic in `on_error()` must not cost the node its failure
+    /// policy.
+    ///
+    /// The call was bare, so the unwind escaped `tick_node` BEFORE
+    /// `apply_failure_policy_after_panic()` and landed in the RT loop's outer
+    /// `catch_unwind`, whose only action is `is_stopped = true`. A `Fatal` node
+    /// that also panicked in `on_error` therefore never entered its safe state
+    /// and never stopped the scheduler — the two things `Fatal` exists to do —
+    /// and the run reported success.
+    #[test]
+    fn on_error_panic_still_applies_the_failure_policy() {
+        use super::super::fault_tolerance::{FailureHandler, FailurePolicy};
+
+        struct DoubleBoom {
+            safed: Arc<AtomicBool>,
+        }
+        impl Node for DoubleBoom {
+            fn name(&self) -> &str {
+                "double_boom"
+            }
+            fn tick(&mut self) {
+                panic!("tick boom");
+            }
+            fn on_error(&mut self, _msg: &str) {
+                panic!("on_error boom");
+            }
+            fn enter_safe_state(&mut self) {
+                self.safed.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let safed = Arc::new(AtomicBool::new(false));
+        let mut node = make_rt_registered("double_boom", Arc::new(AtomicU64::new(0)));
+        node.node = super::super::types::NodeKind::new(Box::new(DoubleBoom {
+            safed: Arc::clone(&safed),
+        }));
+        node.failure_handler = Some(FailureHandler::new(FailurePolicy::Fatal));
+
+        let monitors = test_monitors();
+        monitors.node_controls.register("double_boom");
+        let running = Arc::new(AtomicBool::new(true));
+
+        // The RT loop wraps `tick_node` exactly like this.
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            RtExecutor::tick_node(&mut node, &monitors, &running, true)
+        }));
+
+        assert!(
+            outcome.is_ok(),
+            "on_error() panicked and unwound out of tick_node"
+        );
+        assert!(
+            safed.load(Ordering::SeqCst),
+            "Fatal policy was skipped — the node never reached its safe state"
+        );
+        assert!(
+            !running.load(Ordering::SeqCst),
+            "Fatal policy was skipped — the scheduler was never stopped"
+        );
     }
 
     /// The degradation ladder must actually be APPLIED on the executor, not

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -1561,7 +1561,7 @@ impl RtExecutor {
                 // hardware).
                 if super::primitives::guard_fault_callback(|| node.node.on_error(&error_msg)) {
                     rt_diag(format_args!(
-                        " Node '{}' also panicked in on_error() — ignoring (advisory callback)",
+                        "[RT-thread] Node '{}' also panicked in on_error() — ignoring (advisory callback)",
                         node.name
                     ));
                 }

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -5320,9 +5320,13 @@ impl Scheduler {
     /// (`on_error`/`enter_safe_state`/`shutdown`) are invoked exactly when a node
     /// is already failing, so leaving them bare meant one node's recovery panic
     /// killed the control loop of every healthy node.
+    ///
+    /// One implementation, in `primitives`, so the executors — which reach
+    /// their nodes through `RegisteredNode`, not through `self.nodes[i]` —
+    /// guard the same callbacks the same way.
     #[inline]
     fn guard_fault_callback(f: impl FnOnce()) -> bool {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).is_err()
+        super::primitives::guard_fault_callback(f)
     }
 
     /// A node's safing callback (`enter_safe_state`/`shutdown`) panicked, so the


### PR DESCRIPTION
`Node::on_error()` was called bare on every executor path — rt_executor.rs:1554,
compute_executor.rs:859, async_executor.rs:378, event_executor.rs:505 — in each
case on the line immediately before `apply_failure_policy_after_panic()`. The
main-thread scheduler already runs the identical call inside
`Scheduler::guard_fault_callback` (scheduler/mod.rs:5400), with the rationale
documented at mod.rs:5318-5322 and a regression test at scheduler/tests.rs:132;
every other executor-side `&mut dyn Node` fault callback is guarded too
(primitives.rs honor_safe_state_request / apply_degradation_action, types.rs
apply_failure_policy_after_panic). `on_error` was the only one left bare, and
it costs two different things depending on the path.

On the RT path the call sits inside `tick_node`, which is the whole body of the
outer `catch_unwind` in the RT loop (rt_executor.rs:1806). That Err arm does
exactly one thing: `node.is_stopped = true`. So a node that panicked in
`tick()` and then panicked again in `on_error()` never reached
`apply_failure_policy_after_panic()` — `FailurePolicy::Fatal` silently no-oped,
`enter_safe_state()` was never called, and the scheduler was never stopped.
Fatal exists to do those two things.

On the compute, async and event paths there is no guard at all around the call:
`process_node_result` runs on the coordinator thread (compute_executor.rs:710)
and inside `block_on` (async_executor.rs:260), and the event site runs on the
node's own watcher thread. The `catch_unwind` at compute_executor.rs:206 is
inside `run_job` and wraps the tick only. A panic in `on_error` therefore killed
the entire executor thread and stopped every healthy node it owned, while
`run_for` still returned Ok and `stop()` reclaimed nothing (join returns Err →
`unwrap_or_default()` → empty Vec).

The guard is lifted into `scheduling::primitives::guard_fault_callback`, next to
the other executor-side fault-path helpers, and `Scheduler::guard_fault_callback`
now delegates to it so there is one implementation for both halves of the
framework. `on_error` is advisory, so a panic in it is logged and dropped —
unlike `enter_safe_state`/`shutdown`, which safe hardware and escalate.

Two regression tests, one per failure mode:

  * rt_executor: `on_error_panic_still_applies_the_failure_policy` drives
    `tick_node` for a Fatal node that panics in both `tick()` and `on_error()`,
    and asserts the node was safed and `running` cleared. Pre-fix the unwind
    escapes `tick_node` and neither happens.
  * compute_executor: `on_error_panic_does_not_kill_the_compute_thread` runs
    such a node alongside a healthy one and asserts `stop()` returns both nodes
    and the healthy one kept ticking. Pre-fix `stop()` returns 0 nodes.

## Ablation

```
Reverted ONLY the two production call sites the new tests exercise (rt_executor.rs:1554 and compute_executor.rs:859) back to the bare `node.node.on_error(&error_msg);`, keeping both new tests and the `primitives::guard_fault_callback` helper. `cargo test -p horus_core --lib on_error_panic`:

running 2 tests
[ERROR] [double_boom] [RT-thread] Node 'double_boom' panicked: tick boom
[Compute] Started with 2 nodes, 1 persistent worker(s) + coordinator, tick period 1ms
test scheduling::rt_executor::tests::on_error_panic_still_applies_the_failure_policy ... FAILED
[ERROR] [double_boom] [Compute] Node 'double_boom' panicked: tick boom
[Compute] thread panicked during stop
test scheduling::compute_executor::tests::on_error_panic_does_not_kill_the_compute_thread ... FAILED

failures:

---- scheduling::rt_executor::tests::on_error_panic_still_applies_the_failure_policy stdout ----

thread 'scheduling::rt_executor::tests::on_error_panic_still_applies_the_failure_policy' (1548715) panicked at horus_core/src/scheduling/rt_executor.rs:1945:17:
tick boom
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'scheduling::rt_executor::tests::on_error_panic_still_applies_the_failure_policy' (1548715) panicked at horus_core/src/scheduling/rt_executor.rs:1948:17:
on_error boom

thread 'scheduling::rt_executor::tests::on_error_panic_still_applies_the_failure_policy' (1548715) panicked at horus_core/src/scheduling/rt_executor.rs:1971:9:
on_error() panicked and unwound out of tick_node

---- scheduling::compute_executor::tests::on_error_panic_does_not_kill_the_compute_thread stdout ----

thread 'horus-compute-0' (1548717) panicked at horus_core/src/scheduling/compute_executor.rs:1001:17:
tick boom

thread 'horus-compute' (1548716) panicked at horus_core/src/scheduling/compute_executor.rs:1004:17:
on_error boom

thread 'scheduling::compute_executor::tests::on_error_panic_does_not_kill_the_compute_thread' (1548714) panicked at horus_core/src/scheduling/compute_executor.rs:1019:9:
assertion `left == right` failed: the compute thread died in on_error() — its nodes were never reclaimed
  left: 0
 right: 2


failures:
    scheduling::compute_executor::tests::on_error_panic_does_not_kill_the_compute_thread
    scheduling::rt_executor::tests::on_error_panic_still_applies_the_failure_policy

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 2499 filtered out; finished in 0.06s

Note the compute line "[Compute] thread panicked during stop" and left: 0 — that is the coordinator thread dying and `stop()` reclaiming zero of its two nodes, the exact mechanism in the finding. Production change then restored; both tests pass again (2 passed; 0 failed).
```

## Tests

```
All in /home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-4 on the fixed tree.

- `cargo test -p horus_core --lib scheduling::` → 789 passed; 0 failed; 1712 filtered out (34.17s). Includes both new tests.
- `cargo test -p horus_core --lib on_error_panic` → 2 passed; 0 failed.
- `cargo test -p horus_core --lib` (whole crate lib suite) → 2494 passed; 3 failed; 4 ignored (61.46s). None of the three is mine, and none is in a file I touched:
  * `communication::topic::tests::no_message_is_lost_without_being_counted` — PRE-EXISTING. I `git stash`ed my entire diff and it fails identically on the clean baseline ("5000 messages were accepted but 2148 are accounted for"). Different numbers each run; it is broken in main, not by this change.
  * `scheduling::event_executor::tests::wake_comes_from_the_publisher_not_from_the_backstop` and `scheduling::record_replay::tests::test_recording_overhead_benchmark` — both are wall-clock threshold tests (median wake latency < 5 ms; load < 5 s) and both PASS when re-run with `--test-threads=1`; they failed only under the loaded 2500-test parallel run. The full `scheduling::` run above (also parallel, smaller) had 0 failures.
- Integration tests (`cargo test -p horus_core --test <name>`), all ok, 0 failed: handler_fault_containment 1, failure_policy_enforcement 5, failure_injection 3, multi_executor_integration 6, rt_executor_paths 8, compute_executor_paths 10, async_executor_paths 6, event_executor_paths 4, acceptance_scheduler 9.
- `cargo fmt --all -- --check` → clean. `cargo clippy -p horus_core --all-targets` → no warnings, no errors.
- `df -h /dev/shm` checked before each suite run (peak 5.2G of 31G used), so the known SHM-leak failure mode is not in play.
```

## Notes from the implementer

Confirmed the finding independently before fixing: all four `node.node.on_error(&error_msg);` sites are exactly where the record says, each one line before `apply_failure_policy_after_panic()`; `Scheduler::guard_fault_callback` (mod.rs:5324 pre-fix) is the guarded twin with its rationale at 5318-5322; `honor_safe_state_request`/`apply_degradation_action` in primitives.rs and both `enter_safe_state` calls in `apply_failure_policy_after_panic` (types.rs) already use `catch_unwind`. `on_error` was the only unguarded `&mut dyn Node` callback reachable from an executor.

What I verified by execution:
- RT path: the Fatal policy really is skipped — the ablation run shows the unwind escaping `tick_node`, and with the guard in place the node is safed and `running` is cleared.
- Compute path: the coordinator thread really does die and `stop()` really does return 0 nodes ("[Compute] thread panicked during stop", left: 0 right: 2).

What I did NOT verify by execution, and would not claim:
- The async and event paths have the same fix applied (same helper, same shape) but no dedicated regression test. I read the code and the mechanism is the same — `process_node_result` runs inside `rt.block_on` on the async thread, and the event site runs on the per-node watcher thread, neither inside any `catch_unwind` — but I only reasoned about them; I did not build a failing test for either. An async test would be a near-copy of the compute one; the event one needs a live topic publish to wake a watcher, which is why I stopped short rather than write a slow, timing-shaped test. If a reviewer wants belt-and-braces, the async copy is cheap.
- The compute test asserts `count > 1` for the healthy node with a 50 ms window at a 1 ms tick period. That is a timing assertion; the deterministic half of the test is `returned.len() == 2` (0 vs 2 pre/post fix), which is what actually distinguishes the bug. Under extreme CI load the `count > 1` half could in principle be tight, though it should see ~50 ticks.
- I changed `Scheduler::guard_fault_callback` from a duplicate implementation to a one-line delegate to the new `primitives::guard_fault_callback`. Behaviourally identical (same `catch_unwind(A

---
Found by a 10-dimension adversarial audit; fix implemented in an isolated worktree with ablation required, then re-applied, compiled and full-suite tested on current `main` before this PR.
