### PR TITLE
fix(scheduling): report telemetry export failures instead of discarding them

### DIFF
--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -3756,7 +3756,33 @@ impl Scheduler {
                 }
                 drop(profiler);
 
-                let _ = tm.export();
+                // This was `let _ = tm.export()`. Every failure mode returns a
+                // precise string — an unwritable `file://` path, a UDP socket
+                // that never bound, an HTTP export thread that has exited — and
+                // discarding it left no surface anywhere saying the metrics
+                // were not arriving. `TelemetryManager::export` advances
+                // `last_export` whether or not the snapshot landed, so a broken
+                // endpoint quietly reschedules itself for the life of the
+                // process, under the "[SCHEDULER] Telemetry enabled (endpoint:
+                // ...)" line printed at startup that nothing ever corrected.
+                //
+                // Reported through `hlog!` rather than the `log::` facade the
+                // HTTP export thread uses: `log::` reaches an operator only if
+                // something installed a logger, and only the CLI does
+                // (`try_init_log_bridge` in horus_manager). A robot binary
+                // running its own `Scheduler` — what `horus run` executes as a
+                // subprocess — has no logger, so `log::warn!` there is a no-op.
+                // `hlog!` writes to the shared log buffer (`horus log`,
+                // `horus monitor`) and the console unconditionally.
+                //
+                // Not throttled: `should_export()` already gates this to one
+                // call per export interval (1000 ms wherever a manager is
+                // constructed), so a permanently broken endpoint costs one line
+                // per second — the rate an RT deadline miss is already allowed
+                // (`DiagThrottle::WINDOW_NS`).
+                if let Err(e) = tm.export() {
+                    crate::hlog!(warn, "[TELEMETRY] Export failed: {}", e);
+                }
             }
         }
     }
