### PR TITLE
fix(topic): commit the seqlock fast-forward before the read attempt

### DIFF
--- a/horus_core/src/communication/topic/seqlock.rs
+++ b/horus_core/src/communication/topic/seqlock.rs
@@ -132,6 +132,26 @@ pub(super) unsafe fn seqlock_consume<R>(
             let resume = h.wrapping_sub(capacity);
             *skipped = skipped.wrapping_add(resume.wrapping_sub(next));
             next = resume;
+            // Commit the fast-forward HERE, not only on the success path below.
+            // The skip is already banked in the caller's counter, but `tail` used
+            // to move only after a successful read — so every attempt-exhausted
+            // `None` left `tail` at its pre-lap value and the next call re-derived
+            // the same gap from it and counted it AGAIN. That is not a rare path:
+            // capacity is a power of two and `resume = h - capacity`, so
+            // `resume & mask == h & mask` — the fast-forward lands on exactly the
+            // slot the producer overwrites next, and against a saturated producer
+            // the version check below fails far more often than it passes.
+            // Measured on this function directly (16-slot ring, 4 KiB payloads,
+            // 1 s of a saturated producer against one polling consumer):
+            // 681,629 sends billed 7,500,196,765 skips — 11,003x more loss than
+            // messages ever existed. `recv_fanout_shm` banks `skipped` into
+            // `local.missed` whatever this returns and `Topic::missed_count()`
+            // reports that unclamped, so that is the number a user reads. With
+            // this store the same run reports 592,092 sends / 591,811 skipped,
+            // i.e. `received + skipped == sends` bar what is still in the ring.
+            // `tail` is consumer-owned, so the store is uncontended, and the
+            // success-path store below supersedes it.
+            tail.store(next, Ordering::Release);
         }
         let idx = (next & mask) as usize;
         let expected = next << 1;
@@ -155,4 +175,121 @@ pub(super) unsafe fn seqlock_consume<R>(
         return Some(val);
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// A capacity-`CAP` ring on the heap: the same version array, `head` and
+    /// `tail` the SHM channel hands to `seqlock_publish`/`seqlock_consume`,
+    /// without the SHM plumbing. Single-threaded, so the data slots are `Cell`s.
+    struct Ring {
+        versions: Vec<AtomicU64>,
+        data: Vec<Cell<u64>>,
+        head: AtomicU64,
+        tail: AtomicU64,
+        capacity: u64,
+    }
+
+    impl Ring {
+        fn new(capacity: u64) -> Self {
+            assert!(capacity.is_power_of_two());
+            Self {
+                versions: (0..capacity).map(|_| AtomicU64::new(0)).collect(),
+                data: (0..capacity).map(|_| Cell::new(0)).collect(),
+                head: AtomicU64::new(0),
+                tail: AtomicU64::new(0),
+                capacity,
+            }
+        }
+
+        /// Publish the next position, storing the position itself as the payload
+        /// so a delivered value identifies the position it came from.
+        fn publish(&self) {
+            let pos = self.head.load(Ordering::Relaxed);
+            // SAFETY: `versions` has `capacity == mask + 1` entries and this test
+            // is the only producer.
+            unsafe {
+                seqlock_publish(
+                    self.versions.as_ptr(),
+                    self.capacity - 1,
+                    &self.head,
+                    pos,
+                    |idx| self.data[idx].set(pos),
+                );
+            }
+        }
+
+        fn consume(&self, skipped: &mut u64) -> Option<u64> {
+            // SAFETY: same array bounds, and this test is the only consumer.
+            unsafe {
+                seqlock_consume(
+                    self.versions.as_ptr(),
+                    self.capacity - 1,
+                    self.capacity,
+                    &self.head,
+                    &self.tail,
+                    |idx| self.data[idx].get(),
+                    drop,
+                    skipped,
+                )
+            }
+        }
+    }
+
+    /// A lapped consumer that gives up (every attempt lost the version check)
+    /// must not bill the caller for the same lap again on its next call.
+    ///
+    /// The give-up is not a corner case: `resume = h - capacity` and capacity is
+    /// a power of two, so `resume & mask == h & mask` — the fast-forward lands on
+    /// exactly the slot the producer is about to overwrite. Against a saturated
+    /// producer that read loses far more often than it wins, and each loss used
+    /// to re-bank the whole gap: 1 s of a saturated producer on a 16-slot ring
+    /// reported 7,500,196,765 missed against 681,629 sends (11,003x).
+    #[test]
+    fn a_lapped_consumer_that_gives_up_does_not_re_count_the_gap() {
+        const CAP: u64 = 16;
+        let ring = Ring::new(CAP);
+
+        // 20 sent into 16 slots: positions 0..4 are gone, the consumer is at 0.
+        for _ in 0..20 {
+            ring.publish();
+        }
+        // The producer is now mid-write of position 20 — the state the
+        // fast-forward lands in, since it targets slot `head & mask`. Stamped
+        // odd, data not written yet, `head` not advanced yet (`seqlock_publish`).
+        ring.versions[(20 & (CAP - 1)) as usize].store((20 << 1) | 1, Ordering::Release);
+
+        let mut missed = 0u64;
+        assert_eq!(
+            ring.consume(&mut missed),
+            None,
+            "the slot the producer is writing must not be delivered"
+        );
+        assert_eq!(missed, 4, "20 into a 16-slot ring skips positions 0..4");
+        assert_eq!(ring.consume(&mut missed), None, "still mid-write");
+        assert_eq!(
+            missed, 4,
+            "the second give-up re-counted a lap that was already banked: the \
+             fast-forward must commit `tail`, not leave it for the success path"
+        );
+
+        // The producer finishes position 20; the consumer drains what is left.
+        ring.data[(20 & (CAP - 1)) as usize].set(20);
+        ring.versions[(20 & (CAP - 1)) as usize].store(20 << 1, Ordering::Release);
+        ring.head.store(21, Ordering::Release);
+
+        let mut got = Vec::new();
+        while let Some(v) = ring.consume(&mut missed) {
+            got.push(v);
+        }
+        assert_eq!(
+            got.len() as u64 + missed,
+            21,
+            "received + missed must account for every send and nothing more \
+             (got {got:?}, missed {missed})"
+        );
+    }
 }

