### PR TITLE
fix(topic): a participant slot is only free once its thread has ended

### DIFF
--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -5,7 +5,7 @@
 //! rendezvous. It contains participant tracking, topology detection, and
 //! migration coordination.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::mem;
 use std::mem::offset_of;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
@@ -1931,33 +1931,73 @@ pub(crate) fn hash_thread_id(id: std::thread::ThreadId) -> u64 {
 /// Process-local rather than another shared-memory field, because the entries
 /// that pass can touch are already restricted to `pid == ours`: a foreign
 /// process's participants are judged by `is_process_alive` instead, and a
-/// process-local set needs no header version bump and no `ParticipantEntry`
+/// process-local map needs no header version bump and no `ParticipantEntry`
 /// bytes.
 ///
-/// # The key is a 32-bit hash, and 32-bit hashes collide
+/// # The key is a 32-bit hash, and 32-bit hashes collide — hence the count
 ///
 /// `ParticipantEntry::thread_id_hash` is already `u32`, and already
 /// load-bearing: the FIRST pass of `register_role` matches on it to find this
 /// thread's own entry. A collision there is the dangerous direction — a new
 /// thread silently adopts a live thread's registration and its role bits.
-/// Here it is the safe one, and only the safe one: a collision can only make
-/// this set answer "live" for a thread that has ended, which costs one
-/// reclaimable slot and surfaces as the existing "No available participant
-/// slots" error. Loud, and it says what to do about it.
 ///
-/// So widening is not worth what it costs: `thread_id_hash` is a
+/// Here a collision must be made the SAFE direction, and a plain set of hashes
+/// does not manage it. Two live threads sharing a hash would insert one key
+/// between them, and the first of the two to exit would take it back out —
+/// leaving the other still running, still holding its slot, and reading as
+/// dead. Pass 3 would then reclaim a live subscriber's slot, which is the
+/// entire bug this registry exists to prevent, merely made rarer.
+///
+/// So the value is a count of the live threads carrying that hash, not a
+/// membership bit: `retain_thread_hash` increments, `release_thread_hash`
+/// decrements and removes only at zero. The remaining collision effect is
+/// one-directional and benign — a live thread keeps an ENDED thread's slot
+/// looking live, which costs one reclaimable slot and surfaces as the existing
+/// "No available participant slots" error. Loud, and it says what to do.
+///
+/// (Rust's `ThreadId` itself is guaranteed never to be reused within a
+/// process, even after a thread terminates, so hash truncation to `u32` is the
+/// only source of collisions here.)
+///
+/// Widening is still not worth what it costs: `thread_id_hash` is a
 /// shared-memory field whose struct has `size_of::<ParticipantEntry>() == 24`
 /// asserted in two places (this module's tests and `topic/tests.rs`), and
 /// growing it means a `TOPIC_VERSION` bump that every already-mapped segment
 /// pays for. If the pass-0 collision is ever worth closing, widen the field
-/// once, for that reason, and this set follows for free.
-static LIVE_THREADS: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
+/// once, for that reason, and this map follows for free.
+static LIVE_THREADS: OnceLock<Mutex<HashMap<u32, usize>>> = OnceLock::new();
 
-fn live_threads() -> &'static Mutex<HashSet<u32>> {
-    LIVE_THREADS.get_or_init(|| Mutex::new(HashSet::new()))
+fn live_threads() -> &'static Mutex<HashMap<u32, usize>> {
+    LIVE_THREADS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Takes this thread's hash back out of [`LIVE_THREADS`] when the thread ends.
+/// Count this thread in as an owner of slots keyed by `thread_hash`.
+fn retain_thread_hash(thread_hash: u32) {
+    *live_threads()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .entry(thread_hash)
+        .or_insert(0) += 1;
+}
+
+/// Count one owner back out, dropping the key only when the last one goes.
+fn release_thread_hash(thread_hash: u32) {
+    let mut live = live_threads().lock().unwrap_or_else(|e| e.into_inner());
+    if let std::collections::hash_map::Entry::Occupied(mut slot) = live.entry(thread_hash) {
+        // Saturating for the same reason the role counters are: an unmatched
+        // decrement here would wrap to `usize::MAX` and pin the hash live for
+        // the rest of the process. Every `retain` is paired with exactly one
+        // `release` by `LiveThreadTicket`, so this floor should be unreachable.
+        let remaining = slot.get().saturating_sub(1);
+        if remaining == 0 {
+            slot.remove();
+        } else {
+            *slot.get_mut() = remaining;
+        }
+    }
+}
+
+/// Counts this thread back out of [`LIVE_THREADS`] when the thread ends.
 ///
 /// Thread exit is the event that makes a slot genuinely reclaimable, and a
 /// thread-local's destructor is the only notification of it this crate gets:
@@ -1967,10 +2007,7 @@ struct LiveThreadTicket(u32);
 
 impl Drop for LiveThreadTicket {
     fn drop(&mut self) {
-        live_threads()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&self.0);
+        release_thread_hash(self.0);
     }
 }
 