@@ -4079,7 +4105,13 @@ impl Scheduler {
         if let Some(ref mut tm) = self.monitor.telemetry {
             tm.counter("scheduler_ticks", total_ticks);
             tm.gauge("scheduler_shutdown", 1.0);
-            let _ = tm.export();
+            // Reported for the same reason as the periodic export (see
+            // `periodic_monitoring`), and for the same reason the blackbox save
+            // nine lines above reports its failure: this is the run's last
+            // chance to say the metrics never landed.
+            if let Err(e) = tm.export() {
+                crate::hlog!(warn, "[TELEMETRY] Final export failed: {}", e);
+            }
         }
 
         // Print timing report if profiling enabled and ticks were executed

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -3700,6 +3700,31 @@ impl Scheduler {
     }
 
     /// Periodic registry snapshot, failure logging, blackbox tick, and telemetry export.
+    ///
+    /// # Why the telemetry export reports, and how
+    ///
+    /// This export and the final one in `finalize_run` were both
+    /// `let _ = tm.export()`. Every failure mode returns a precise string — an
+    /// unwritable `file://` path, a UDP socket that never bound, an HTTP export
+    /// thread that has exited — and discarding it left no surface anywhere
+    /// saying the metrics were not arriving. `TelemetryManager::export` advances
+    /// `last_export` whether or not the snapshot landed, so a broken endpoint
+    /// quietly reschedules itself for the life of the process, under the
+    /// `[SCHEDULER] Telemetry enabled (endpoint: ...)` line printed at startup
+    /// that nothing ever corrected.
+    ///
+    /// Reported through `hlog!` rather than the `log::` facade the HTTP export
+    /// thread uses: `log::` reaches an operator only if something installed a
+    /// logger, and only the CLI does (`try_init_log_bridge` in `horus_manager`).
+    /// A robot binary running its own `Scheduler` — what `horus run` executes as
+    /// a subprocess — has no logger, so `log::warn!` there is a no-op. `hlog!`
+    /// writes to the shared log buffer (`horus log`, `horus monitor`) and the
+    /// console unconditionally.
+    ///
+    /// Not throttled: `should_export()` already gates this to one call per
+    /// export interval (1000 ms wherever a manager is constructed), so a
+    /// permanently broken endpoint costs one line per second — the rate an RT
+    /// deadline miss is already allowed (`DiagThrottle::WINDOW_NS`).
     fn periodic_monitoring(&mut self, start_time: Instant) {
         // Registry snapshot every 5 seconds
         if self.monitor.last_snapshot.elapsed() >= 5_u64.secs() {
@@ -3756,30 +3781,10 @@ impl Scheduler {
                 }
                 drop(profiler);
 
-                // This was `let _ = tm.export()`. Every failure mode returns a
-                // precise string — an unwritable `file://` path, a UDP socket
-                // that never bound, an HTTP export thread that has exited — and
-                // discarding it left no surface anywhere saying the metrics
-                // were not arriving. `TelemetryManager::export` advances
-                // `last_export` whether or not the snapshot landed, so a broken
-                // endpoint quietly reschedules itself for the life of the
-                // process, under the "[SCHEDULER] Telemetry enabled (endpoint:
-                // ...)" line printed at startup that nothing ever corrected.
-                //
-                // Reported through `hlog!` rather than the `log::` facade the
-                // HTTP export thread uses: `log::` reaches an operator only if
-                // something installed a logger, and only the CLI does
-                // (`try_init_log_bridge` in horus_manager). A robot binary
-                // running its own `Scheduler` — what `horus run` executes as a
-                // subprocess — has no logger, so `log::warn!` there is a no-op.
-                // `hlog!` writes to the shared log buffer (`horus log`,
-                // `horus monitor`) and the console unconditionally.
-                //
-                // Not throttled: `should_export()` already gates this to one
-                // call per export interval (1000 ms wherever a manager is
-                // constructed), so a permanently broken endpoint costs one line
-                // per second — the rate an RT deadline miss is already allowed
-                // (`DiagThrottle::WINDOW_NS`).
+                // Was `let _ = tm.export()`, which left a misconfigured
+                // endpoint silent for the life of the process. Why the report
+                // goes through `hlog!` and is not throttled: doc comment on
+                // this function.
                 if let Err(e) = tm.export() {
                     crate::hlog!(warn, "[TELEMETRY] Export failed: {}", e);
                 }
@@ -4105,9 +4110,9 @@ impl Scheduler {
         if let Some(ref mut tm) = self.monitor.telemetry {
             tm.counter("scheduler_ticks", total_ticks);
             tm.gauge("scheduler_shutdown", 1.0);
-            // Reported for the same reason as the periodic export (see
-            // `periodic_monitoring`), and for the same reason the blackbox save
-            // nine lines above reports its failure: this is the run's last
+            // Reported for the same reason as the periodic export (rationale
+            // on `periodic_monitoring`), and for the same reason the blackbox
+            // save nine lines above reports its failure: this is the run's last
             // chance to say the metrics never landed.
             if let Err(e) = tm.export() {
                 crate::hlog!(warn, "[TELEMETRY] Final export failed: {}", e);

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -3458,14 +3458,51 @@ fn telemetry_export_failures_reach_the_log() {
 
     let first_unread = crate::core::log_buffer::GLOBAL_LOG_BUFFER.write_idx();
 
+    // Ends the run on an OBSERVED export failure rather than on a wall-clock
+    // guess about when the 1000 ms interval elapses inside a fixed `run_for`.
+    // The scheduler ticks this node, then runs `periodic_monitoring` in the same
+    // iteration, so the line is picked up one tick (10 ms) after it is written
+    // and `finalize_run` follows immediately with the final export. `run_for`
+    // below is therefore a timeout, not a schedule: a loaded machine that
+    // stalls the tick loop costs latency here instead of a failure, and the
+    // window in which the shared log ring could evict the line before the
+    // assertions read it shrinks from hundreds of milliseconds to one tick.
+    struct StopOnExportFailure {
+        since: u64,
+        running: Arc<AtomicBool>,
+    }
+    impl Node for StopOnExportFailure {
+        fn name(&self) -> &str {
+            "telemetry_probe"
+        }
+        fn tick(&mut self) {
+            let reported = crate::core::log_buffer::GLOBAL_LOG_BUFFER
+                .get_since(self.since)
+                .into_iter()
+                .any(|entry| entry.message.contains("[TELEMETRY] Export failed"));
+            if reported {
+                self.running.store(false, Ordering::SeqCst);
+            }
+        }
+    }
+
     let mut scheduler = Scheduler::new()
         .tick_rate(100_u64.hz())
         .telemetry(&endpoint);
-    scheduler.add(CounterNode::new("telemetry_probe")).build();
+    let running = scheduler.running_flag();
+    scheduler
+        .add(StopOnExportFailure {
+            since: first_unread,
+            running,
+        })
+        .build();
 
-    // Longer than the 1000 ms export interval, so the periodic export runs at
-    // least once before `finalize_run` performs the final one.
-    scheduler.run_for(1400_u64.ms()).unwrap();
+    // Upper bound, not the expected duration. The export interval starts when
+    // `finalize_config` builds the manager, just before the run clock does, so
+    // the periodic export normally reports ~1.0 s in and the node above ends
+    // the run right there. Five seconds leaves room for a four-second stall
+    // before the assertions below report what was actually logged.
+    scheduler.run_for(5000_u64.ms()).unwrap();
 
     let reported: Vec<String> = crate::core::log_buffer::GLOBAL_LOG_BUFFER
         .get_since(first_unread)

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -3476,10 +3476,27 @@ fn telemetry_export_failures_reach_the_log() {
             "telemetry_probe"
         }
         fn tick(&mut self) {
+            // Sample the write index BEFORE the scan and advance `since` to it
+            // afterwards, so each tick deserialises only what arrived since the
+            // previous one instead of re-walking the whole window every 10 ms.
+            // GLOBAL_LOG_BUFFER is a cross-process ring shared with every other
+            // horus process on the machine, so under a parallel `cargo test`
+            // the un-advanced window reaches the ring's full capacity (5000
+            // slots by default) and each tick re-deserialises thousands of
+            // other processes' entries — each one a bincode decode under the
+            // buffer's mutex, with a 5 ms spin available per slot that is
+            // mid-write.
+            //
+            // Sampled before, not after: an index read after the scan would
+            // advance past entries written *during* it, and `get_since` never
+            // returns those again. Read first, and the worst case is that the
+            // next tick re-scans a handful of entries.
+            let upto = crate::core::log_buffer::GLOBAL_LOG_BUFFER.write_idx();
             let reported = crate::core::log_buffer::GLOBAL_LOG_BUFFER
                 .get_since(self.since)
                 .into_iter()
                 .any(|entry| entry.message.contains("[TELEMETRY] Export failed"));
+            self.since = upto;
             if reported {
                 self.running.store(false, Ordering::SeqCst);
             }
@@ -3490,12 +3507,18 @@ fn telemetry_export_failures_reach_the_log() {
         .tick_rate(100_u64.hz())
         .telemetry(&endpoint);
     let running = scheduler.running_flag();
+    // `.unwrap()`, not a discarded `Result`: `unused_must_use` is allowed
+    // workspace-wide, so a `build()` that ever starts failing validation here
+    // would drop the node silently. The run would then fall through to the
+    // 5 s timeout below and still pass, hiding the loss of the very thing that
+    // makes this test prompt.
     scheduler
         .add(StopOnExportFailure {
             since: first_unread,
             running,
         })
-        .build();
+        .build()
+        .unwrap();
 
     // Upper bound, not the expected duration. The export interval starts when
     // `finalize_config` builds the manager, just before the run clock does, so

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -3434,6 +3434,59 @@ fn test_telemetry_builder() {
     );
 }
 
+/// A telemetry endpoint the process cannot write must say so — on both the
+/// periodic path and the final export.
+///
+/// Both callers used to be `let _ = tm.export()`, and `export()` advances
+/// `last_export` whether or not the snapshot landed, so a `file://` endpoint
+/// pointing somewhere unwritable failed on every interval for the life of the
+/// process with no diagnostic on any surface — under the
+/// "[SCHEDULER] Telemetry enabled (endpoint: ...)" line printed at startup.
+#[test]
+fn telemetry_export_failures_reach_the_log() {
+    let _guard = lock_scheduler();
+
+    // A regular file where the exporter needs a directory: `create_dir_all`
+    // then fails on every export with "File exists (os error 17)". That is
+    // deterministic, and it does not depend on the test user's permissions the
+    // way an unwritable directory would (a suite running as root can write
+    // through mode 0o555).
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let blocker = temp_dir.path().join("not-a-directory");
+    std::fs::write(&blocker, b"").unwrap();
+    let endpoint = format!("file://{}/metrics.json", blocker.display());
+
+    let first_unread = crate::core::log_buffer::GLOBAL_LOG_BUFFER.write_idx();
+
+    let mut scheduler = Scheduler::new()
+        .tick_rate(100_u64.hz())
+        .telemetry(&endpoint);
+    scheduler.add(CounterNode::new("telemetry_probe")).build();
+
+    // Longer than the 1000 ms export interval, so the periodic export runs at
+    // least once before `finalize_run` performs the final one.
+    scheduler.run_for(1400_u64.ms()).unwrap();
+
+    let reported: Vec<String> = crate::core::log_buffer::GLOBAL_LOG_BUFFER
+        .get_since(first_unread)
+        .into_iter()
+        .map(|entry| entry.message)
+        .filter(|message| message.contains("[TELEMETRY]"))
+        .collect();
+
+    assert!(
+        reported
+            .iter()
+            .any(|m| m.contains("Export failed") && m.contains("not-a-directory")),
+        "the periodic export must report the failure and name the path it could \
+         not write; telemetry lines seen: {reported:?}"
+    );
+    assert!(
+        reported.iter().any(|m| m.contains("Final export failed")),
+        "the shutdown export must report its failure too; telemetry lines seen: {reported:?}"
+    );
+}
+
 // ============================================================================
 // Error path and negative tests
 // ============================================================================

--- a/horus_core/src/scheduling/telemetry.rs
+++ b/horus_core/src/scheduling/telemetry.rs
@@ -274,13 +274,22 @@ impl TelemetryManager {
 
     /// Export to local file
     ///
-    /// Every error names the path it was writing. The scheduler reports this
-    /// string and nothing else in that line says where the export was going —
-    /// "Permission denied (os error 13)" on its own is not something an
-    /// operator can act on.
+    /// Every error names the destination file — including the `create_dir_all`
+    /// failure, which names the parent it could not create as well, since the
+    /// two paths differ and only one of them is the thing to go fix. The
+    /// scheduler reports this string and nothing else in that line says where
+    /// the export was going — "Permission denied (os error 13)" on its own is
+    /// not something an operator can act on.
     fn export_to_file(&self, path: &PathBuf, snapshot: &TelemetrySnapshot) -> Result<(), String> {
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|e| format!("{}: {}", parent.display(), e))?;
+            fs::create_dir_all(parent).map_err(|e| {
+                format!(
+                    "{}: creating parent directory {}: {}",
+                    path.display(),
+                    parent.display(),
+                    e
+                )
+            })?;
         }
 
         let json = serde_json::to_string_pretty(snapshot).map_err(|e| e.to_string())?;

--- a/horus_core/src/scheduling/telemetry.rs
+++ b/horus_core/src/scheduling/telemetry.rs
@@ -273,15 +273,21 @@ impl TelemetryManager {
     }
 
     /// Export to local file
+    ///
+    /// Every error names the path it was writing. The scheduler reports this
+    /// string and nothing else in that line says where the export was going —
+    /// "Permission denied (os error 13)" on its own is not something an
+    /// operator can act on.
     fn export_to_file(&self, path: &PathBuf, snapshot: &TelemetrySnapshot) -> Result<(), String> {
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            fs::create_dir_all(parent).map_err(|e| format!("{}: {}", parent.display(), e))?;
         }
 
         let json = serde_json::to_string_pretty(snapshot).map_err(|e| e.to_string())?;
 
-        let mut file = File::create(path).map_err(|e| e.to_string())?;
-        file.write_all(json.as_bytes()).map_err(|e| e.to_string())?;
+        let mut file = File::create(path).map_err(|e| format!("{}: {}", path.display(), e))?;
+        file.write_all(json.as_bytes())
+            .map_err(|e| format!("{}: {}", path.display(), e))?;
 
         Ok(())
     }
@@ -293,11 +299,17 @@ impl TelemetryManager {
 
             socket
                 .send_to(json.as_bytes(), addr)
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| format!("{}: {}", addr, e))?;
 
             Ok(())
         } else {
-            Err("UDP socket not initialized".to_string())
+            // `new()` computes `enabled` before it binds, so a bind that failed
+            // (EMFILE under fd exhaustion is the realistic one) leaves an
+            // endpoint that reports itself as live and fails every export.
+            Err(format!(
+                "UDP socket not initialized at startup, cannot send to {}",
+                addr
+            ))
         }
     }
 

--- a/horus_core/src/scheduling/telemetry.rs
+++ b/horus_core/src/scheduling/telemetry.rs
@@ -274,12 +274,21 @@ impl TelemetryManager {
 
     /// Export to local file
     ///
-    /// Every error names the destination file — including the `create_dir_all`
-    /// failure, which names the parent it could not create as well, since the
-    /// two paths differ and only one of them is the thing to go fix. The
-    /// scheduler reports this string and nothing else in that line says where
-    /// the export was going — "Permission denied (os error 13)" on its own is
-    /// not something an operator can act on.
+    /// Every error names both the destination file and the operation that
+    /// failed, because the caller prints this string on its own:
+    /// `[TELEMETRY] Export failed: <this>`.
+    ///
+    /// The destination, because nothing else in that line says where the export
+    /// was going — "Permission denied (os error 13)" by itself is not something
+    /// an operator can act on. The `create_dir_all` arm names the parent it
+    /// could not create as well, since that path differs from the destination
+    /// and is the one to go fix.
+    ///
+    /// The operation, because the four failures here have four different fixes
+    /// and the errno does not separate them: `EACCES` from `create_dir_all` is
+    /// a permission on the parent directory, the same `EACCES` from
+    /// `File::create` is a permission on the file itself, and `EIO` or `ENOSPC`
+    /// can surface from either the create or the write.
     fn export_to_file(&self, path: &PathBuf, snapshot: &TelemetrySnapshot) -> Result<(), String> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
@@ -292,23 +301,33 @@ impl TelemetryManager {
             })?;
         }
 
-        let json = serde_json::to_string_pretty(snapshot).map_err(|e| e.to_string())?;
+        let json = serde_json::to_string_pretty(snapshot)
+            .map_err(|e| format!("{}: serializing snapshot: {}", path.display(), e))?;
 
-        let mut file = File::create(path).map_err(|e| format!("{}: {}", path.display(), e))?;
+        let mut file =
+            File::create(path).map_err(|e| format!("{}: creating file: {}", path.display(), e))?;
         file.write_all(json.as_bytes())
-            .map_err(|e| format!("{}: {}", path.display(), e))?;
+            .map_err(|e| format!("{}: writing file: {}", path.display(), e))?;
 
         Ok(())
     }
 
     /// Export to UDP endpoint
+    ///
+    /// Every arm names the destination and the operation, for the reason given
+    /// on `export_to_file`: the caller prints this string on its own. Here the
+    /// operation is what separates "the datagram did not leave this host"
+    /// (`send_to`) from "the snapshot never became bytes" (serialisation) —
+    /// one is a network or route problem, the other is a bug in this process,
+    /// and both would otherwise read as a bare address followed by an errno.
     fn export_to_udp(&self, addr: &str, snapshot: &TelemetrySnapshot) -> Result<(), String> {
         if let Some(ref socket) = self.udp_socket {
-            let json = serde_json::to_string(snapshot).map_err(|e| e.to_string())?;
+            let json = serde_json::to_string(snapshot)
+                .map_err(|e| format!("{}: serializing snapshot: {}", addr, e))?;
 
             socket
                 .send_to(json.as_bytes(), addr)
-                .map_err(|e| format!("{}: {}", addr, e))?;
+                .map_err(|e| format!("{}: sending over udp: {}", addr, e))?;
 
             Ok(())
         } else {


### PR DESCRIPTION
Both production callers of `TelemetryManager::export()` were `let _ =
tm.export();` — the periodic export in `periodic_monitoring` and the final
export in `finalize_run`. `export()` returns a precise error for every real
failure mode (an unwritable `file://` path, a UDP socket that never bound, an
HTTP export thread that has exited) and nothing inside `export()`,
`export_to_file` or `export_to_udp` logs, so a misconfigured endpoint produced
no diagnostic on any surface. `export()` also advances `last_export` whether or
not the snapshot landed, so the failing export simply rescheduled itself every
interval for the life of the process — under the
"[SCHEDULER] Telemetry enabled (endpoint: ...)" line printed at startup, which
nothing ever corrected. The blackbox save nine lines above the shutdown export
already reports its failure; telemetry was the outlier.

Both callsites now report through `hlog!(warn, ...)`. Not the `log::` facade the
HTTP export thread uses: `log::` only reaches an operator if something installed
a logger and only the CLI does (`try_init_log_bridge` in horus_manager), while
`horus run` executes the robot binary as a subprocess — so `log::warn!` from a
scheduler in that binary is a no-op. `hlog!` writes to the shared log buffer
(`horus log`, `horus monitor`) and the console unconditionally.

No throttle: `should_export()` already gates the periodic path to one call per
export interval (1000 ms at both construction sites), so a permanently broken
endpoint costs one line per second — the rate an RT deadline miss is already
allowed (`DiagThrottle::WINDOW_NS`).

`export_to_file` and `export_to_udp` now name the path/address in their errors.
The reported line is the only place the destination could appear, and
"Permission denied (os error 13)" on its own is not actionable.

## Ablation

```
Reverted ONLY the production files (`git checkout -- horus_core/src/scheduling/scheduler/mod.rs horus_core/src/scheduling/telemetry.rs`), kept the new test, and ran `cargo test -p horus_core --lib telemetry_export_failures_reach_the_log`:

=== HORUS Crash Report ===
Scheduler: Scheduler
PID: 1578803
Thread: scheduling::scheduler::tests::telemetry_export_failures_reach_the_log
Location: horus_core/src/scheduling/scheduler/tests.rs:3475:5
Panic: the periodic export must report the failure and name the path it could not write; telemetry lines seen: []
Blackbox flushed: false
===========================

test scheduling::scheduler::tests::telemetry_export_failures_reach_the_log ... FAILED

failures:

---- scheduling::scheduler::tests::telemetry_export_failures_reach_the_log stdout ----

thread 'scheduling::scheduler::tests::telemetry_export_failures_reach_the_log' (1578804) panicked at horus_core/src/scheduling/scheduler/tests.rs:3475:5:
the periodic export must report the failure and name the path it could not write; telemetry lines seen: []
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    scheduling::scheduler::tests::telemetry_export_failures_reach_the_log

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2499 filtered out; finished in 1.43s

The test compiles unchanged against the reverted tree (it uses only the public `Scheduler` API and `GLOBAL_LOG_BUFFER`), so this is a behavioural failure, not a compile error: the scheduler ran a full 1.4 s with a broken `file://` endpoint and emitted zero `[TELEMETRY]` lines — exactly the defect. Production files were then restored from a scratchpad copy and the test passes again (verified 3 consecutive runs).

With the fix in place the two lines actually emitted are:
[WARN] [unknown] [TELEMETRY] Export failed: /tmp/.tmpllPKvx/not-a-directory: File exists (os error 17)
[WARN] [unknown] [TELEMETRY] Final export failed: /tmp/.tmpllPKvx/not-a-directory: File exists (os error 17)
```

## Tests

```
Touched crate: horus_core.

- `cargo test -p horus_core --lib` (full lib suite, with fix): 2495 passed, 1 failed, 4 ignored, 73.67 s. The single failure is `communication::topic::tests::no_message_is_lost_without_being_counted` ("MpscShm: 5000 messages were accepted but 591 are accounted for"), which is PRE-EXISTING and unrelated: I `git stash`-ed all three of my files and it fails identically on the untouched tree (`test result: FAILED. 0 passed; 1 failed ... finished in 5.05s`).
- `cargo test -p horus_core --lib telemetry` (9 tests: the new one plus the existing telemetry/config/builder tests): ok, 9 passed, 0 failed — run 3 times (1.41 s / 1.55 s / 1.42 s), no flakes.
- `cargo test -p horus_core --lib scheduling::` run under heavy concurrent load: 785 passed, 3 failed — `test_recording_overhead_benchmark`, `large_graph_performance`, `test_tick_hz_very_large`, all timing/throughput assertions unrelated to telemetry. All three passed in the full-suite run above and pass in isolation afterwards (`test result: ok. 3 passed`), so they are load flakes on this machine, not regressions.
- `cargo fmt --all --check`: clean.
- `cargo clippy -p horus_core --lib --all-targets`: no warnings, no errors.
```

## Notes from the implementer

CONFIRMED the finding independently before fixing: `let _ = tm.export();` at scheduler/mod.rs:3759 (periodic) and :4082 (shutdown) were the only non-test callers; `export()` sets `last_export` unconditionally at telemetry.rs:271; no `log::`/`print_line`/`eprint` anywhere in telemetry.rs:234-302; the blackbox save nine lines above the shutdown export does report its failure. The ablation above is the empirical proof: a real scheduler with an unwritable `file://` endpoint ran to completion and said nothing.

Two deliberate deviations from the suggested fix, both argued in the code comments:
1. The finding suggested `log::warn!`. I used `hlog!(warn, ...)` instead. `log::` macros are no-ops unless a logger is installed, and `try_init_log_bridge` is called in exactly one place in the repo — `horus_manager/src/main.rs:2385`, the CLI process. `horus run` spawns the user's robot binary as a subprocess (`horus_manager/src/commands/run/run_rust.rs`), and that process installs no logger, so `log::warn!` from the scheduler there would have been dropped — the same silence in a different costume. `hlog!` writes to GLOBAL_LOG_BUFFER (`horus log`, `horus monitor --tui`) and the console unconditionally. I verified the grep (only horus_manager installs the bridge) but did NOT build and run a standalone robot binary to observe `log::warn!` being dropped in practice.
2. No rate limiting was added. `should_export()` gates the periodic path to one call per interval and both construction sites (mod.rs:1654, :2643) hardcode 1000 ms, giving at most one line per second — the rate `DiagThrottle::WINDOW_NS` already grants a persistent RT deadline miss. I deliberately avoided `hlog_every!`: its counter lives in a `static` at the expansion point, which the codebase itself documents as a trap (scheduling/types.rs:450, `throttle_state_is_per_node_not_per_call_site`), and it would also make the test order-dependent. If `TelemetryManager::new`'s `interval_ms` is ever wired to a small user-configured

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
