### PR TITLE
test(horus_core): scope the SHM corruption tests to their own namespace

### DIFF
--- a/horus_core/tests/production_fanout_battle.rs
+++ b/horus_core/tests/production_fanout_battle.rs
@@ -1787,6 +1787,54 @@ fn fault_kill9_publisher_mid_stream() {
     );
 }
 
+/// The SHM backing files a killed child left behind for `topic` — and nothing
+/// else on this machine.
+///
+/// One topic occupies more than one file (`<name>`, plus the `<name>_fanout`
+/// region a FanoutShm handle allocates), so this matches by prefix. What it
+/// will not do is leave `shm_topics_dir()`, this binary's own `test_<hash>`
+/// namespace; the killed child is inside it too, because `shm_namespace()`
+/// publishes a test binary's namespace to its children through
+/// `HORUS_NAMESPACE` (horus_sys/src/shm/mod.rs).
+///
+/// The two corruption tests below used to enumerate `/dev/shm` itself and write
+/// into every `horus_*/topics/*` file on the box: `/dev/shm/horus_default`,
+/// where an installed `horus` or a `cargo run` binary keeps a live robot's
+/// regions, and every concurrent test run's `test_<hash>` namespace — exactly
+/// the isolation `cargo_test_namespace` exists to provide. Measured in an
+/// isolated tmpfs: one `cargo test --test production_fanout_battle` took a
+/// planted 65536-byte region in `horus_default` down to 8192 zero bytes (the
+/// recovery test's `fs::write` is O_TRUNC, so it truncates rather than zeroing
+/// a prefix), and both tests still reported "ok" — a process holding that
+/// region mapped takes SIGBUS past the new end of file.
+fn orphan_topic_files(topic: &str) -> Vec<std::path::PathBuf> {
+    let suffixed = format!("{topic}_");
+    let Ok(entries) = std::fs::read_dir(horus_sys::shm::shm_topics_dir()) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n == topic || n.starts_with(&suffixed))
+        })
+        .collect()
+}
+
+/// Overwrite the first 8 bytes of an SHM region — where the magic lives — with
+/// garbage, leaving the length of the file and every other byte alone.
+fn corrupt_magic_bytes(path: &std::path::Path) -> bool {
+    let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(path) else {
+        return false;
+    };
+    use std::io::Write;
+    f.write_all(&[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE])
+        .is_ok()
+}
+
 /// SHM corruption detection: corrupted magic bytes must not cause SIGSEGV.
 ///
 /// Production scenario: power failure corrupts the SHM backing file.