--- a/horus_core/src/communication/topic/seqlock.rs
+++ b/horus_core/src/communication/topic/seqlock.rs
@@ -132,25 +132,18 @@ pub(super) unsafe fn seqlock_consume<R>(
             let resume = h.wrapping_sub(capacity);
             *skipped = skipped.wrapping_add(resume.wrapping_sub(next));
             next = resume;
-            // Commit the fast-forward HERE, not only on the success path below.
-            // The skip is already banked in the caller's counter, but `tail` used
-            // to move only after a successful read — so every attempt-exhausted
-            // `None` left `tail` at its pre-lap value and the next call re-derived
-            // the same gap from it and counted it AGAIN. That is not a rare path:
-            // capacity is a power of two and `resume = h - capacity`, so
-            // `resume & mask == h & mask` — the fast-forward lands on exactly the
-            // slot the producer overwrites next, and against a saturated producer
-            // the version check below fails far more often than it passes.
-            // Measured on this function directly (16-slot ring, 4 KiB payloads,
-            // 1 s of a saturated producer against one polling consumer):
-            // 681,629 sends billed 7,500,196,765 skips — 11,003x more loss than
-            // messages ever existed. `recv_fanout_shm` banks `skipped` into
-            // `local.missed` whatever this returns and `Topic::missed_count()`
-            // reports that unclamped, so that is the number a user reads. With
-            // this store the same run reports 592,092 sends / 591,811 skipped,
-            // i.e. `received + skipped == sends` bar what is still in the ring.
-            // `tail` is consumer-owned, so the store is uncontended, and the
-            // success-path store below supersedes it.
+            // Commit the fast-forward HERE, not only on the success path below:
+            // the gap is billed to `skipped` above, so the cursor has to move
+            // with it, or an attempt-exhausted `None` leaves `tail` at its
+            // pre-lap value and the next call re-derives and re-bills the same
+            // gap. That give-up is the common path, not a corner — capacity is a
+            // power of two and `resume = h - capacity`, so
+            // `resume & mask == h & mask`: the fast-forward lands on exactly the
+            // slot the producer overwrites next, and the version check below
+            // loses to a saturated producer far more often than it wins.
+            // Nothing extra is dropped (`resume` is the oldest position still in
+            // the ring), `tail` is consumer-owned so the store is uncontended,
+            // and the success-path store below supersedes it.
             tail.store(next, Ordering::Release);
         }
         let idx = (next & mask) as usize;