@@ -1981,8 +2018,8 @@ thread_local! {
 
 /// Record this thread as a live owner of participant slots.
 ///
-/// The hash goes into the set only from inside the thread-local that will take
-/// it out again: an entry with no ticket behind it would mark the thread live
+/// The hash is counted in only from inside the thread-local that will count it
+/// back out again: a retain with no ticket behind it would mark the thread live
 /// for the life of the process and make every slot it holds permanently
 /// unreclaimable — trading a wrong steal for a slow leak. `try_with` fails only
 /// while this thread's TLS is already being destroyed, and a thread that far
@@ -1991,10 +2028,7 @@ fn mark_thread_live(thread_hash: u32) {
     let _ = LIVE_THREAD_TICKET.try_with(|ticket| {
         let mut ticket = ticket.borrow_mut();
         if ticket.is_none() {
-            live_threads()
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(thread_hash);
+            retain_thread_hash(thread_hash);
             *ticket = Some(LiveThreadTicket(thread_hash));
         }
     });
@@ -2005,7 +2039,7 @@ fn thread_is_live(thread_hash: u32) -> bool {
     live_threads()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .contains(&thread_hash)
+        .contains_key(&thread_hash)
 }
 
 /// Monotonic milliseconds — the timebase for every timestamp this header keeps.
@@ -3049,6 +3083,48 @@ mod tests {
 
             release_tx.send(()).ok();
         });
+    }
+
+    /// Two live threads sharing one truncated hash: the first to end must not
+    /// carry the second's slot out of the registry with it.
+    ///
+    /// `thread_id_hash` is a `u64` hash truncated to `u32`, so distinct threads
+    /// can collide. A plain `HashSet<u32>` stored one key for both, and the
+    /// first exit removed it — leaving a still-running thread reading as dead
+    /// and its slot reclaimable by pass 3, which is precisely the live-slot
+    /// steal this registry exists to prevent. The count is what makes the
+    /// collision one-directional.
+    ///
+    /// Driven through `retain`/`release` rather than two real threads because a
+    /// `u32` collision cannot be provoked from `ThreadId`s on demand. The key is
+    /// a sentinel no participant in this process carries: `mark_thread_live`
+    /// only ever inserts a real `hash_thread_id`, and `plant_participant` uses
+    /// `0xDEAD_BEEF`, so nothing else in the suite touches this entry.
+    #[test]
+    fn a_hash_shared_by_two_live_threads_survives_the_first_exit() {
+        const COLLIDING: u32 = 0x0BAD_5107;
+
+        assert!(!thread_is_live(COLLIDING), "sentinel starts unused");
+
+        retain_thread_hash(COLLIDING); // thread A claims a slot
+        retain_thread_hash(COLLIDING); // thread B collides, claims another
+        assert!(thread_is_live(COLLIDING));
+
+        release_thread_hash(COLLIDING); // A ends
+        assert!(
+            thread_is_live(COLLIDING),
+            "B is still running and still owns its slot, so the hash is still live"
+        );
+
+        release_thread_hash(COLLIDING); // B ends
+        assert!(
+            !thread_is_live(COLLIDING),
+            "the last owner is gone, so the slot is genuinely reclaimable"
+        );
+
+        // Unmatched release is floored, not wrapped to usize::MAX.
+        release_thread_hash(COLLIDING);
+        assert!(!thread_is_live(COLLIDING));
     }
 
     // ── Topology detection ──────────────────────────────────────────────

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -879,6 +879,12 @@ impl TopicHeader {
             if p.source_host.load(Ordering::Acquire) != 0 || p.pid.load(Ordering::Acquire) != pid {
                 continue;
             }
+            // Locked per candidate rather than once around the loop: the body
+            // below calls `finish_claim`, which takes this same lock through
+            // `mark_thread_live`, and `std::sync::Mutex` is not reentrant — a
+            // guard held across the loop would deadlock the registration it is
+            // meant to speed up. The cost it saves is at most MAX_PARTICIPANTS
+            // = 16 uncontended locks on a startup-shaped path.
             if thread_is_live(p.thread_id_hash.load(Ordering::Acquire)) {
                 continue;
             }
@@ -1927,6 +1933,24 @@ pub(crate) fn hash_thread_id(id: std::thread::ThreadId) -> u64 {
 /// process's participants are judged by `is_process_alive` instead, and a
 /// process-local set needs no header version bump and no `ParticipantEntry`
 /// bytes.
+///
+/// # The key is a 32-bit hash, and 32-bit hashes collide
+///
+/// `ParticipantEntry::thread_id_hash` is already `u32`, and already
+/// load-bearing: the FIRST pass of `register_role` matches on it to find this
+/// thread's own entry. A collision there is the dangerous direction — a new
+/// thread silently adopts a live thread's registration and its role bits.
+/// Here it is the safe one, and only the safe one: a collision can only make
+/// this set answer "live" for a thread that has ended, which costs one
+/// reclaimable slot and surfaces as the existing "No available participant
+/// slots" error. Loud, and it says what to do about it.
+///
+/// So widening is not worth what it costs: `thread_id_hash` is a
+/// shared-memory field whose struct has `size_of::<ParticipantEntry>() == 24`
+/// asserted in two places (this module's tests and `topic/tests.rs`), and
+/// growing it means a `TOPIC_VERSION` bump that every already-mapped segment
+/// pays for. If the pass-0 collision is ever worth closing, widen the field
+/// once, for that reason, and this set follows for free.
 static LIVE_THREADS: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
 
 fn live_threads() -> &'static Mutex<HashSet<u32>> {
@@ -2960,57 +2984,71 @@ mod tests {
     #[test]
     fn a_running_thread_never_loses_its_slot_to_a_new_registration() {
         let h = make_header(8, 8, true, 16);
-        let header_ptr = &h as *const TopicHeader as usize;
 
-        // A subscriber on another thread, parked for the whole test so there is
-        // no doubt it is still there.
-        let (registered_tx, registered_rx) = std::sync::mpsc::channel();
-        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
-        let victim = std::thread::spawn(move || {
-            // SAFETY: header_ptr was derived from a valid stack-allocated TopicHeader that
-            // outlives this thread (main thread joins before h is dropped).
-            let h = unsafe { &*(header_ptr as *const TopicHeader) };
-            let slot = h.register_consumer().expect("subscriber registers");
-            let hash = hash_thread_id(std::thread::current().id()) as u32;
-            registered_tx.send((slot, hash)).unwrap();
-            release_rx.recv().ok();
-        });
-        let (victim_slot, victim_hash) = registered_rx.recv().expect("subscriber registered");
-        assert_eq!(h.sub_count(), 1);
+        // `scope`, not `spawn`: the victim borrows `&h` directly, so the test
+        // needs no raw pointer and no `unsafe` — `TopicHeader` is all atomics
+        // and PODs, so it is `Sync` on its own. The scope's join is also what
+        // makes the borrow sound on the FAILURE path: with `spawn`, an assertion
+        // that fired below unwound the test frame and dropped `h` while the
+        // still-parked victim held a pointer into it.
+        std::thread::scope(|s| {
+            // The channels live inside the scope so that an assertion failure
+            // drops `release_tx` as it unwinds. That releases the victim, and
+            // the scope's join finishes instead of hanging on a parked thread.
+            let (registered_tx, registered_rx) = std::sync::mpsc::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
 
-        // Its lease has run out — all that says is that it has been polling
-        // below the refresh rate.
-        h.participants[victim_slot]
-            .lease_expires_ms
-            .store(1, Ordering::Release);
+            // A subscriber on another thread, parked for the whole test so there
+            // is no doubt it is still there.
+            let header = &h;
+            s.spawn(move || {
+                let slot = header.register_consumer().expect("subscriber registers");
+                let hash = hash_thread_id(std::thread::current().id()) as u32;
+                registered_tx.send((slot, hash)).unwrap();
+                release_rx.recv().ok();
+            });
+            let (victim_slot, victim_hash) = registered_rx.recv().expect("subscriber registered");
+            assert_eq!(h.sub_count(), 1);
 
-        // Every other slot is held, with a lease that is still good, so the two
-        // safe passes find nothing and the last resort runs.
-        let fresh = current_time_ms() + 60_000;
-        for i in 0..MAX_PARTICIPANTS {
-            if i != victim_slot {
-                plant_participant(&h, i, std::process::id(), 1, fresh);
+            // Its lease has run out — all that says is that it has been polling
+            // below the refresh rate.
+            h.participants[victim_slot]
+                .lease_expires_ms
+                .store(1, Ordering::Release);
+
+            // Every other slot is held, with a lease that is still good, so the
+            // two safe passes find nothing and the last resort runs.
+            let fresh = current_time_ms() + 60_000;
+            for i in 0..MAX_PARTICIPANTS {
+                if i != victim_slot {
+                    plant_participant(&h, i, std::process::id(), 1, fresh);
+                }
             }
-        }
 
-        let result = h.register_producer();
+            let result = h.register_producer();
 
-        assert!(
-            result.is_err(),
-            "the only reclaimable-looking slot belongs to a thread that is still \
-             running, so there is no slot to hand out; got {result:?}"
-        );
-        assert_eq!(
-            h.sub_count(),
-            1,
-            "the running subscriber is still registered and still reading"
-        );
-        let entry = &h.participants[victim_slot];
-        assert_eq!(entry.thread_id_hash.load(Ordering::Acquire), victim_hash);
-        assert_eq!(entry.role.load(Ordering::Acquire), 2);
+            assert!(
+                result.is_err(),
+                "the only reclaimable-looking slot belongs to a thread that is still \
+                 running, so there is no slot to hand out; got {result:?}"
+            );
+            assert_eq!(
+                h.sub_count(),
+                1,
+                "the running subscriber is still registered and still reading"
+            );
+            let entry = &h.participants[victim_slot];
+            assert_eq!(entry.thread_id_hash.load(Ordering::Acquire), victim_hash);
+            assert_eq!(
+                entry.role.load(Ordering::Acquire),
+                2,
+                "still exactly the bit `register_consumer` sets — `register_role(2, \
+                 &self.subscriber_count)` — not overwritten by the producer that \
+                 tried to take the slot"
+            );
 
-        release_tx.send(()).ok();
-        victim.join().unwrap();
+            release_tx.send(()).ok();
+        });
     }
 
     // ── Topology detection ──────────────────────────────────────────────

--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -5,9 +5,11 @@
 //! rendezvous. It contains participant tracking, topology detection, and
 //! migration coordination.
 
+use std::collections::HashSet;
 use std::mem;
 use std::mem::offset_of;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use crate::error::{HorusError, HorusResult};
 
@@ -765,6 +767,10 @@ impl TopicHeader {
         now_ms: u64,
         timeout_ms: u64,
     ) {
+        // The one place a thread takes ownership of a slot, so the one place to
+        // record it as a live owner: the last-resort pass in `register_role`
+        // refuses to reclaim an entry whose thread is still running.
+        mark_thread_live(thread_hash);
         p.pid.store(pid, Ordering::Release);
         p.thread_id_hash.store(thread_hash, Ordering::Release);
         p.role.store(role_bit, Ordering::Release);
@@ -846,10 +852,23 @@ impl TopicHeader {
         }
 
         // Pass 3, last resort: a stale entry belonging to a thread of THIS
-        // process. `Drop for Topic` does not deregister, so a finished thread's
-        // slot is never reclaimed by anything else — and the reaper skips our
-        // own pid deliberately, because it cannot tell a departed thread from a
-        // busy one. A foreign live pid is never stolen.
+        // process that has ENDED. `Drop for Topic` does not deregister, so a
+        // finished thread's slot is never reclaimed by anything else — and the
+        // reaper skips our own pid deliberately, because it cannot tell a
+        // departed thread from a busy one. A foreign live pid is never stolen.
+        //
+        // "Ended" is asked of `thread_is_live`, not of the lease. The lease was
+        // the whole bug the paragraph above describes, and passes 1-2 only
+        // removed it for the case where a free slot exists: leases refresh every
+        // `LEASE_CHECK_INTERVAL` = 64 polls (dispatch.rs), so a subscriber
+        // polling at 1 Hz sits expired for ~92% of every cycle while draining
+        // the ring normally. Stealing from it decrements `subscriber_count`
+        // under a live reader — the under-count direction, the dangerous one:
+        // `nothing_is_draining` then sees `sub_count() == 0` and the lossy
+        // `send` starts retiring slots the victim has not read yet, and the
+        // victim never recovers, because `ensure_role` short-circuits on the
+        // role it already believes it holds. Refusing the registration outright
+        // is the honest alternative.
         for (i, p) in self.participants.iter().enumerate() {
             if p.active.load(Ordering::Acquire) != 1 {
                 continue;
@@ -858,6 +877,9 @@ impl TopicHeader {
                 continue;
             }
             if p.source_host.load(Ordering::Acquire) != 0 || p.pid.load(Ordering::Acquire) != pid {
+                continue;
+            }
+            if thread_is_live(p.thread_id_hash.load(Ordering::Acquire)) {
                 continue;
             }
             if p.active
@@ -1888,6 +1910,80 @@ pub(crate) fn hash_thread_id(id: std::thread::ThreadId) -> u64 {
     hasher.finish()
 }
 
+/// Thread hashes of THIS process that own a participant slot and are still
+/// running.
+///
+/// `register_role`'s last-resort pass reclaims a lease-expired slot from our own
+/// pid — nothing else can, because `Drop` does not deregister (see
+/// `tests/participant_count_leak.rs` for why that is still open) and the reaper
+/// skips our own pid deliberately. What it must not do is take one from a thread
+/// that is still using it, and the lease cannot tell it apart: leases are
+/// refreshed every `LEASE_CHECK_INTERVAL` = 64 polls (dispatch.rs), so a
+/// subscriber polling at 1 Hz — an ordinary robotics rate — is expired for most
+/// of every cycle while reading perfectly well.
+///
+/// Process-local rather than another shared-memory field, because the entries
+/// that pass can touch are already restricted to `pid == ours`: a foreign
+/// process's participants are judged by `is_process_alive` instead, and a
+/// process-local set needs no header version bump and no `ParticipantEntry`
+/// bytes.
+static LIVE_THREADS: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
+
+fn live_threads() -> &'static Mutex<HashSet<u32>> {
+    LIVE_THREADS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Takes this thread's hash back out of [`LIVE_THREADS`] when the thread ends.
+///
+/// Thread exit is the event that makes a slot genuinely reclaimable, and a
+/// thread-local's destructor is the only notification of it this crate gets:
+/// the participant table is in shared memory and the handles that registered
+/// against it are long gone by then.
+struct LiveThreadTicket(u32);
+
+impl Drop for LiveThreadTicket {
+    fn drop(&mut self) {
+        live_threads()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.0);
+    }
+}
+
+thread_local! {
+    static LIVE_THREAD_TICKET: std::cell::RefCell<Option<LiveThreadTicket>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Record this thread as a live owner of participant slots.
+///
+/// The hash goes into the set only from inside the thread-local that will take
+/// it out again: an entry with no ticket behind it would mark the thread live
+/// for the life of the process and make every slot it holds permanently
+/// unreclaimable — trading a wrong steal for a slow leak. `try_with` fails only
+/// while this thread's TLS is already being destroyed, and a thread that far
+/// into its exit has no slot worth protecting.
+fn mark_thread_live(thread_hash: u32) {
+    let _ = LIVE_THREAD_TICKET.try_with(|ticket| {
+        let mut ticket = ticket.borrow_mut();
+        if ticket.is_none() {
+            live_threads()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(thread_hash);
+            *ticket = Some(LiveThreadTicket(thread_hash));
+        }
+    });
+}
+
+/// True while a thread of this process carrying this hash is still running.
+fn thread_is_live(thread_hash: u32) -> bool {
+    live_threads()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains(&thread_hash)
+}
+
 /// Monotonic milliseconds — the timebase for every timestamp this header keeps.
 ///
 /// Participant leases, `last_topology_change_ms` and the drain-stall detector
@@ -2848,6 +2944,73 @@ mod tests {
         .join()
         .unwrap();
         result.unwrap_err();
+    }
+
+    /// A slot may only be taken from a thread that has ENDED.
+    ///
+    /// `register_role`'s last-resort pass reclaims a lease-expired slot held by
+    /// our own pid, and an expired lease proves nothing about the owner: leases
+    /// refresh every `LEASE_CHECK_INTERVAL` = 64 polls (dispatch.rs), so a
+    /// subscriber polling at 1 Hz is expired for ~92% of every cycle while
+    /// draining the ring normally. Taking its slot decremented
+    /// `subscriber_count` under a live reader, after which `nothing_is_draining`
+    /// reads `sub_count() == 0` and the lossy `send` retires slots that reader
+    /// has not taken yet — the same silent loss passes 1-2 were introduced to
+    /// eliminate, still reachable through pass 3 whenever the table is full.
+    #[test]
+    fn a_running_thread_never_loses_its_slot_to_a_new_registration() {
+        let h = make_header(8, 8, true, 16);
+        let header_ptr = &h as *const TopicHeader as usize;
+
+        // A subscriber on another thread, parked for the whole test so there is
+        // no doubt it is still there.
+        let (registered_tx, registered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let victim = std::thread::spawn(move || {
+            // SAFETY: header_ptr was derived from a valid stack-allocated TopicHeader that
+            // outlives this thread (main thread joins before h is dropped).
+            let h = unsafe { &*(header_ptr as *const TopicHeader) };
+            let slot = h.register_consumer().expect("subscriber registers");
+            let hash = hash_thread_id(std::thread::current().id()) as u32;
+            registered_tx.send((slot, hash)).unwrap();
+            release_rx.recv().ok();
+        });
+        let (victim_slot, victim_hash) = registered_rx.recv().expect("subscriber registered");
+        assert_eq!(h.sub_count(), 1);
+
+        // Its lease has run out — all that says is that it has been polling
+        // below the refresh rate.
+        h.participants[victim_slot]
+            .lease_expires_ms
+            .store(1, Ordering::Release);
+
+        // Every other slot is held, with a lease that is still good, so the two
+        // safe passes find nothing and the last resort runs.
+        let fresh = current_time_ms() + 60_000;
+        for i in 0..MAX_PARTICIPANTS {
+            if i != victim_slot {
+                plant_participant(&h, i, std::process::id(), 1, fresh);
+            }
+        }
+
+        let result = h.register_producer();
+
+        assert!(
+            result.is_err(),
+            "the only reclaimable-looking slot belongs to a thread that is still \
+             running, so there is no slot to hand out; got {result:?}"
+        );
+        assert_eq!(
+            h.sub_count(),
+            1,
+            "the running subscriber is still registered and still reading"
+        );
+        let entry = &h.participants[victim_slot];
+        assert_eq!(entry.thread_id_hash.load(Ordering::Acquire), victim_hash);
+        assert_eq!(entry.role.load(Ordering::Acquire), 2);
+
+        release_tx.send(()).ok();
+        victim.join().unwrap();
     }
 
     // ── Topology detection ──────────────────────────────────────────────


### PR DESCRIPTION
`register_role`'s last-resort pass (pass 3) took any lease-expired slot
belonging to this process and decremented the role counter under it. An
expired lease is not evidence that the owner is gone: `housekeep_recv!` /
`housekeep_epoch!` refresh only every `LEASE_CHECK_INTERVAL` = 64 polls
(dispatch.rs:493), so a subscriber polling at 1 Hz — an ordinary robotics
rate — sits expired for roughly 92% of every cycle while draining the ring
perfectly well.

So the pass deregistered live subscribers. This is exactly the failure the
comment above passes 1-2 already describes ("it decremented `subscriber_count`
for a participant that was still reading... Silent message loss, with no
counter to show it") — passes 1-2 only removed it for the case where a free
slot EXISTS. With all 16 slots taken it was still reachable, and the scan runs
in index order, so the slot it takes first is the earliest registrant:
typically the subscriber.

The victim never recovers. `ensure_role` (mod.rs:1651) short-circuits on
`local.role.can_recv()`, so it never re-registers, and `refresh_lease` writes
only `lease_expires_ms` — through the stale `local.slot_index` it now refreshes
the THIEF's lease. Meanwhile `sub_count()` reads 0 on a topic with a live
reader, `nothing_is_draining` (mod.rs:2909) returns true on that alone, and the
lossy `send` starts retiring ring slots the reader has not taken yet.

A full participant table is not an exotic state: nothing deregisters, so slots
leak one per distinct thread that touches the topic. `tests/participant_count_leak.rs`
documents that leak as open, and records that deregistering in `Drop` was
implemented, measured and rejected — a handle cannot tell its own registration
from a later one in the same slot.

Fix: pass 3 asks whether the owning thread is still running instead of asking
the lease. Process-local, because the entries that pass may touch are already
restricted to `pid == ours` (a foreign process's participants are judged by
`is_process_alive`): a thread records its hash in a small set when it claims a
slot, and a thread-local destructor takes it back out when the thread ends —
which is the event that actually makes a slot reclaimable. No `ParticipantEntry`
byte, no `TOPIC_VERSION` bump, no `/proc` and no platform split. A finished
thread's slot is still reclaimed exactly as before.

The visible behaviour change: a registration that used to succeed by stealing
from a live thread now fails with the existing "No available participant slots"
error, whose message already tells the operator what to do. That is the honest
answer — refusing to register is loud, and under-counting subscribers is the
direction this tree already documents as the dangerous one.

Gate: with only the liveness check removed (registry and test kept) the new
test fails on its first assertion — `got Ok(0)`: the registration took slot 0
from a subscriber thread that was still parked in the test.

horus_core lib: 2497 passed / 1 failed and 2496 passed / 2 failed on two runs
of the full suite on a machine at load ~40; the three failures were different
tests each time, all wall-clock or single-threaded cases that cannot reach
pass 3, and each passes in isolation. clippy clean (`--lib --all-features` and
`--tests`), `cargo fmt --all --check` clean.

## Ablation

```
Reverted ONLY the production gate — deleted the three lines

    if thread_is_live(p.thread_id_hash.load(Ordering::Acquire)) {
        continue;
    }

from pass 3 of `register_role` (the registry, `mark_thread_live` in
`finish_claim`, and the test all kept; `thread_is_live` got a temporary
`#[allow(dead_code)]` so the crate still compiled). Exact output of
`cargo test -p horus_core --lib communication::topic::header::tests::a_running_thread_never_loses_its_slot`:

    running 1 test
    test communication::topic::header::tests::a_running_thread_never_loses_its_slot_to_a_new_registration ... FAILED

    failures:

    ---- communication::topic::header::tests::a_running_thread_never_loses_its_slot_to_a_new_registration stdout ----

    thread 'communication::topic::header::tests::a_running_thread_never_loses_its_slot_to_a_new_registration' (1848136) panicked at horus_core/src/communication/topic/header.rs:2996:9:
    the only reclaimable-looking slot belongs to a thread that is still running, so there is no slot to hand out; got Ok(0)
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


    failures:
        communication::topic::header::tests::a_running_thread_never_loses_its_slot_to_a_new_registration

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2501 filtered out; finished in 0.00s

    error: test failed, to rerun pass `-p horus_core --lib`

`Ok(0)` is the theft itself: the new registration was handed slot 0, the slot
the still-parked subscriber thread holds. The production change was then
restored and the test re-run: 1 passed.
```

## Tests

```
All in /home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-11, on a machine at load average ~40 (12 cores) shared with sibling sessions.

- New test alone, with the fix: `cargo test -p horus_core --lib ... a_running_thread_never_loses_its_slot_to_a_new_registration` → 1 passed; 0 failed (run twice: once before the final comment edits, once on the final tree).
- Touched module: `cargo test -p horus_core --lib communication::topic::header::tests` → 95 passed; 0 failed; 0 ignored, 0.09s.
- Touched crate, full lib suite, run 1: 2497 passed; 1 failed; 4 ignored, 58.33s. Failure: `communication::topic::tests::no_message_is_lost_without_being_counted` (SpmcShm: 2861 of 5000 accounted). That test then passed 3/3 when run alone (4.24s, 0.17s, 0.22s).
- Touched crate, full lib suite, run 2: 2496 passed; 2 failed; 4 ignored, 80.95s. Different failures: `scheduling::scheduler::tests::test_panicking_node_doesnt_starve_others` and `scheduling::scheduler::tests::test_parallel_rt_nodes_run_sequentially` — both "node never ticked" assertions over a 500ms/1000ms wall-clock window. `no_message_is_lost_without_being_counted` passed in this run.
- `cargo clippy -p horus_core --lib --all-features` → Finished, no warnings.
- `cargo clippy -p horus_core --tests` → Finished, no warning/error lines at all (this is the invocation that lints the new unit test).
- `cargo fmt --all -- --check` → clean.
```

## Notes from the implementer

CONFIRMED the finding by reading the code myself; the claim's mechanism holds at every step I checked:
- header.rs pass 3 guards are exactly `active == 1`, `is_lease_expired`, `source_host == 0`, `pid == ours`, then `decrement_to_floor(&self.subscriber_count)`. No liveness test of any kind.
- `Drop for RingTopic` (mod.rs) never touches `header.participants`, so slots leak per thread. `horus_core/tests/participant_count_leak.rs` documents that leak as a known-open defect AND records that the obvious `Drop` deregistration was built, measured (0/0/0 failures on main vs 0/3/2 with it) and rejected — which is why I did not take the finding's second suggestion.
- `ensure_role` (mod.rs:1651) short-circuits on `local.role.can_recv()`, so a robbed subscriber never re-registers; worse, its later `refresh_lease` goes through the stale `local.slot_index` and refreshes the thief's lease.
- `nothing_is_draining` (mod.rs:2909) returns true on `sub_count() == 0` alone, and its only caller is `send_lossy_retry`, which then does `header.tail.fetch_max(head - (capacity - 1))` — retiring an unread slot. So the loss is real but confined to the lossy `send`; `try_send`/`send_blocking` are explicitly excluded. My comments say "the lossy `send`" rather than repeating the finding's overstated "any backpressured topic".

Design choice worth a reviewer's attention: I rejected the finding's first suggestion (store the OS tid in `ParticipantEntry` and stat `/proc/self/task/<tid>`) because the entry is a versioned shared-memory struct with a `size_of == 24` assertion in two test files, and because it would be Linux-only. Only entries with `pid == ours` are reachable in pass 3, so a process-local live-thread set answers the same question with no shm change and no platform split. Cost: an extra `Mutex<HashSet<u32>>` lock on the (startup-shaped) registration path, and one HashSet entry per thread that has ever claimed a slot.

Behaviour change a human must sign off on: where 17+ threads of ONE proc

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