@@ -1829,29 +1877,13 @@ fn fault_shm_magic_corruption_rejected() {
     child.kill().expect("kill child");
     child.wait().expect("wait child");
 
-    // Scan ALL /dev/shm/horus_* dirs for topic files to corrupt
-    let shm_root = std::path::PathBuf::from("/dev/shm");
+    // Corrupt the orphans the killed child left for THIS topic (see
+    // `orphan_topic_files` — never another namespace's files).
     let mut corrupted_count = 0;
-    if let Ok(entries) = std::fs::read_dir(&shm_root) {
-        for entry in entries.flatten() {
-            let dir_name = entry.file_name().to_string_lossy().to_string();
-            if dir_name.starts_with("horus_") {
-                let topics_dir = entry.path().join("topics");
-                if let Ok(files) = std::fs::read_dir(&topics_dir) {
-                    for file in files.flatten() {
-                        let path = file.path();
-                        if path.is_file() {
-                            if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(&path) {
-                                use std::io::Write;
-                                let garbage = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
-                                let _ = f.write_all(&garbage);
-                                corrupted_count += 1;
-                                eprintln!("Corrupted: {}", path.display());
-                            }
-                        }
-                    }
-                }
-            }
+    for path in orphan_topic_files(&name) {
+        if corrupt_magic_bytes(&path) {
+            corrupted_count += 1;
+            eprintln!("Corrupted: {}", path.display());
         }
     }
 
@@ -1926,24 +1958,18 @@ fn fault_shm_recovery_after_corruption() {
     child.kill().expect("kill child");
     child.wait().expect("wait child");
 
-    // Corrupt ALL orphaned SHM files
-    let shm_root = std::path::PathBuf::from("/dev/shm");
-    if let Ok(entries) = std::fs::read_dir(&shm_root) {
-        for entry in entries.flatten() {
-            let dir_name = entry.file_name().to_string_lossy().to_string();
-            if dir_name.starts_with("horus_") {
-                let topics_dir = entry.path().join("topics");
-                if let Ok(files) = std::fs::read_dir(&topics_dir) {
-                    for file in files.flatten() {
-                        let path = file.path();
-                        if path.is_file() {
-                            if let Ok(metadata) = std::fs::metadata(&path) {
-                                let zeros = vec![0u8; metadata.len().min(8192) as usize];
-                                let _ = std::fs::write(&path, &zeros);
-                            }
-                        }
-                    }
-                }
+    // Zero the head of the orphans this test's own child left (see
+    // `orphan_topic_files` — never another namespace's files).
+    for path in orphan_topic_files(&name) {
+        if let Ok(metadata) = std::fs::metadata(&path) {
+            let zeros = vec![0u8; metadata.len().min(8192) as usize];
+            // Deliberately not `fs::write`: that opens O_TRUNC, so it does not
+            // zero the first 8 KiB of the region, it cuts the region down to
+            // them — and a still-mapped region then takes SIGBUS past the new
+            // end of file, which is not the corruption this test recovers from.
+            if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(&path) {
+                use std::io::Write;
+                let _ = f.write_all(&zeros);
             }
         }
     }
@@ -1960,6 +1986,81 @@ fn fault_shm_recovery_after_corruption() {
     }
 
     eprintln!("Recovery successful: topic works after corruption + cleanup");
+}
+
+/// The two fault-injection tests above must corrupt only their own namespace.
+///
+/// They select their victims with `orphan_topic_files` and write them with
+/// `corrupt_magic_bytes`; this drives that pair against a region planted in a
+/// namespace that is *not* ours, named the way the ones the tests used to
+/// destroy are named — `/dev/shm/horus_default` is a live robot's, and every
+/// concurrent `cargo test` on the box owns a `/dev/shm/horus_test_<hash>`.
+/// Both live in sibling directories of ours and are indistinguishable from it
+/// to a walk that starts at the SHM root.
+#[test]
+fn shm_corruption_stays_inside_this_namespace() {
+    if !horus_sys::shm::regions_are_file_backed() {
+        eprintln!("Regions are not file-backed on this platform — nothing to scope");
+        return;
+    }
+
+    let _shm_guard = cleanup_stale_shm();
+    let name = unique("scope");
+
+    /// Removes the planted namespace however this test ends, panic included.
+    struct DecoyNamespace(std::path::PathBuf);
+    impl Drop for DecoyNamespace {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    let shm_root = horus_sys::shm::shm_base_dir()
+        .parent()
+        .expect("SHM base dir always has a parent")
+        .to_path_buf();
+    let decoy = DecoyNamespace(shm_root.join(format!("horus_{}", unique("decoy_ns"))));
+    let foreign_topics = decoy.0.join("topics");
+    std::fs::create_dir_all(&foreign_topics).expect("create decoy namespace");
+    // Same topic name in both namespaces: only the namespace separates them,
+    // so a name-based filter alone cannot pass this test.
+    let foreign = foreign_topics.join(&name);
+    let intact = vec![0xA5u8; 65536];
+    std::fs::write(&foreign, &intact).expect("plant foreign region");
+
+    // Ours is planted by hand rather than orphaned by a killed child: what is
+    // under test is which files get written, not topic semantics, and a region
+    // nothing has mapped cannot take SIGBUS if this ever regresses again.
+    let topics_dir = horus_sys::shm::shm_topics_dir();
+    horus_sys::shm::create_shm_dir_all(&topics_dir).expect("create our topics dir");
+    let ours = topics_dir.join(&name);
+    std::fs::write(&ours, &intact).expect("plant our region");
+
+    for path in orphan_topic_files(&name) {
+        corrupt_magic_bytes(&path);
+    }
+
+    // Compared with `assert!` rather than `assert_eq!`: these are 64 KiB
+    // vectors, and the pair `assert_eq!` prints on failure buries the message.
+    let foreign_after = std::fs::read(&foreign).expect("read foreign region");
+    assert!(
+        foreign_after == intact,
+        "corruption escaped this namespace into {} — now {} bytes, head {:02x?}. \
+         A robot's live regions and every other test run's sit in directories \
+         exactly like it.",
+        foreign.display(),
+        foreign_after.len(),
+        &foreign_after[..8.min(foreign_after.len())]
+    );
+    let ours_after = std::fs::read(&ours).expect("read our region");
+    assert!(
+        ours_after != intact,
+        "our own region at {} was not corrupted — the scoping is too tight and \
+         the corruption tests are asserting nothing",
+        ours.display()
+    );
+
+    let _ = std::fs::remove_file(&ours);
 }
 
 // ============================================================================

--- a/horus_core/tests/production_fanout_battle.rs
+++ b/horus_core/tests/production_fanout_battle.rs
@@ -1816,7 +1816,14 @@ fn orphan_topic_files(topic: &str) -> Vec<std::path::PathBuf> {
         .flatten()
         .map(|e| e.path())
         .filter(|p| {
-            p.is_file()
+            // `symlink_metadata`, not `Path::is_file()`: the latter follows
+            // symlinks, so a link sitting where a region file should be is a
+            // way straight back out of this namespace — the escape route the
+            // whole helper exists to close. `horus_sys::shm` already refuses
+            // a symlinked SHM directory for the same reason
+            // (verify_shm_dir_ownership, horus_sys/src/shm/mod.rs), and
+            // /dev/shm is mode 1777.
+            std::fs::symlink_metadata(p).is_ok_and(|m| m.file_type().is_file())
                 && p.file_name()
                     .and_then(|n| n.to_str())
                     .is_some_and(|n| n == topic || n.starts_with(&suffixed))
@@ -1824,15 +1831,42 @@ fn orphan_topic_files(topic: &str) -> Vec<std::path::PathBuf> {
         .collect()
 }
 
+/// Open an SHM backing file for writing without following a symlink.
+///
+/// `orphan_topic_files` screens links out of the *selection*; `O_NOFOLLOW`
+/// closes the window between that check and this open, so neither half of a
+/// swap race can redirect a write out of `shm_topics_dir()`.
+fn open_region_for_write(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    opts.open(path)
+}
+
 /// Overwrite the first 8 bytes of an SHM region — where the magic lives — with
 /// garbage, leaving the length of the file and every other byte alone.
+///
+/// Returns `false` without touching the file if it is shorter than the pattern:
+/// `write_all` would then *grow* it, and "leaves the length alone" is the one
+/// property this helper owes its callers. A real region is far larger than 8
+/// bytes, so a short file here means the selection matched something that is
+/// not a region, which is not something to silently rewrite.
 fn corrupt_magic_bytes(path: &std::path::Path) -> bool {
-    let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(path) else {
+    const GARBAGE: [u8; 8] = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+    let Ok(mut f) = open_region_for_write(path) else {
         return false;
     };
+    // Measured through the open handle rather than the path, so the length the
+    // check saw is the length of the file being written.
+    if f.metadata().map(|m| m.len()).unwrap_or(0) < GARBAGE.len() as u64 {
+        return false;
+    }
     use std::io::Write;
-    f.write_all(&[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE])
-        .is_ok()
+    f.write_all(&GARBAGE).is_ok()
 }
 
 /// SHM corruption detection: corrupted magic bytes must not cause SIGSEGV.
@@ -1960,19 +1994,37 @@ fn fault_shm_recovery_after_corruption() {
 
     // Zero the head of the orphans this test's own child left (see
     // `orphan_topic_files` — never another namespace's files).
+    use std::io::Write;
+    let mut zeroed = 0usize;
     for path in orphan_topic_files(&name) {
-        if let Ok(metadata) = std::fs::metadata(&path) {
-            let zeros = vec![0u8; metadata.len().min(8192) as usize];
-            // Deliberately not `fs::write`: that opens O_TRUNC, so it does not
-            // zero the first 8 KiB of the region, it cuts the region down to
-            // them — and a still-mapped region then takes SIGBUS past the new
-            // end of file, which is not the corruption this test recovers from.
-            if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(&path) {
-                use std::io::Write;
-                let _ = f.write_all(&zeros);
-            }
-        }
+        // Deliberately not `fs::write`: that opens O_TRUNC, so it does not
+        // zero the first 8 KiB of the region, it cuts the region down to
+        // them — and a still-mapped region then takes SIGBUS past the new
+        // end of file, which is not the corruption this test recovers from.
+        //
+        // Every failure below is fatal rather than ignored: these are this
+        // test's own files, in its own namespace, under the `cleanup_stale_shm`
+        // guard held for the whole body, so failing to open or write one is a
+        // real fault. Swallowing it left the test asserting nothing but that
+        // `Topic::new` works, under a name that promises recovery-from-
+        // corruption.
+        let mut f = open_region_for_write(&path)
+            .unwrap_or_else(|e| panic!("open orphan {} to corrupt it: {e}", path.display()));
+        let len = f
+            .metadata()
+            .unwrap_or_else(|e| panic!("stat orphan {}: {e}", path.display()))
+            .len();
+        let zeros = vec![0u8; len.min(8192) as usize];
+        f.write_all(&zeros)
+            .unwrap_or_else(|e| panic!("zero orphan {}: {e}", path.display()));
+        zeroed += 1;
     }
+    // Deliberately not `assert!(zeroed > 0)`: whether the SIGKILLed child got
+    // far enough to leave a backing file is timing-dependent, and the sibling
+    // `fault_shm_magic_corruption_rejected` tolerates zero for the same reason.
+    // The count is printed so a run that corrupted nothing says so instead of
+    // looking identical to one that did.
+    eprintln!("Zeroed the head of {zeroed} orphan SHM files");
 
     // Clean up corrupted files
     let _shm_guard = cleanup_stale_shm();
@@ -1997,6 +2049,12 @@ fn fault_shm_recovery_after_corruption() {
 /// concurrent `cargo test` on the box owns a `/dev/shm/horus_test_<hash>`.
 /// Both live in sibling directories of ours and are indistinguishable from it
 /// to a walk that starts at the SHM root.
+///
+/// A symlink planted in our own topics dir is the second way out, and one a
+/// name-and-directory filter alone does not close: `Path::is_file()` follows
+/// it. Measured against these fixtures with the pre-`symlink_metadata`
+/// selection, the foreign region came back with head
+/// `de ad be ef ca fe ba be`.
 #[test]
 fn shm_corruption_stays_inside_this_namespace() {
     if !horus_sys::shm::regions_are_file_backed() {
@@ -2036,6 +2094,16 @@ fn shm_corruption_stays_inside_this_namespace() {
     let ours = topics_dir.join(&name);
     std::fs::write(&ours, &intact).expect("plant our region");
 
+    // A symlink inside our own topics dir, named so the prefix filter matches
+    // it, pointing at the foreign region. `Path::is_file()` follows it and the
+    // corruption lands in the other namespace; `symlink_metadata` does not.
+    // /dev/shm is mode 1777, which is why horus_sys screens SHM directories
+    // for exactly this.
+    #[cfg(unix)]
+    let link = topics_dir.join(format!("{name}_link"));
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&foreign, &link).expect("plant symlink decoy");
+
     for path in orphan_topic_files(&name) {
         corrupt_magic_bytes(&path);
     }
@@ -2061,6 +2129,8 @@ fn shm_corruption_stays_inside_this_namespace() {
     );
 
     let _ = std::fs::remove_file(&ours);
+    #[cfg(unix)]
+    let _ = std::fs::remove_file(&link);
 }
 
 // ============================================================================


### PR DESCRIPTION
`fault_shm_magic_corruption_rejected` and `fault_shm_recovery_after_corruption`
enumerated the literal `/dev/shm`, matched every directory named `horus_*`, and
wrote into every regular file under `<dir>/topics/`. That is not their own
namespace: it is `/dev/shm/horus_default`, where an installed `horus` or a
`cargo run` binary keeps a live robot's regions, plus every concurrent test
run's `horus_test_<hash>` — the isolation `horus_sys::shm::cargo_test_namespace`
exists to provide and that the suite's own `cleanup_stale_shm` already honours.
Neither test is `#[ignore]`d, so a plain
`cargo test -p horus_core --test production_fanout_battle` did it, and both
reported "ok" afterwards.

The recovery test's `std::fs::write` is O_TRUNC, so it did not zero the first
8 KiB of a foreign region, it truncated the region to them: measured in an
isolated tmpfs, a planted 65536-byte region in `horus_default` came back 8192
bytes. A process still holding that region mapped takes SIGBUS past the new end
of file.

Both walks now go through `orphan_topic_files`, which reads
`horus_sys::shm::shm_topics_dir()` — this binary's own `test_<hash>` namespace,
which the killed child shares through the `HORUS_NAMESPACE` publish in
`shm_namespace()` — and returns only the files of the topic the test itself
generated. The recovery test also zeroes in place instead of truncating, which
is what its comment always claimed. `shm_corruption_stays_inside_this_namespace`
plants a region in a sibling `horus_*` namespace and fails if the corruption
reaches it.

## Ablation

```
Reverted ONLY the production change: replaced the body of `orphan_topic_files` with
the pre-fix selection (walk the literal `/dev/shm`, take every regular file under
`horus_*/topics/`), keeping the new test and both call sites. Rebuilt and ran the
new test inside an isolated tmpfs (`bwrap --dev-bind / / --tmpfs /dev/shm --proc
/proc`) so the ablation could not damage the real machine. EXACT output:

running 1 test

thread 'shm_corruption_stays_inside_this_namespace' (1521491) panicked at horus_core/tests/production_fanout_battle.rs:2053:5:
corruption escaped this namespace into /dev/shm/horus_decoy_ns_1521473_1/topics/scope_1521473_0 — now 65536 bytes, head [de, ad, be, ef, ca, fe, ba, be]. A robot's live regions and every other test run's sit in directories exactly like it.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test shm_corruption_stays_inside_this_namespace ... FAILED

failures:

failures:
    shm_corruption_stays_inside_this_namespace

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.01s

Production change then restored from a saved copy (verified: 0 occurrences of the
ABLATION marker remain), rebuilt, and the same test re-run: `test result: ok.
1 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.01s`.
```

## Tests

```
Independent reproduction of the defect BEFORE the fix (pre-fix binary, isolated
tmpfs via bwrap, two decoy regions of 65536 bytes planted at
/dev/shm/horus_default/topics/victim and
/dev/shm/horus_test_ffffffffffffffff/topics/victim):
  - fault_shm_magic_corruption_rejected ... ok  (1 passed)
  - fault_shm_recovery_after_corruption ... ok  (1 passed)
  - both decoys AFTER: 8192 bytes, head `0000 0000 0000 0000` (were 65536 bytes of 0xAA).
    Both foreign namespaces truncated and zeroed while both tests reported "ok".

Same script with the FIXED binary and all three tests: 3/3 ok, both decoys still
65536 bytes with head `aaaa aaaa aaaa aaaa` — untouched.

Touched test binary, full runs on the real machine (safe now that the walk is scoped):
  cargo test --no-default-features -p horus_core --test production_fanout_battle -- --test-threads=1
    -> test result: ok. 19 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 99.38s
  cargo test --no-default-features -p horus_core --test production_fanout_battle   (default parallelism)
    -> test result: ok. 19 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 101.31s
  (19 = 18 pre-existing + the new shm_corruption_stays_inside_this_namespace.)

Non-vacuity of the repaired fault test on the real machine:
  Corrupted: /dev/shm/horus_test_b57d984cc89ed696/topics/corrupt_magic_1507033_0
  Corrupted 1 SHM files
  Corrupted topic: Topic::new returned Err (rejected corruption)
  — it still finds and cor
```

## Notes from the implementer

Finding confirmed, not taken on trust: I read both walks
(horus_core/tests/production_fanout_battle.rs, pre-fix lines 1832-1856 and
1929-1948), confirmed they are plain `#[test]` with no `#[ignore]`, and then
reproduced the damage end-to-end with the pre-built pre-fix binary inside an
isolated tmpfs. Two planted foreign regions went 65536 -> 8192 bytes and zeroed
while both tests printed "ok". The severity is not hypothetical on this box: as I
worked, /dev/shm held horus_default (131 MB) plus five foreign horus_test_<hash>
namespaces (two of 837 MB) belonging to other sessions actively running
horus_core tests. I never ran the unfixed tests outside the sandbox.

Why the scoping is safe for what the tests assert: the killed child inherits the
parent's namespace through the `HORUS_NAMESPACE` publish in
`horus_sys::shm::shm_namespace()` (horus_sys/src/shm/mod.rs:230), so the orphan
files land in `shm_topics_dir()`. Verified empirically — the repaired magic test
still reports "Corrupted 1 SHM files" and still drives `Topic::new` into the
reject path. The prefix match (`<name>` plus `<name>_*`) exists because a
FanoutShm handle allocates a second region, `<name>_fanout`
(horus_core/src/communication/topic/mod.rs:2036); `unique()` names are
`<prefix>_<pid>_<counter>`, so the prefix cannot collide with another test's
topic. Directories such as `topics/.service_gateway` are skipped by `is_file()`.

I also changed the recovery test's `std::fs::write` to an in-place write. That is
one line beyond the strict scoping fix, and I judged it in scope because the
O_TRUNC behaviour is half of what made the original bug destructive (truncation,
not zeroing) and it contradicted the test's own comment. Say the word if you want
it split out.

What I could NOT verify:
- Only Linux. The new test guards on `regions_are_file_backed()` and derives the
  SHM root from `shm_base_dir().parent()`, so it should be correct on macOS
  (/tmp) and skip on Windows, but I have no macOS or Windows machin

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