@@ -246,14 +239,14 @@ mod tests {
     /// a power of two, so `resume & mask == h & mask` — the fast-forward lands on
     /// exactly the slot the producer is about to overwrite. Against a saturated
     /// producer that read loses far more often than it wins, and each loss used
-    /// to re-bank the whole gap: 1 s of a saturated producer on a 16-slot ring
-    /// reported 7,500,196,765 missed against 681,629 sends (11,003x).
+    /// to re-bank the whole gap, so the reported loss ran orders of magnitude
+    /// above the number of messages ever sent.
     #[test]
     fn a_lapped_consumer_that_gives_up_does_not_re_count_the_gap() {
         const CAP: u64 = 16;
         let ring = Ring::new(CAP);
 
-        // 20 sent into 16 slots: positions 0..4 are gone, the consumer is at 0.
+        // 20 sent into 16 slots: positions 0-3 are gone, the consumer is at 0.
         for _ in 0..20 {
             ring.publish();
         }
@@ -268,7 +261,7 @@ mod tests {
             None,
             "the slot the producer is writing must not be delivered"
         );
-        assert_eq!(missed, 4, "20 into a 16-slot ring skips positions 0..4");
+        assert_eq!(missed, 4, "20 into a 16-slot ring skips 4 positions (0-3)");
         assert_eq!(ring.consume(&mut missed), None, "still mid-write");
         assert_eq!(
             missed, 4,

--- a/horus_core/tests/loom_fanout.rs
+++ b/horus_core/tests/loom_fanout.rs
@@ -80,6 +80,11 @@ impl<const CAP: usize> SeqRing<CAP> {
             }
             if avail > CAP as u64 {
                 next = h.wrapping_sub(CAP as u64);
+                // Mirrors the fast-forward commit in `seqlock_consume`: the skip
+                // is banked into the caller's counter before the read, so `tail`
+                // has to move with it or an attempt-exhausted `None` re-counts
+                // the same gap on the next call.
+                self.tail.store(next, Ordering::Release);
             }
             let idx = (next & Self::MASK) as usize;
             let expected = next << 1;


### PR DESCRIPTION
`seqlock_consume` banked the lap gap into the caller's `skipped` counter as
soon as it fast-forwarded, but stored `tail` only on the success path. When
the 16-attempt loop then exhausted and returned `None`, the skip was already
billed while `tail` still held its pre-lap value — so the next call reloaded
that stale cursor, re-derived the same (or a larger) gap, and billed it again.

The give-up is the common case, not a corner: capacity is a power of two and
`resume = h - capacity`, so `resume & mask == h & mask` — the fast-forward
lands on exactly the slot the producer overwrites next, and against a
saturated producer the version check loses far more often than it wins.
`recv_fanout_shm` passes `&mut local.missed` in regardless of the return value
(dispatch.rs) and `Topic::missed_count()` reports it unclamped, so the
over-count is what a user reads.

Differential measurement on `seqlock_consume` itself (16-slot ring, 4 KiB
payloads, 1 s of a saturated producer against one polling consumer, debug
build), the only change between runs being this store:

    before:  sends=681,629  recv=446  missed=7,500,196,765   (11,003x)
    after:   sends=592,092  recv=264  missed=591,811         (1.0000x)

`tail` is consumer-owned, so the extra store is uncontended and the
success-path store still supersedes it. No delivery behaviour changes: the
positions skipped were already unreachable, and a committed cursor can only
land where the old code's recomputation would have landed or later.

Adds a deterministic unit test in `seqlock.rs` that puts the ring in the state
the fast-forward actually lands in (producer mid-write of `head`, slot stamped
odd) and asserts a second give-up does not re-bank the lap, plus
`received + missed == sends` over the whole run. The loom mirror of
`seqlock_consume` in tests/loom_fanout.rs gains the same store so the model
stays faithful (4 loom tests still pass).

## Ablation

```
Reverted ONLY the production line (`tail.store(next, Ordering::Release);` in the
`avail > capacity` branch of `seqlock_consume`), kept the new test and the loom
mirror change, then ran
`cargo test -p horus_core --lib -- communication::topic::seqlock --nocapture`.
Exact output:

     Running unittests src/lib.rs (target/debug/deps/horus_core-084e9e0d5e0fa763)

running 1 test

thread 'communication::topic::seqlock::tests::a_lapped_consumer_that_gives_up_does_not_re_count_the_gap' (1551479) panicked at horus_core/src/communication/topic/seqlock.rs:270:9:
assertion `left == right` failed: the second give-up re-counted a lap that was already banked: the fast-forward must commit `tail`, not leave it for the success path
  left: 8
 right: 4
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test communication::topic::seqlock::tests::a_lapped_consumer_that_gives_up_does_not_re_count_the_gap ... FAILED

failures:

failures:
    communication::topic::seqlock::tests::a_lapped_consumer_that_gives_up_does_not_re_count_the_gap

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2499 filtered out; finished in 0.01s

error: test failed, to rerun pass `-p horus_core --lib`

(left: 8 = the same 4-message lap billed twice. The `seqlock.rs:270` line number
is from the ablation run; a later comment reword shifted it by two lines.)
Production change restored afterwards; the test passes again.
```

## Tests

```
All on the worktree, debug profile.

1. New test alone (with fix): `cargo test -p horus_core --lib -- communication::topic::seqlock`
   -> 1 passed; 0 failed; 0 ignored; 2499 filtered out; 0.00s.
2. Touched-module suites: `cargo test -p horus_core --lib -- communication::topic::seqlock communication::topic::shm_fanout`
   -> 35 passed; 0 failed; 1 ignored; 2464 filtered out; 2.01s.
3. Loom model (mirror updated): `cargo test -p horus_core --test loom_fanout`
   -> 4 passed; 0 failed; 23.45s (23.56s on the first run of the same change).
4. Whole crate lib suite with the fix: `cargo test -p horus_core --lib`
   -> 2494 passed; 2 failed; 4 ignored; 58.74s. The two failures are PRE-EXISTING:
   I stashed my diff (clean main, 71e6a4a8) and both reproduce there —
   - communication::topic::tests::no_message_is_lost_without_being_counted
     (baseline: "SpmcShm: 5000 accepted but 4842 accounted for"; with my diff it
     tripped one backend earlier, "MpscShm: ... 405 accounted for" — it varies run
     to run, and neither backend goes through seqlock.rs)
   - scheduling::event_executor::tests::wake_comes_from_the_publisher_not_from_the_backstop
     (timing assertion: 11.7 ms median on baseline, 9.75 ms with my diff, threshold 5 ms)
5. `cargo clippy -p horus_core --lib --tests` -> finished with no warnings.
   `cargo fmt --all -- --check` -> clean.
6. /dev/shm went 1.4G -> 2.3G of 31G across the full lib run; no exhaustion.
```

## Notes from the implementer

CONFIRMED THE DEFECT MYSELF before fixing. seqlock.rs:128-135 advances the local
`next` and adds `resume - next` to `*skipped`; the only `tail` store was on the
success path (:154). `recv_fanout_shm` (topic/dispatch.rs:1260 and :1267) passes
`&mut local.missed` in unconditionally, and `Topic::missed_count()` returns
`self.local().missed` unclamped, so nothing downstream guards it. The geometric
premise is arithmetic, not speculation: `resume = h - capacity` with capacity a
power of two gives `resume & mask == h & mask`.

I re-measured the impact myself rather than trusting the finding's numbers: a
1 s two-thread differential harness driving `seqlock_consume` directly (16-slot
ring, 4 KiB payload with the alloc+memcpy `try_recv_serde` does), the only
difference between runs being the one store. Unfixed: sends=681,629 recv=446
missed=7,500,196,765 (11,003x). Fixed: sends=592,092 recv=264 missed=591,811
(1.0000x). That harness was temporary and is NOT in the diff. Caveats: debug
build, one run per arm, one machine, and measured at the seqlock level — I did
NOT measure end-to-end through `Topic::missed_count()`; the propagation to that
surface is established by reading the call path, not by a run. The in-code
comment is worded to say exactly that.

WHAT I DELIBERATELY DID NOT DO. The finding's suggested fix has a second,
separable half: change the landing point to `h - capacity + capacity/2` (what
`recv_shm_pod_broadcast` uses, dispatch.rs:2126-2131). That is a real liveness
issue — with only my fix the consumer still receives ~264 of 592,092 under a
saturated producer, because it keeps aiming at the slot the producer is about to
write — but it is a behaviour change, not a counting fix: it drops an extra
capacity/2 live messages on every lap in exchange for landing on a settled slot.
Tradeoff for a human to decide: (a) leave as-is — drop-oldest keeps the maximum
possible data, but a consumer that stays a lap behind delivers almost nothing;
(b) adopt the half-lap landing

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
