### PR TITLE
fix(topic): fence the colo fast path's seqlock write phase

### DIFF
--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2769,7 +2769,28 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
                         // published just below — that asymmetry is why this
                         // path could previously skip stamping entirely.
                         let seq = head.wrapping_add(1);
-                        (*stamp).store(seq | layout::SLOT_WRITING, Ordering::Release);
+                        // Boehm seqlock write phase, and the fence is the whole
+                        // protocol — not decoration. A Release *store* on the
+                        // marker orders only the accesses BEFORE it; it says
+                        // nothing about the payload store that follows, so the
+                        // payload may become visible while the stamp still reads
+                        // the previous lap's value. `recv_shm_pod_broadcast`
+                        // (dispatch.rs) accepts on `v1 == tail + 1` and re-checks
+                        // the same stamp after copying, so it would see two
+                        // matching stale stamps around new bytes and return a
+                        // mixture of two messages. aarch64 -O makes the gap
+                        // visible: the marker compiles to `stlr` and the payload
+                        // to a plain `str`, with nothing between them; with the
+                        // fence it is `str` + `dmb ish` + `str`. Free on x86,
+                        // where the fence emits no instruction at all.
+                        //
+                        // This is the same pairing as dispatch.rs's
+                        // `send_shm_pod_broadcast`, `seqlock::seqlock_publish`
+                        // and `communication/mod.rs`'s raw publisher; the naive
+                        // all-Release form is the one tests/loom_fanout.rs and
+                        // tests/loom_pod_broadcast.rs show failing under loom.
+                        (*stamp).store(seq | layout::SLOT_WRITING, Ordering::Relaxed);
+                        std::sync::atomic::fence(Ordering::Release);
                         std::ptr::write(data, msg);
                         (*stamp).store(seq, Ordering::Release);
                     } else {

--- a/horus_core/tests/loom_pod_broadcast.rs
+++ b/horus_core/tests/loom_pod_broadcast.rs
@@ -29,6 +29,11 @@
 //! loom; it is kept (ignored) so the model is demonstrably able to catch the bug
 //! it was written for, rather than passing vacuously.
 //!
+//! A second ignored arm covers the near-miss form — marker stamped first, but
+//! with a Release *store* instead of the fence — which is what `Topic::send`'s
+//! colo fast path shipped. It tears too, and it is the one that looks correct at
+//! a glance. `tests/seqlock_write_phase.rs` keeps the real code off both forms.
+//!
 //! Run with: `cargo test --test loom_pod_broadcast -- --nocapture`
 
 use loom::sync::atomic::{fence, AtomicU64, Ordering};
@@ -78,6 +83,24 @@ impl<const CAP: usize> BroadcastRing<CAP> {
 
         self.ready[idx].store(stamp | SLOT_WRITING, Ordering::Relaxed);
         fence(Ordering::Release);
+        self.data[idx].store(value_for(seq), Ordering::Relaxed);
+        self.ready[idx].store(stamp, Ordering::Release);
+    }
+
+    /// Producer, colo fast path as `Topic::send` wrote it before the fix: the
+    /// marker IS stamped first, but with a Release *store* and no fence.
+    ///
+    /// This is the subtler of the two broken forms, and the reason it needs its
+    /// own arm: it looks like the fixed protocol. A Release store orders the
+    /// accesses BEFORE it, so it does nothing to keep the payload store below
+    /// from being observed ahead of the marker — the consumer can see the new
+    /// bytes under two matching stale stamps and accept the mixture.
+    fn publish_colo_release_marker(&self) {
+        let seq = self.head.fetch_add(1, Ordering::Relaxed);
+        let idx = (seq & Self::MASK) as usize;
+        let stamp = seq.wrapping_add(1);
+
+        self.ready[idx].store(stamp | SLOT_WRITING, Ordering::Release);
         self.data[idx].store(value_for(seq), Ordering::Relaxed);
         self.ready[idx].store(stamp, Ordering::Release);
     }
@@ -256,6 +279,60 @@ fn naive_protocol_tears_proving_the_model_can_detect_it() {
                 val,
                 value_for(pos),
                 "torn read under the OLD protocol (expected — this is the bug)"
+            );
+        }
+    });
+}
+
+/// The colo fast path's write phase, against the REAL consumer.
+///
+/// `Topic::send`'s role=Both POD fast path publishes into this same ring
+/// (`mod.rs`, the `cached_colo_stride != 0` branch), and sibling handles on the
+/// topic drain it through `recv_shm_pod_broadcast` — modelled here by `consume`,
+/// unchanged. That path stamped the marker with `store(Release)` and no fence,
+/// which is what this arm runs. It is expected to FAIL, and is `#[ignore]`d for
+/// the same reason as the arm above: a model that cannot fail proves nothing,
+/// and this failure is what makes the fence in `Topic::send` load-bearing rather
+/// than ornamental.
+///
+///   cargo test --test loom_pod_broadcast -- --ignored colo
+#[test]
+#[ignore = "demonstrates the pre-fix colo write phase failing; run by hand to validate the model"]
+fn colo_release_marker_tears_proving_the_fence_is_load_bearing() {
+    loom::model(|| {
+        let ring = Arc::new(BroadcastRing::<2>::new());
+
+        let producer = {
+            let ring = ring.clone();
+            loom::thread::spawn(move || {
+                for _ in 0..3 {
+                    ring.publish_colo_release_marker();
+                }
+            })
+        };
+
+        let consumer = {
+            let ring = ring.clone();
+            loom::thread::spawn(move || {
+                let mut accepted = Vec::new();
+                for _ in 0..2 {
+                    if let Some(r) = ring.consume() {
+                        accepted.push(r);
+                    }
+                }
+                accepted
+            })
+        };
+
+        producer.join().unwrap();
+        let accepted = consumer.join().unwrap();
+
+        for (val, pos) in accepted {
+            assert_eq!(
+                val,
+                value_for(pos),
+                "torn read: the Release-store marker does not order the payload \
+                 write that follows it (expected — this is the bug)"
             );
         }
     });

--- a/horus_core/tests/seqlock_write_phase.rs
+++ b/horus_core/tests/seqlock_write_phase.rs
@@ -24,6 +24,17 @@
 //! form they already condemn — `Topic::send`'s colo fast path did exactly that,
 //! stamping with `store(Release)` while the three other write phases in the
 //! crate were fenced. This test is the thing that notices.
+//!
+//! What counts as "followed by a Release fence" is deliberately narrow on one
+//! axis and wide on another: the call must be `sync::atomic::fence` and not
+//! `compiler_fence` (which constrains the optimiser and emits no instruction —
+//! it would leave the aarch64 reordering this file exists to prevent), and the
+//! ordering may be `Release` or anything stronger (`AcqRel`, `SeqCst`).
+//!
+//! A guard that silently stops checking is worse than no guard, so every
+//! mention of the constant in `src` must fall into a shape this file
+//! recognises. An unrecognised one — a publication that grew a line wrap, say —
+//! fails the test instead of dropping out of the scan.
 
 use std::path::{Path, PathBuf};
 
@@ -52,6 +63,66 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
 /// is ever wired onto that stamp, delete this entry and fence the site — do not
 /// widen the exemption.
 const EXEMPT_FNS: &[&str] = &["send_shm_sp_pod"];
+
+/// The line with `//` comments dropped and string/char literals blanked, so the
+/// scanning below sees punctuation that is code and nothing else.
+///
+/// Without this, a trailing comment or a literal that happens to contain `;`,
+/// a bracket, or the word `fence` steers the delimiter counting and the fence
+/// match. Both directions of that are bad: a spurious CI failure, or a real
+/// unfenced site skipped.
+fn code_only(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '/' && chars.get(i + 1) == Some(&'/') {
+            break;
+        }
+        if c == '"' {
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '"' {
+                    break;
+                }
+                i += 1;
+            }
+            i += 1;
+            out.push('_');
+            continue;
+        }
+        // `'` is a char literal only in `'x'` / `'\n'` shape; otherwise it opens
+        // a lifetime and must be left alone.
+        if c == '\'' {
+            let escaped = chars.get(i + 1) == Some(&'\\');
+            let simple = chars.get(i + 2) == Some(&'\'');
+            if escaped || simple {
+                i += 1;
+                while i < chars.len() {
+                    if chars[i] == '\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if chars[i] == '\'' {
+                        break;
+                    }
+                    i += 1;
+                }
+                i += 1;
+                out.push('_');
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
 
 /// Name of the `fn` a line sits inside, searching upward. Returns `None` rather
 /// than guessing, which makes an unrecognised site fail the test instead of
@@ -87,16 +158,92 @@ fn enclosing_fn(lines: &[&str], line_idx: usize) -> Option<String> {
     None
 }
 
-/// A line that publishes the marker: it names `SLOT_WRITING` and stores it,
-/// either through an atomic directly or through a `publish` helper. Reads of the
-/// bit (`v1 & SLOT_WRITING`, `raw & !SLOT_WRITING`) and the `use`/`const` lines
-/// match neither.
-fn publishes_marker(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    if trimmed.starts_with("//") || !trimmed.contains("SLOT_WRITING") {
-        return false;
+/// Index of the line holding the `;` that ends the statement starting at
+/// `start`.
+///
+/// The terminator is the first `;` at delimiter depth zero *relative to the
+/// start of the statement*, not simply the first `;` at or after `start`. A
+/// wrapped store whose arguments carry a block or a macro with its own `;`
+/// — `store({ let v = f(); v }, Ordering::Release)` — would otherwise be cut
+/// short, and the fence check would then run against a line from the middle of
+/// the store and report a violation that is not there.
+fn statement_end(lines: &[&str], start: usize) -> Option<usize> {
+    let mut depth: i32 = 0;
+    for (offset, line) in lines[start..].iter().enumerate() {
+        for c in code_only(line).chars() {
+            match c {
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => depth -= 1,
+                ';' if depth <= 0 => return Some(start + offset),
+                _ => {}
+            }
+        }
     }
-    trimmed.contains(".store(") || trimmed.contains("publish(")
+    None
+}
+
+/// Whether `code` calls `sync::atomic::fence` with Release or stronger.
+///
+/// Not a substring test for `fence(Ordering::Release)`: that also matches
+/// `compiler_fence(Ordering::Release)`, which is an optimisation barrier that
+/// emits no instruction and leaves aarch64 free to sink the payload store
+/// past the marker — the guard would pass on exactly the bug it is here to
+/// catch. `compiler_fence` is already used in this crate
+/// (`src/memory/backend.rs`), so that is drift the codebase can actually
+/// perform, not a hypothetical. Qualified paths (`std::sync::atomic::fence`,
+/// `core::sync::atomic::fence`, `atomic::fence`) are all accepted, as are
+/// orderings stronger than Release.
+fn is_release_fence(code: &str) -> bool {
+    const NEEDLE: &str = "fence(";
+    const ORDERINGS: &[&str] = &["Release", "AcqRel", "SeqCst"];
+    let mut from = 0usize;
+    while let Some(rel) = code[from..].find(NEEDLE) {
+        let at = from + rel;
+        // `compiler_fence` and any other `*_fence`: the byte before the needle
+        // continues an identifier. `::fence(` and ` fence(` do not.
+        let joined_to_ident = code[..at]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if !joined_to_ident {
+            let args = &code[at + NEEDLE.len()..];
+            let args = args.split(')').next().unwrap_or(args);
+            if ORDERINGS.iter().any(|o| args.contains(o)) {
+                return true;
+            }
+        }
+        from = at + NEEDLE.len();
+    }
+    false
+}
+
+/// A statement that publishes the marker: it names `SLOT_WRITING` and stores
+/// it, either through an atomic directly or through a `publish` helper.
+fn publishes_marker(code: &str) -> bool {
+    code.contains("SLOT_WRITING") && (code.contains(".store(") || code.contains("publish("))
+}
+
+/// A mention that only *reads* the bit — `v1 & SLOT_WRITING`,
+/// `raw & !layout::SLOT_WRITING`. Nothing is published, so there is nothing to
+/// order.
+fn reads_marker(code: &str) -> bool {
+    let Some(at) = code.find("SLOT_WRITING") else {
+        return false;
+    };
+    let before = code[..at].trim_end_matches(|c: char| c.is_alphanumeric() || c == '_' || c == ':');
+    let before = before.trim_end().trim_end_matches('!').trim_end();
+    before.ends_with('&')
+}
+
+/// Blank lines, `//` comments and the body of a `/* */` block — none of them is
+/// the statement that follows the marker.
+fn is_code_line(line: &str) -> bool {
+    let t = line.trim();
+    !t.is_empty()
+        && !t.starts_with("//")
+        && !t.starts_with("/*")
+        && !t.starts_with('*')
+        && !t.starts_with("*/")
 }
 
 #[test]
@@ -118,10 +265,36 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
             .to_string();
 
         for (i, line) in lines.iter().enumerate() {
-            if !publishes_marker(line) {
+            let code = code_only(line);
+            if !code.contains("SLOT_WRITING") {
                 continue;
             }
             let site = format!("{rel}:{}", i + 1);
+            let trimmed = code.trim();
+
+            if !publishes_marker(&code) {
+                // Every other shape the crate uses is inert: the constant's own
+                // definition, a `use` of it, and reads of the bit. Anything
+                // else is a shape this guard was not written for — most
+                // importantly a publication that grew a line wrap, which would
+                // otherwise just stop being scanned. Fail rather than skip.
+                let inert = trimmed.starts_with("use ")
+                    || trimmed.starts_with("const ")
+                    || trimmed.starts_with("pub const ")
+                    || trimmed.starts_with("pub(crate) const ")
+                    || reads_marker(&code);
+                if !inert {
+                    violations.push(format!(
+                        "{site}: `SLOT_WRITING` appears in a shape this guard does \
+                         not recognise ({trimmed}). If a publication was wrapped \
+                         across lines it is no longer being checked — teach \
+                         `publishes_marker` the new shape rather than leaving the \
+                         guard blind."
+                    ));
+                }
+                continue;
+            }
+
             match enclosing_fn(&lines, i) {
                 Some(name) if EXEMPT_FNS.contains(&name.as_str()) => continue,
                 Some(_) => {}
@@ -135,25 +308,41 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
             }
 
             // The statement may wrap; find the line that ends it, then the next
-            // line that is actually code.
-            let Some(end) = (i..lines.len()).find(|&j| lines[j].contains(';')) else {
+            // line that is actually code, and take that whole statement — the
+            // fence may wrap too.
+            let Some(end) = statement_end(&lines, i) else {
                 violations.push(format!("{site}: marker store has no statement end"));
                 continue;
             };
-            let next = lines[end + 1..].iter().find(|l| {
-                let t = l.trim();
-                !t.is_empty() && !t.starts_with("//")
-            });
+            let next = lines[end + 1..]
+                .iter()
+                .copied()
+                .position(is_code_line)
+                .map(|off| end + 1 + off);
 
             checked += 1;
-            match next {
-                Some(l) if l.contains("fence(Ordering::Release)") => {}
-                other => violations.push(format!(
+            let Some(next) = next else {
+                violations.push(format!(
+                    "{site}: the WRITING marker is the last statement in the file \
+                     — nothing fences the payload write that would follow it."
+                ));
+                continue;
+            };
+            let next_end = statement_end(&lines, next).unwrap_or(next);
+            let next_stmt: String = lines[next..=next_end]
+                .iter()
+                .map(|l| code_only(l))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            if !is_release_fence(&next_stmt) {
+                violations.push(format!(
                     "{site}: the WRITING marker is not followed by a Release fence \
-                     (next code line: {}). A Release store on the marker does not \
-                     order the payload write below it; see this file's header.",
-                    other.map(|l| l.trim()).unwrap_or("<end of file>")
-                )),
+                     (next statement: {}). A Release store on the marker does not \
+                     order the payload write below it, and `compiler_fence` does \
+                     not either; see this file's header.",
+                    next_stmt.trim()
+                ));
             }
         }
     }

--- a/horus_core/tests/seqlock_write_phase.rs
+++ b/horus_core/tests/seqlock_write_phase.rs
@@ -1,0 +1,174 @@
+//! Every `SLOT_WRITING` marker in `horus_core` must be followed by a Release
+//! fence before the payload it guards is written.
+//!
+//! The marker is the write side of a Boehm seqlock: the consumer
+//! (`recv_shm_pod_broadcast`) loads the stamp, copies the slot, executes an
+//! Acquire fence and requires the stamp to be unchanged. That protocol rejects a
+//! lapping producer only if the producer's payload store cannot be observed
+//! ahead of the marker — which is what the Release fence buys, and what a
+//! Release *store* on the marker does NOT. A release store orders the accesses
+//! before itself and says nothing about the store that follows, so the consumer
+//! can see new bytes under two matching stale stamps and accept a value that is
+//! half of one message and half of another.
+//!
+//! That is not a theoretical distinction on the targets this ships to. aarch64
+//! `-O` compiles the marker to `stlr` and the payload to a plain `str` with
+//! nothing in between; with the fence it is `str` + `dmb ish` + `str`. On x86
+//! the fence costs nothing (it is a no-op for StoreStore), so there is no
+//! platform on which the naive form is worth keeping.
+//!
+//! `tests/loom_pod_broadcast.rs` proves the two broken forms tear
+//! (`naive_protocol_tears_proving_the_model_can_detect_it` and
+//! `colo_release_marker_tears_proving_the_fence_is_load_bearing`). Those models
+//! are transcriptions, so nothing stops the real code from drifting back to a
+//! form they already condemn — `Topic::send`'s colo fast path did exactly that,
+//! stamping with `store(Release)` while the three other write phases in the
+//! crate were fenced. This test is the thing that notices.
+
+use std::path::{Path, PathBuf};
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read src dir").flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Write phases whose stamp is not read by anybody, checked one at a time.
+///
+/// `send_shm_sp_pod` serves SpmcShm only (`mod.rs`'s send-dispatch table), and
+/// its consumer `recv_shm_spmc_pod` never loads the per-slot stamp at all — it
+/// gates on head/tail and a CAS on `header.tail`. Its marker is therefore inert
+/// and cannot tear, whatever ordering it uses; the "Boehm seqlock write side"
+/// comment above it describes `send_shm_pod_broadcast`, not itself. If a reader
+/// is ever wired onto that stamp, delete this entry and fence the site — do not
+/// widen the exemption.
+const EXEMPT_FNS: &[&str] = &["send_shm_sp_pod"];
+
+/// Name of the `fn` a line sits inside, searching upward. Returns `None` rather
+/// than guessing, which makes an unrecognised site fail the test instead of
+/// silently matching an exemption.
+fn enclosing_fn(lines: &[&str], line_idx: usize) -> Option<String> {
+    for line in lines[..=line_idx].iter().rev() {
+        let mut rest = line.trim_start();
+        // Skip the modifiers a definition can carry before `fn`.
+        loop {
+            let next = rest
+                .strip_prefix("pub(crate) ")
+                .or_else(|| rest.strip_prefix("pub(super) "))
+                .or_else(|| rest.strip_prefix("pub "))
+                .or_else(|| rest.strip_prefix("const "))
+                .or_else(|| rest.strip_prefix("async "))
+                .or_else(|| rest.strip_prefix("unsafe "))
+                .or_else(|| rest.strip_prefix("extern \"C\" "));
+            match next {
+                Some(r) => rest = r,
+                None => break,
+            }
+        }
+        if let Some(after) = rest.strip_prefix("fn ") {
+            let name: String = after
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                return Some(name);
+            }
+        }
+    }
+    None
+}
+
+/// A line that publishes the marker: it names `SLOT_WRITING` and stores it,
+/// either through an atomic directly or through a `publish` helper. Reads of the
+/// bit (`v1 & SLOT_WRITING`, `raw & !SLOT_WRITING`) and the `use`/`const` lines
+/// match neither.
+fn publishes_marker(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") || !trimmed.contains("SLOT_WRITING") {
+        return false;
+    }
+    trimmed.contains(".store(") || trimmed.contains("publish(")
+}
+
+#[test]
+fn every_writing_marker_is_followed_by_a_release_fence() {
+    let mut files = Vec::new();
+    rust_sources(&crate_root().join("src"), &mut files);
+    files.sort();
+
+    let mut checked = 0usize;
+    let mut violations = Vec::new();
+
+    for file in &files {
+        let src = std::fs::read_to_string(file).expect("read source");
+        let lines: Vec<&str> = src.lines().collect();
+        let rel = file
+            .strip_prefix(crate_root())
+            .unwrap_or(file)
+            .display()
+            .to_string();
+
+        for (i, line) in lines.iter().enumerate() {
+            if !publishes_marker(line) {
+                continue;
+            }
+            let site = format!("{rel}:{}", i + 1);
+            match enclosing_fn(&lines, i) {
+                Some(name) if EXEMPT_FNS.contains(&name.as_str()) => continue,
+                Some(_) => {}
+                None => {
+                    violations.push(format!(
+                        "{site}: marker published outside any fn — this test cannot \
+                         tell whether it is a seqlock write phase"
+                    ));
+                    continue;
+                }
+            }
+
+            // The statement may wrap; find the line that ends it, then the next
+            // line that is actually code.
+            let Some(end) = (i..lines.len()).find(|&j| lines[j].contains(';')) else {
+                violations.push(format!("{site}: marker store has no statement end"));
+                continue;
+            };
+            let next = lines[end + 1..].iter().find(|l| {
+                let t = l.trim();
+                !t.is_empty() && !t.starts_with("//")
+            });
+
+            checked += 1;
+            match next {
+                Some(l) if l.contains("fence(Ordering::Release)") => {}
+                other => violations.push(format!(
+                    "{site}: the WRITING marker is not followed by a Release fence \
+                     (next code line: {}). A Release store on the marker does not \
+                     order the payload write below it; see this file's header.",
+                    other.map(|l| l.trim()).unwrap_or("<end of file>")
+                )),
+            }
+        }
+    }
+
+    // A rename of the constant, or a refactor that moves every write phase out
+    // of `src`, would otherwise leave this test passing while checking nothing.
+    assert!(
+        checked >= 3,
+        "expected at least 3 SLOT_WRITING write phases in horus_core/src, found \
+         {checked} — the marker was probably renamed and this guard is now blind"
+    );
+
+    assert!(
+        violations.is_empty(),
+        "unfenced seqlock write phase(s):\n  {}",
+        violations.join("\n  ")
+    );
+}

--- a/horus_core/tests/seqlock_write_phase.rs
+++ b/horus_core/tests/seqlock_write_phase.rs
@@ -62,64 +62,178 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
 /// comment above it describes `send_shm_pod_broadcast`, not itself. If a reader
 /// is ever wired onto that stamp, delete this entry and fence the site — do not
 /// widen the exemption.
-const EXEMPT_FNS: &[&str] = &["send_shm_sp_pod"];
-
-/// The line with `//` comments dropped and string/char literals blanked, so the
-/// scanning below sees punctuation that is code and nothing else.
 ///
-/// Without this, a trailing comment or a literal that happens to contain `;`,
-/// a bracket, or the word `fence` steers the delimiter counting and the fence
-/// match. Both directions of that are bad: a spurious CI failure, or a real
-/// unfenced site skipped.
-fn code_only(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
-    let mut out = String::with_capacity(line.len());
-    let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-        if c == '/' && chars.get(i + 1) == Some(&'/') {
-            break;
-        }
-        if c == '"' {
-            i += 1;
-            while i < chars.len() {
-                if chars[i] == '\\' {
-                    i += 2;
-                    continue;
+/// Keyed on the file as well as the function name. An exemption is the one hole
+/// in this guard, and an unqualified name would silently cover a second
+/// `send_shm_sp_pod` defined in some other module. Moving the function is
+/// expected to fail this test until the path below is updated: that is the
+/// fail-closed direction to err in.
+const EXEMPT_SITES: &[(&str, &str)] = &[("src/communication/topic/dispatch.rs", "send_shm_sp_pod")];
+
+/// Lexer state, carried across line boundaries by `sanitize`.
+#[derive(Clone, Copy)]
+enum Scan {
+    Code,
+    /// Inside `/* */`, which Rust allows to nest.
+    Block(u32),
+    /// Inside `"..."`.
+    Str,
+    /// Inside a raw string, holding its hash count: `r##"` closes on `"##`.
+    Raw(usize),
+}
+
+/// If a raw string opens at `i`, how many chars its opener spans and how many
+/// hashes it carries.
+///
+/// `r"`, `r#"` and `br##"` open one; the `r` of `for`, and the raw identifier
+/// `r#type`, do not.
+fn raw_string_open(chars: &[char], i: usize) -> Option<(usize, usize)> {
+    // Nothing may run into the `b`/`r`, or it is the tail of an identifier.
+    if i.checked_sub(1)
+        .and_then(|p| chars.get(p))
+        .is_some_and(|c| c.is_alphanumeric() || *c == '_')
+    {
+        return None;
+    }
+    let mut j = i;
+    if chars.get(j) == Some(&'b') {
+        j += 1;
+    }
+    if chars.get(j) != Some(&'r') {
+        return None;
+    }
+    j += 1;
+    let hashes = chars[j.min(chars.len())..]
+        .iter()
+        .take_while(|c| **c == '#')
+        .count();
+    if chars.get(j + hashes) == Some(&'"') {
+        Some((j + hashes + 1 - i, hashes))
+    } else {
+        None
+    }
+}
+
+/// Whether the `hashes` chars at `from` are all `#`, closing a raw string.
+fn closes_raw(chars: &[char], from: usize, hashes: usize) -> bool {
+    (0..hashes).all(|k| chars.get(from + k) == Some(&'#'))
+}
+
+/// The file's lines with comments dropped and literals blanked, so the scanning
+/// below sees punctuation that is code and nothing else. Numbering is
+/// preserved: output line `i` is input line `i`.
+///
+/// Without this, a comment or a literal that happens to contain `;`, a bracket,
+/// or the word `fence` steers the delimiter counting and the fence match. Both
+/// directions of that are bad, and both were reachable when this ran per line
+/// with no cross-line state:
+///
+/// * a `/* */` comment that merely *mentions* the constant was reported as an
+///   unrecognised publication, failing CI on a comment;
+/// * a payload written as `*ptr = msg;` was taken for the continuation line of
+///   a block comment and skipped, so `marker; *ptr = msg; fence(Release)` — the
+///   payload store left unordered with respect to the marker, exactly the bug
+///   this file exists to reject — passed the guard.
+///
+/// The state is per file rather than per line because every construct that
+/// matters here can span lines: block comments, ordinary strings continued with
+/// a trailing `\`, and raw strings.
+fn sanitize(src: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut state = Scan::Code;
+    for line in src.lines() {
+        let chars: Vec<char> = line.chars().collect();
+        let mut buf = String::with_capacity(line.len());
+        let mut i = 0;
+        while i < chars.len() {
+            match state {
+                Scan::Block(depth) => {
+                    if chars[i] == '/' && chars.get(i + 1) == Some(&'*') {
+                        state = Scan::Block(depth + 1);
+                        i += 2;
+                    } else if chars[i] == '*' && chars.get(i + 1) == Some(&'/') {
+                        state = if depth <= 1 {
+                            Scan::Code
+                        } else {
+                            Scan::Block(depth - 1)
+                        };
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
                 }
-                if chars[i] == '"' {
-                    break;
+                Scan::Str => match chars[i] {
+                    // A trailing `\` continues the string onto the next line;
+                    // `i` running past the end simply carries `Str` over.
+                    '\\' => i += 2,
+                    '"' => {
+                        state = Scan::Code;
+                        buf.push('_');
+                        i += 1;
+                    }
+                    _ => i += 1,
+                },
+                Scan::Raw(hashes) => {
+                    if chars[i] == '"' && closes_raw(&chars, i + 1, hashes) {
+                        state = Scan::Code;
+                        buf.push('_');
+                        i += 1 + hashes;
+                    } else {
+                        i += 1;
+                    }
                 }
-                i += 1;
-            }
-            i += 1;
-            out.push('_');
-            continue;
-        }
-        // `'` is a char literal only in `'x'` / `'\n'` shape; otherwise it opens
-        // a lifetime and must be left alone.
-        if c == '\'' {
-            let escaped = chars.get(i + 1) == Some(&'\\');
-            let simple = chars.get(i + 2) == Some(&'\'');
-            if escaped || simple {
-                i += 1;
-                while i < chars.len() {
-                    if chars[i] == '\\' {
+                Scan::Code => {
+                    let c = chars[i];
+                    if c == '/' && chars.get(i + 1) == Some(&'/') {
+                        break;
+                    }
+                    if c == '/' && chars.get(i + 1) == Some(&'*') {
+                        state = Scan::Block(1);
                         i += 2;
                         continue;
                     }
-                    if chars[i] == '\'' {
-                        break;
+                    // Raw strings first: `\` is not an escape inside one, so
+                    // scanning `r"C:\dir\"` as an ordinary string runs the
+                    // closing quote past the end and blanks the rest of the
+                    // file — a guard that checks nothing.
+                    if let Some((skip, hashes)) = raw_string_open(&chars, i) {
+                        state = Scan::Raw(hashes);
+                        i += skip;
+                        continue;
                     }
+                    if c == '"' {
+                        state = Scan::Str;
+                        i += 1;
+                        continue;
+                    }
+                    // `'` is a char literal only in `'x'` / `'\n'` shape;
+                    // otherwise it opens a lifetime and must be left alone.
+                    if c == '\'' {
+                        let escaped = chars.get(i + 1) == Some(&'\\');
+                        let simple = chars.get(i + 2) == Some(&'\'');
+                        if escaped || simple {
+                            i += 1;
+                            while i < chars.len() {
+                                if chars[i] == '\\' {
+                                    i += 2;
+                                    continue;
+                                }
+                                if chars[i] == '\'' {
+                                    break;
+                                }
+                                i += 1;
+                            }
+                            i += 1;
+                            buf.push('_');
+                            continue;
+                        }
+                    }
+                    buf.push(c);
                     i += 1;
                 }
-                i += 1;
-                out.push('_');
-                continue;
             }
         }
-        out.push(c);
-        i += 1;
+        out.push(buf);
     }
     out
 }
@@ -127,7 +241,10 @@ fn code_only(line: &str) -> String {
 /// Name of the `fn` a line sits inside, searching upward. Returns `None` rather
 /// than guessing, which makes an unrecognised site fail the test instead of
 /// silently matching an exemption.
-fn enclosing_fn(lines: &[&str], line_idx: usize) -> Option<String> {
+///
+/// Runs on sanitized lines, so a `fn` written inside a comment cannot be
+/// mistaken for the enclosing definition.
+fn enclosing_fn(lines: &[String], line_idx: usize) -> Option<String> {
     for line in lines[..=line_idx].iter().rev() {
         let mut rest = line.trim_start();
         // Skip the modifiers a definition can carry before `fn`.
@@ -139,7 +256,10 @@ fn enclosing_fn(lines: &[&str], line_idx: usize) -> Option<String> {
                 .or_else(|| rest.strip_prefix("const "))
                 .or_else(|| rest.strip_prefix("async "))
                 .or_else(|| rest.strip_prefix("unsafe "))
-                .or_else(|| rest.strip_prefix("extern \"C\" "));
+                // `sanitize` blanks the ABI string, so `extern "C" fn` reaches
+                // this as `extern _ fn`.
+                .or_else(|| rest.strip_prefix("extern _ "))
+                .or_else(|| rest.strip_prefix("extern "));
             match next {
                 Some(r) => rest = r,
                 None => break,
@@ -167,10 +287,10 @@ fn enclosing_fn(lines: &[&str], line_idx: usize) -> Option<String> {
 /// — `store({ let v = f(); v }, Ordering::Release)` — would otherwise be cut
 /// short, and the fence check would then run against a line from the middle of
 /// the store and report a violation that is not there.
-fn statement_end(lines: &[&str], start: usize) -> Option<usize> {
+fn statement_end(lines: &[String], start: usize) -> Option<usize> {
     let mut depth: i32 = 0;
     for (offset, line) in lines[start..].iter().enumerate() {
-        for c in code_only(line).chars() {
+        for c in line.chars() {
             match c {
                 '(' | '[' | '{' => depth += 1,
                 ')' | ']' | '}' => depth -= 1,
@@ -235,15 +355,14 @@ fn reads_marker(code: &str) -> bool {
     before.ends_with('&')
 }
 
-/// Blank lines, `//` comments and the body of a `/* */` block — none of them is
-/// the statement that follows the marker.
-fn is_code_line(line: &str) -> bool {
-    let t = line.trim();
-    !t.is_empty()
-        && !t.starts_with("//")
-        && !t.starts_with("/*")
-        && !t.starts_with('*')
-        && !t.starts_with("*/")
+/// Whether a sanitized line carries any code at all.
+///
+/// Comment bodies and blank lines sanitize to whitespace, so this does not have
+/// to guess at comment shapes from punctuation — guessing is what let a
+/// `*ptr = payload;` deref write be mistaken for the `*` continuation line of a
+/// `/* */` block and skipped over on the way to finding the fence.
+fn has_code(line: &str) -> bool {
+    !line.trim().is_empty()
 }
 
 #[test]
@@ -257,22 +376,22 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
 
     for file in &files {
         let src = std::fs::read_to_string(file).expect("read source");
-        let lines: Vec<&str> = src.lines().collect();
+        let lines = sanitize(&src);
         let rel = file
             .strip_prefix(crate_root())
             .unwrap_or(file)
             .display()
-            .to_string();
+            .to_string()
+            .replace('\\', "/");
 
-        for (i, line) in lines.iter().enumerate() {
-            let code = code_only(line);
+        for (i, code) in lines.iter().enumerate() {
             if !code.contains("SLOT_WRITING") {
                 continue;
             }
             let site = format!("{rel}:{}", i + 1);
             let trimmed = code.trim();
 
-            if !publishes_marker(&code) {
+            if !publishes_marker(code) {
                 // Every other shape the crate uses is inert: the constant's own
                 // definition, a `use` of it, and reads of the bit. Anything
                 // else is a shape this guard was not written for — most
@@ -282,7 +401,7 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
                     || trimmed.starts_with("const ")
                     || trimmed.starts_with("pub const ")
                     || trimmed.starts_with("pub(crate) const ")
-                    || reads_marker(&code);
+                    || reads_marker(code);
                 if !inert {
                     violations.push(format!(
                         "{site}: `SLOT_WRITING` appears in a shape this guard does \
@@ -296,7 +415,7 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
             }
 
             match enclosing_fn(&lines, i) {
-                Some(name) if EXEMPT_FNS.contains(&name.as_str()) => continue,
+                Some(name) if EXEMPT_SITES.iter().any(|(f, n)| *f == rel && *n == name) => continue,
                 Some(_) => {}
                 None => {
                     violations.push(format!(
@@ -316,8 +435,7 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
             };
             let next = lines[end + 1..]
                 .iter()
-                .copied()
-                .position(is_code_line)
+                .position(|l| has_code(l))
                 .map(|off| end + 1 + off);
 
             checked += 1;
@@ -329,11 +447,7 @@ fn every_writing_marker_is_followed_by_a_release_fence() {
                 continue;
             };
             let next_end = statement_end(&lines, next).unwrap_or(next);
-            let next_stmt: String = lines[next..=next_end]
-                .iter()
-                .map(|l| code_only(l))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let next_stmt = lines[next..=next_end].join(" ");
 
             if !is_release_fence(&next_stmt) {
                 violations.push(format!(


### PR DESCRIPTION
`Topic::send`'s role=Both POD fast path stamped the seqlock WRITING marker
with `store(Release)` and then wrote the payload with nothing in between
(mod.rs:2772). A release store orders only the accesses BEFORE it, so it
does not keep the payload store that follows from being observed first.

The slot it publishes is drained by `recv_shm_pod_broadcast`, a textbook
Boehm reader: `v1 = stamp.load(Acquire)` / copy / `fence(Acquire)` /
`stamp.load(Relaxed) == v1`. That protocol rejects a lapping producer only
against the fenced write side. Against this one the consumer can see new
payload bytes under two matching stale stamps and return a value that is
half of one message and half of another — on a robot, a pose or velocity
that never existed, with nothing indicating it.

Not theoretical on a shipped target. rustc 1.97.1 -O for
aarch64-unknown-linux-gnu emits `stlr x8,[x0]; str x3,[x1]; stlr x2,[x0]`
for this form and `str x8,[x0]; dmb ish; str x3,[x1]; stlr x2,[x0]` for the
fenced one; aarch64 and armv7 wheels are built by CI. On x86_64 the two
compile to identical instructions — the fence is a compiler barrier only —
so the fix is free where it is not needed.

The crate's three other implementations of this same write phase were
already fenced: dispatch.rs:1497, topic/seqlock.rs:80-90, and
communication/mod.rs:283/313. This makes the fourth match them.

Tests: `tests/loom_pod_broadcast.rs` gains an ignored `colo` arm that runs
the pre-fix write phase against the unchanged consumer model and tears, so
the fence is demonstrably load-bearing rather than ornamental. A new
`tests/seqlock_write_phase.rs` scans horus_core/src and fails if any
SLOT_WRITING marker is not followed by a Release fence — the loom models
are transcriptions, and nothing else stopped the real code from drifting
back to a form they already condemn.

## Ablation

```
Reverted ONLY the production change (mod.rs back to `store(..., Ordering::Release)` with no fence), kept both tests, re-ran the guard:

    $ cargo test -p horus_core --test seqlock_write_phase
        Finished `test` profile [unoptimized + debuginfo] target(s) in 36.29s
         Running tests/seqlock_write_phase.rs (target/debug/deps/seqlock_write_phase-9a8c1c4b05df6bdc)

    running 1 test
    test every_writing_marker_is_followed_by_a_release_fence ... FAILED

    failures:

    ---- every_writing_marker_is_followed_by_a_release_fence stdout ----

    thread 'every_writing_marker_is_followed_by_a_release_fence' (1853565) panicked at horus_core/tests/seqlock_write_phase.rs:169:5:
    unfenced seqlock write phase(s):
      src/communication/topic/mod.rs:2792: the WRITING marker is not followed by a Release fence (next code line: std::ptr::write(data, msg);). A Release store on the marker does not order the payload write below it; see this file's header.
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


    failures:
        every_writing_marker_is_followed_by_a_release_fence

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.04s

    error: test failed, to rerun pass `-p horus_core --test seqlock_write_phase`

Production change restored; the same command then passes (1 passed; 0 failed, 2.71s). It flagged exactly the one reverted line and nothing else, so the guard is not a blanket assertion.

Second, independent ablation of the MECHANISM (the loom arm; production code is not involved, so this one does not move with the diff — it shows the reverted write phase is genuinely unsound, not merely different):

    $ cargo test -p horus_core --test loom_pod_broadcast -- --ignored colo --nocapture
    running 1 test

    thread 'colo_release_marker_tears_proving_the_fence_is_load_bearing' (1500251) panicked at horus_core/tests/loom_pod_broadcast.rs:326:13:
    assertion `left == right` failed: torn read: the Release-store marker does not order the payload write that follows it (expected — this is the bug)
      left: 11935946388429271922
     right: 11935946387415367680
    test colo_release_marker_tears_proving_the_fence_is_load_bearing ... FAILED

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.03s

Third leg, codegen, run by me rather than taken from the finding — rustc 1.97.1, `-O`, the two forms side by side:

    aarch64-unknown-linux-gnu
      naive:  orr x8,x2,#0x8000000000000000 / stlr x8,[x0] / str x3,[x1] / stlr x2,[x0]
```

## Tests

```
All on the final tree (fix + both tests), horus_core only — that is the single crate touched.

- `cargo test -p horus_core --test seqlock_write_phase` — 1 passed, 0 failed (3.58s). New guard.
- `cargo test -p horus_core --test loom_pod_broadcast` — 2 passed, 0 failed, 2 ignored, 1242.37s. The two live loom models (`broadcast_read_never_tears_under_lapping_producer`, `broadcast_consumer_never_accepts_a_slot_mid_write`) still pass; the two demonstration arms are `#[ignore]`d, matching how CI invokes this file (ci.yml:392 runs it without `--ignored`), so CI runtime is unchanged.
- `cargo test -p horus_core --test loom_pod_broadcast -- --ignored colo` — 1 failed, as designed (output in `ablation`).
- `cargo test -p horus_core --lib` — 2495 passed, 0 failed, 4 ignored, 70.82s. This is the suite that contains `communication::topic::tests` (~2500 unit tests, the module I changed).
- `cargo clippy -p horus_core --all-targets` — clean, zero warnings.
- `cargo fmt --all -- --check` — clean (exit 0).

Pre-existing flake, ruled out as mine: two earlier full `--lib` runs failed `communication::topic::tests::no_message_is_lost_without_being_counted` (2494 passed / 1 failed) in its **SpmcShm** arm — "5000 messages were accepted but 491 / 982 are accounted for". I ran the same suite on pristine HEAD with my production change reverted: it failed too, plus `scheduling::scheduler::tests::test_ready_dispatch_fan_in_waits_for_all` (2493 passed / 2 failed). In isolation the test passes, and the fi
```

## Notes from the implementer

Confirmed the finding myself before touching anything: mod.rs:2771-2774 stamps with `store(Release)` and writes the payload with nothing between; dispatch.rs:2171-2277 is the Boehm reader that consumes those slots (`v1` Acquire load, copy, `fence(Acquire)`, relaxed re-check, accept on `v1 == tail+1`); dispatch.rs:1497-1500, topic/seqlock.rs:80-90 and communication/mod.rs:283/313 are all fenced. seqlock.rs's own comment says "Verified by tests/loom_fanout.rs (the naive all-Release form fails loom)" — the repo already knew, and this one site did not follow. Reachability is structural: `cached_colo_stride != 0` comes from `point_at_slots` reading the region's layout kind, and PodShm (the default backend for POD types) maps colo, with `recv_shm_pod_broadcast` as its reader.

What I could NOT verify:
- No runtime test can catch this on the hardware I have. x86-64 does not reorder StoreStore, and both forms compile to the same three `movq`s there. That is why the ablatable test is a source guard rather than a race test: it asserts the invariant the loom models justify. The repo already uses this pattern (`tests/rt_output_safety.rs` scans src the same way). If you would rather not land a lint-shaped test, the loom arm alone still documents the mechanism — but then nothing stops the drift recurring, which is exactly what happened here.
- I did not reproduce a torn read on real aarch64 hardware; I have no arm machine. The evidence is the loom model plus the codegen diff.
- I did not run horus_core's ~100 integration test binaries, only `--lib` (which holds the topic module's own ~2500 tests) plus the two loom/guard binaries. Full-suite time and the known /dev/shm-fills-up interference made that a poor signal; the root filesystem on this box is also at 100% (445G/469G, 0 avail), which broke `git add` at one point.

Deliberately NOT fixed, and you may disagree: dispatch.rs:1332 in `send_shm_sp_pod` has the identical `store(SLOT_WRITING | new_seq, Ordering::Release)` form under

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
