### PR TITLE
docs(topic): put send_blocking's real error contract on the method users read

### DIFF
--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -3078,8 +3078,10 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
     ///
     /// # Errors
     ///
+    /// - [`SendBlockingError::NoBackpressure`] — the backend overwrites unread
+    ///   messages and has no full condition to wait on; checked before the first
+    ///   `try_send`, so no time is spent waiting
     /// - [`SendBlockingError::Timeout`] — ring buffer stayed full for the entire `timeout`
-    /// - [`SendBlockingError::Serialization`] — non-POD message failed to serialize
     pub fn send_blocking(
         &self,
         msg: T,
@@ -3957,9 +3959,12 @@ impl<T: TopicMessage> Topic<T> {
 
     /// Whether a full ring can make this topic's `try_send` refuse a message.
     ///
-    /// See [`RingTopic::provides_backpressure`]. Returns `false` on the
-    /// broadcast backends, which is what a topic silently becomes once a second
-    /// subscriber attaches.
+    /// Returns `false` on the broadcast backends (`PodShm`, `FanoutShm`), which
+    /// is what a topic silently becomes once a second subscriber attaches, and
+    /// `false` on a backend this handle has not resolved yet — every topic is in
+    /// that state until its first send or recv, and an unresolved backend is not
+    /// a promise of backpressure. So check this AFTER the first send/recv; see
+    /// [`send_blocking()`](Self::send_blocking) for why a command topic should.
     pub fn provides_backpressure(&self) -> bool {
         self.ring.provides_backpressure()
     }
@@ -4244,12 +4249,56 @@ where
 
     /// Send a message, blocking until the ring has space or the timeout expires.
     ///
-    /// Use this for critical command topics (emergency stop, motor setpoints) where
-    /// message loss is unacceptable. For high-frequency sensor data where dropping
-    /// stale frames is acceptable, prefer [`send()`](Self::send).
+    /// Unlike [`send()`](Self::send), which drops the message after a brief
+    /// spin+yield retry, this reports a full ring instead of swallowing it --
+    /// **on the backends that have a full ring at all.** Strategy: spin briefly
+    /// (256 iters), yield briefly (8 iters), then sleep in 100μs increments
+    /// until the deadline.
     ///
-    /// Returns `Ok(())` if the message was sent, or `Err(SendBlockingError::Timeout)`
-    /// if the ring remained full for the entire timeout duration.
+    /// # This does NOT guarantee delivery on a broadcast topic
+    ///
+    /// Every phase of the wait is a retry of `try_send`, so this can only block
+    /// where `try_send` can fail. On the broadcast backends -- `PodShm` and
+    /// `FanoutShm` -- it cannot: they overwrite the oldest unread message rather
+    /// than refuse a new one, so there is no full ring to wait for.
+    ///
+    /// And you do not choose the backend -- participant count does. One
+    /// subscriber gives `SpscShm` and real backpressure; a second subscriber,
+    /// including a logger or a `horus topic echo`, silently switches the same
+    /// POD topic to `PodShm` broadcast. Once this handle has resolved that
+    /// change (the first send or recv after it does), this call reports
+    /// `SendBlockingError::NoBackpressure` instead of the `Ok(())` in
+    /// nanoseconds it would otherwise return for a delivery nobody guaranteed.
+    ///
+    /// This doc used to recommend the method for "critical command topics
+    /// (emergency stop, motor setpoints) where message loss is unacceptable".
+    /// On a topic with two subscribers that was exactly backwards, and it is the
+    /// reason [`provides_backpressure()`](Self::provides_backpressure) exists.
+    /// Assert that on any topic carrying commands -- but AFTER the first send or
+    /// recv, not before. A handle does not resolve its backend until it moves a
+    /// message, and an unresolved backend answers `false` (it is not a promise
+    /// of anything), so an assertion placed before the first send fires on every
+    /// topic including the ones that are fine:
+    ///
+    /// ```rust,ignore
+    /// estop.send(Stop); // resolves the backend
+    /// assert!(
+    ///     estop.provides_backpressure(),
+    ///     "e-stop settled on a lossy backend"
+    /// );
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - `SendBlockingError::NoBackpressure` — this topic's backend overwrites
+    ///   unread messages and never reports a full ring, so there is nothing to
+    ///   wait on. Refusing is deliberate: reporting success for a delivery
+    ///   nobody guaranteed is worse on an e-stop path than failing loudly. It
+    ///   does not clear on retry — it lasts as long as the topology that caused
+    ///   it, so the fix is to move the topic back to one subscriber or to accept
+    ///   the loss with `send()`/`try_send()`.
+    /// - `SendBlockingError::Timeout` — the ring stayed full for the entire
+    ///   `timeout`.
     pub fn send_blocking(
         &self,
         msg: T,

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -4251,9 +4251,10 @@ where
     ///
     /// Unlike [`send()`](Self::send), which drops the message after a brief
     /// spin+yield retry, this reports a full ring instead of swallowing it --
-    /// **on the backends that have a full ring at all.** Strategy: spin briefly
-    /// (256 iters), yield briefly (8 iters), then sleep in 100μs increments
-    /// until the deadline.
+    /// **on the backends that have a full ring at all.** It backs off in stages
+    /// -- spin, then yield, then sleep -- and re-checks the deadline before
+    /// every wait after the spin, so a short or zero `timeout` returns near it
+    /// rather than overshooting by a scheduling quantum.
     ///
     /// # This does NOT guarantee delivery on a broadcast topic
     ///

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -12330,10 +12330,19 @@ fn every_send_blocking_doc_states_the_error_contract_the_enum_actually_has() {
     for (at, _) in SRC.match_indices("pub fn send_blocking(") {
         let doc = doc_above(SRC, at);
         for variant in &variants {
-            if !doc.contains(variant) {
+            // The qualified path, not the bare variant name. `Timeout` is also an
+            // ordinary English word on a method whose argument is called
+            // `timeout`, so a doc block that had dropped the error contract
+            // entirely could still satisfy a bare `contains` on one capitalised
+            // mention in prose — a drift detector that its own subject can
+            // accidentally satisfy. Both blocks already write the path, linked or
+            // in a code span, so the stricter needle costs nothing to satisfy
+            // honestly and cannot be met by accident.
+            let named = format!("SendBlockingError::{variant}");
+            if !doc.contains(&named) {
                 drift.push(format!(
                     "the doc above the `send_blocking` at byte {at} never names \
-                     `SendBlockingError::{variant}`, which it can return"
+                     `{named}`, which it can return"
                 ));
             }
         }

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -12169,7 +12169,22 @@ fn send_blocking_refuses_a_backend_that_cannot_apply_backpressure() {
     // other handles in this process, whose send guard then re-resolves the mode.
     // Which is also the real sequence — a topic is already publishing when the
     // subscriber that flips it attaches.
-    while rx.recv().is_some() {}
+    //
+    // Bounded, not `while rx.recv().is_some() {}`: nothing publishes to this
+    // topic except the test thread itself, which stopped at `tx.send(0)`, so the
+    // drain ends after at most the 16 slots this ring has. An unbounded loop
+    // whose exit depends on that staying true has one failure mode — a CI
+    // timeout with no output — so the cap is set far above the ring and says
+    // what it means when it trips.
+    let mut drained = 0;
+    while rx.recv().is_some() {
+        drained += 1;
+        assert!(
+            drained <= 1024,
+            "rx.recv() has yielded {drained} messages and is still not empty; \
+             something is publishing to this topic that the test did not"
+        );
+    }
     tx.send(1);
     assert_eq!(
         tx.mode(),
@@ -12205,22 +12220,66 @@ fn every_send_blocking_doc_states_the_error_contract_the_enum_actually_has() {
     const SRC: &str = include_str!("mod.rs");
 
     // Variant names as declared, so the check cannot drift from the enum.
+    //
+    // Line-based rather than a brace-depth scan of the raw text: the `#[error]`
+    // attributes here are thiserror format strings, so `{}` and `{0}` appear
+    // inside string literals and a depth counter would close the enum in the
+    // wrong place. There is no Rust parser in dev-dependencies to do it properly
+    // (criterion, tempfile, trybuild, loom, proptest), and pulling `syn` in for
+    // one test is not worth it. What this leans on instead is rustfmt, which CI
+    // enforces: a top-level enum closes at column 0 and every variant sits at
+    // exactly one indent, which is what the two filters below read.
+    //
+    // Every variant form is matched by its leading identifier, not by a trailing
+    // comma — `Timeout,`, `Elapsed(Duration)`, `Rejected { .. }` and `A = 1` all
+    // start the same way. The comma-suffix version of this parser silently
+    // dropped every non-unit variant, which would have quietly narrowed the
+    // contract check below to whatever variants happened to be unit ones: a
+    // drift detector that stops detecting drift is worse than none.
     fn variants(src: &str) -> Vec<&str> {
         let start = src
             .find("pub enum SendBlockingError {")
             .expect("SendBlockingError is no longer declared in this file");
         let body = &src[start..];
         let end = body.find("\n}").expect("unterminated enum");
-        body[..end]
+        let body = &body[..end];
+        let names: Vec<&str> = body
             .lines()
-            .map(str::trim)
-            .filter_map(|line| line.strip_suffix(','))
-            .filter(|name| {
-                let mut chars = name.chars();
-                chars.next().is_some_and(|first| first.is_ascii_uppercase())
-                    && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+            // One indent exactly: variant lines. Deeper lines are struct-variant
+            // fields or the continuation lines of a multi-line attribute string.
+            .filter_map(|line| line.strip_prefix("    "))
+            .filter(|line| !line.starts_with(' '))
+            .filter_map(|line| {
+                let name_len = line
+                    .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+                    .unwrap_or(line.len());
+                let (name, rest) = line.split_at(name_len);
+                let starts_upper = name.chars().next().is_some_and(|c| c.is_ascii_uppercase());
+                // What follows the identifier is what makes it a declaration:
+                // unit, tuple, struct or discriminant. Prose inside an attribute
+                // string does not survive this.
+                let declares = matches!(
+                    rest.trim_start().chars().next(),
+                    Some(',' | '(' | '{' | '=')
+                );
+                (starts_upper && declares).then_some(name)
             })
-            .collect()
+            .collect();
+
+        // Self-check on the parse itself. thiserror needs a display attribute on
+        // every variant of this enum, so the counts agree unless the scan missed
+        // a variant — whether because of a shape it does not know or because the
+        // `\n}` above ended the body early. Either way the drift check below
+        // would go on passing while covering less than it claims to, so it fails
+        // here instead.
+        let attrs = body.matches("#[error").count();
+        assert_eq!(
+            names.len(),
+            attrs,
+            "parsed {names:?} out of `SendBlockingError`, but its body carries \
+             {attrs} `#[error]` attributes — this parser missed a variant"
+        );
+        names
     }
 
     // The `///` block directly above the item beginning at `idx`.

--- a/horus_core/src/communication/topic/tests.rs
+++ b/horus_core/src/communication/topic/tests.rs
@@ -12124,32 +12124,173 @@ fn a_colo_topic_does_not_grow_its_region_on_an_epoch_change() {
 // ============================================================================
 
 /// `send_blocking` documents itself for "emergency stop, motor setpoints" and
-/// promises "delivery or an explicit timeout error". On the default POD
-/// broadcast backend it could keep neither promise: `send_shm_pod_broadcast` has
-/// a single exit, `Ok(())`, so phase 1's `try_send` always succeeded and the
-/// method returned Ok having guaranteed nothing — the slot may be overwritten
-/// before any subscriber reads it.
+/// promises "delivery or an explicit timeout error". On a POD broadcast backend
+/// it could keep neither promise: `send_shm_pod_broadcast` has a single exit,
+/// `Ok(())`, so phase 1's `try_send` always succeeded and the method returned Ok
+/// having guaranteed nothing — the slot may be overwritten before any subscriber
+/// reads it.
+///
+/// This test used to open one handle, call `t.send(0)` and skip unless the mode
+/// came back `PodShm`. It never did, so the test passed without asserting
+/// anything: `detect_optimal_backend` picks PodShm only at `sub_count >= 2`, one
+/// handle is 1P/1C (`SpscShm`), and participant slots are keyed by
+/// (pid, thread) — a second handle on the same thread shares the slot and does
+/// not raise the count. Observed before the repair:
+/// "skipping: expected PodShm, got SpscShm".
 ///
 /// GATE: remove the `provides_backpressure` guard in `send_blocking` and this
 /// fails, because the call returns Ok on a backend that cannot deliver.
 #[test]
 fn send_blocking_refuses_a_backend_that_cannot_apply_backpressure() {
     let name = unique("sb_no_backpressure");
-    let t: Topic<u64> = Topic::new(&name).expect("create");
-    // Drive it onto the POD broadcast backend, the default for POD types.
-    t.send(0);
-    let _ = t.recv();
+    let tx: Topic<u64> = Topic::with_capacity(&name, 16, None).expect("tx");
+    let rx: Topic<u64> = Topic::with_capacity(&name, 16, None).expect("rx");
+    assert!(rx.recv().is_none(), "nothing published yet");
+    tx.send(0);
+    let _ = rx.recv();
+    assert!(
+        tx.provides_backpressure(),
+        "1P/1C should select a backend with backpressure, got {}",
+        tx.backend_name()
+    );
 
-    if t.mode() != BackendMode::PodShm {
-        eprintln!("skipping: expected PodShm, got {:?}", t.mode());
-        return;
-    }
+    // Reach the broadcast backend the second subscriber would have selected.
+    // Deliberately NOT `force_migrate`: that syncs this handle's cached epoch,
+    // and the guard that re-resolves the cached mode would then never fire.
+    let migrated = matches!(
+        BackendMigrator::new(tx.ring.header()).try_migrate(BackendMode::PodShm),
+        MigrationResult::Success { .. } | MigrationResult::NotNeeded
+    );
+    assert!(migrated, "could not reach PodShm to test it");
 
-    let r = t.send_blocking(1, 5_u64.ms());
+    // `send_blocking` reads the handle's CACHED mode before its first `try_send`,
+    // so the epoch change has to be observed first: an empty recv runs
+    // `migration_check!` unconditionally, and that publishes the new epoch to the
+    // other handles in this process, whose send guard then re-resolves the mode.
+    // Which is also the real sequence — a topic is already publishing when the
+    // subscriber that flips it attaches.
+    while rx.recv().is_some() {}
+    tx.send(1);
+    assert_eq!(
+        tx.mode(),
+        BackendMode::PodShm,
+        "the migration above must have taken effect for this test to mean anything"
+    );
+
+    let r = tx.send_blocking(2, 5_u64.ms());
     assert!(
         matches!(r, Err(SendBlockingError::NoBackpressure)),
         "send_blocking on a broadcast backend must refuse rather than report a \
          delivery it cannot guarantee; got {r:?}"
+    );
+}
+
+/// The public `send_blocking` doc is the only copy of the contract a caller reads.
+///
+/// `Topic::send_blocking` is the public entry point; `RingTopic::send_blocking`
+/// holds the implementation and `RingTopic` is `pub(crate)`, so its doc renders
+/// nowhere. The corrected contract landed only on the inner one. The public doc
+/// kept promising `Ok(())` or `SendBlockingError::Timeout` and recommending the
+/// call for "critical command topics (emergency stop, motor setpoints)", while
+/// the error a caller actually gets once a logger or a `horus topic echo`
+/// attaches — `NoBackpressure` — appeared nowhere in the rendered page
+/// (`cargo doc -p horus`: 0 occurrences on `struct.Topic.html`). The inner block
+/// meanwhile documented `SendBlockingError::Serialization`, a variant this enum
+/// has never had.
+///
+/// Source text is the observable on purpose: rustdoc output is not reachable
+/// from a unit test, and every part of this defect is in what the caller is told.
+#[test]
+fn every_send_blocking_doc_states_the_error_contract_the_enum_actually_has() {
+    const SRC: &str = include_str!("mod.rs");
+
+    // Variant names as declared, so the check cannot drift from the enum.
+    fn variants(src: &str) -> Vec<&str> {
+        let start = src
+            .find("pub enum SendBlockingError {")
+            .expect("SendBlockingError is no longer declared in this file");
+        let body = &src[start..];
+        let end = body.find("\n}").expect("unterminated enum");
+        body[..end]
+            .lines()
+            .map(str::trim)
+            .filter_map(|line| line.strip_suffix(','))
+            .filter(|name| {
+                let mut chars = name.chars();
+                chars.next().is_some_and(|first| first.is_ascii_uppercase())
+                    && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+            })
+            .collect()
+    }
+
+    // The `///` block directly above the item beginning at `idx`.
+    fn doc_above(src: &str, idx: usize) -> String {
+        let mut block: Vec<&str> = src[..idx]
+            .lines()
+            .rev()
+            .skip_while(|line| {
+                let t = line.trim();
+                t.is_empty() || t.starts_with('#')
+            })
+            .take_while(|line| line.trim_start().starts_with("///"))
+            .collect();
+        block.reverse();
+        block.join("\n")
+    }
+
+    let variants = variants(SRC);
+    assert!(
+        variants.contains(&"Timeout") && variants.contains(&"NoBackpressure"),
+        "parsed {variants:?} — the enum has both, so this parse is what broke"
+    );
+
+    // Collected rather than asserted one at a time: the two blocks drifted apart
+    // in different ways, and a run should name every way at once.
+    let mut drift: Vec<String> = Vec::new();
+
+    // A documented variant that does not exist is a promise about behaviour that
+    // cannot happen, and rustdoc cannot flag it on a `pub(crate)` item because it
+    // never renders one.
+    for (at, _) in SRC.match_indices("SendBlockingError::") {
+        let named: String = SRC[at + "SendBlockingError::".len()..]
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if !named.is_empty() && !variants.iter().any(|v| *v == named) {
+            drift.push(format!(
+                "`SendBlockingError::{named}` is referenced at byte {at}, but the \
+                 enum declares only {variants:?}"
+            ));
+        }
+    }
+
+    // Both definitions: the public one on `Topic` and the inner one on
+    // `RingTopic`. Only the first is ever rendered, which is exactly how the two
+    // drifted, so both are held to the same contract.
+    let mut checked = 0;
+    for (at, _) in SRC.match_indices("pub fn send_blocking(") {
+        let doc = doc_above(SRC, at);
+        for variant in &variants {
+            if !doc.contains(variant) {
+                drift.push(format!(
+                    "the doc above the `send_blocking` at byte {at} never names \
+                     `SendBlockingError::{variant}`, which it can return"
+                ));
+            }
+        }
+        checked += 1;
+    }
+    assert!(
+        checked >= 2,
+        "expected the public `Topic::send_blocking` and the inner \
+         `RingTopic::send_blocking`; found {checked}"
+    );
+
+    assert!(
+        drift.is_empty(),
+        "send_blocking's documented error contract does not match \
+         `SendBlockingError`:\n- {}",
+        drift.join("\n- ")
     );
 }
 


### PR DESCRIPTION
`Topic::send_blocking` is the public entry point; `RingTopic::send_blocking` is
the implementation, and `RingTopic` is `pub(crate)` (mod.rs:722), so nothing on
it renders. The corrected prose about broadcast backends landed only on the
inner method. The public doc still said "Use this for critical command topics
(emergency stop, motor setpoints) where message loss is unacceptable" and
"Returns Ok(()) ... or Err(SendBlockingError::Timeout)" — omitting
`NoBackpressure`, which is the error the method actually returns once a POD
topic has two subscribers (`detect_optimal_backend`: subs >= 2 selects PodShm,
header.rs:1211-1237) and this handle has resolved that change. Verified in the
rendered output: before this change `cargo doc -p horus --no-deps` produced
doc/horus/prelude/struct.Topic.html with 0 occurrences of "NoBackpressure";
after, the section and both `# Errors` bullets are there.

Also in this diff:
- The inner `# Errors` listed `SendBlockingError::Serialization`. That variant
  has never existed — the enum (mod.rs:569-591) has only Timeout and
  NoBackpressure. Replaced with the NoBackpressure bullet.
- `Topic::provides_backpressure` (public) linked `[RingTopic::provides_backpressure]`,
  a `pub(crate)` target, which rustdoc renders as literal text with no href.
  Inlined the explanation, including the `false`-on-unresolved behaviour that
  makes the "assert after the first send" advice necessary.
- The public doc uses code spans, not intra-doc links, for the two variants:
  `communication` is `#[doc(hidden)]` in horus_core (lib.rs:20-23), so an
  intra-doc link from a rendered page is an href to a page rustdoc never
  generates. (The signature's own `SendBlockingError` link already 404s for that
  reason; this change adds no new dead links.)

Tests:
- `send_blocking_refuses_a_backend_that_cannot_apply_backpressure` passed
  vacuously: one handle is 1P/1C, so the mode was always SpscShm and the test
  hit its `eprintln!("skipping: ...")` + `return`. Rebuilt on the pattern
  `a_broadcast_backend_cannot_refuse_a_send` already uses — migrate the header
  with `BackendMigrator` (not `force_migrate`, which syncs the handle's cached
  epoch and disarms the guard), let an empty recv publish the epoch, then send
  so the guard re-resolves the cached mode that `send_blocking` reads.
- New `every_send_blocking_doc_states_the_error_contract_the_enum_actually_has`
  parses the variant list out of the enum and holds BOTH `send_blocking` doc
  blocks to it, and rejects any `SendBlockingError::X` reference in the file
  that is not a declared variant. It is the drift detector the pair lacked:
  rustdoc cannot lint a `pub(crate)` item's doc, which is how the two copies
  came apart in the first place.

## Ablation

```
Reverted ONLY horus_core/src/communication/topic/mod.rs to HEAD (`git show HEAD:... > mod.rs`), kept both tests, then `cargo test -p horus_core --lib every_send_blocking_doc`. Verified the tree was doc-reverted first: `git diff --stat` showed only tests.rs modified. EXACT output:

   Compiling horus_core v0.4.0 (/home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-13/horus_core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 8m 26s
     Running unittests src/lib.rs (target/debug/deps/horus_core-084e9e0d5e0fa763)

running 1 test
test communication::topic::tests::every_send_blocking_doc_states_the_error_contract_the_enum_actually_has ... FAILED

failures:

---- communication::topic::tests::every_send_blocking_doc_states_the_error_contract_the_enum_actually_has stdout ----

thread 'communication::topic::tests::every_send_blocking_doc_states_the_error_contract_the_enum_actually_has' (1881591) panicked at horus_core/src/communication/topic/tests.rs:12289:5:
send_blocking's documented error contract does not match `SendBlockingError`:
- `SendBlockingError::Serialization` is referenced at byte 151295, but the enum declares only ["Timeout", "NoBackpressure"]
- the doc above the `send_blocking` at byte 151374 never names `SendBlockingError::NoBackpressure`, which it can return
- the doc above the `send_blocking` at byte 200883 never names `SendBlockingError::NoBackpressure`, which it can return
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    communication::topic::tests::every_send_blocking_doc_states_the_error_contract_the_enum_actually_has

test result: FAILED. 0 passed; 1 failed; 4 ignored... (line as printed: `test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2501 filtered out; finished in 0.00s`)

error: test failed, to rerun pass `-p horus_core --lib`

Byte 200883 is the PUBLIC `Topic::send_blocking`; byte 151374 is the inner `RingTopic::send_blocking`. Production change restored afterwards and the same test re-run: ok.

Note on the earlier ablation attempt: a first pass asserted per-violation and stopped at the phantom-variant failure alone, masking the public-doc failure. I changed the test to collect all violations and re-ran the ablation to get the output above.
```

## Tests

```
Machine was heavily loaded throughout (12 cores, load average 20-48 from sibling sessions' cargo builds).

- `cargo test -p horus_core --lib send_blocking` (final tree): 18 passed; 0 failed; 0 ignored; 2484 filtered out; 0.10s. Includes the repaired `send_blocking_refuses_a_backend_that_cannot_apply_backpressure` (no longer prints its "skipping:" line) and the new `every_send_blocking_doc_states_the_error_contract_the_enum_actually_has`.
- `cargo test -p horus_core --lib` (whole crate, run #1, on the fixed tree before the final code-span-only doc tweak): 2498 passed; 0 failed; 4 ignored; 57.56s.
- `cargo test -p horus_core --lib` (whole crate, run #2, final tree): 2497 passed; 1 failed; 4 ignored; 73.62s. The failure is `scheduling::event_executor::tests::wake_comes_from_the_publisher_not_from_the_backstop` — "the median of 9 serial notify->tick round trips was 6.26745ms" against its 5 ms threshold, i.e. a futex-wake latency test losing to machine load. Re-run alone on the same binary: `test result: ok. 1 passed; 0 failed; ... finished in 2.08s`, and it passed in run #1 of the same tree. Nothing in this diff touches the scheduler.
- `cargo clippy -p horus_core --all-targets`: exit 0, 0 warnings.
- `cargo fmt --all -- --check`: exit 0.
- `cargo doc -p horus_core --no-deps` and `cargo doc -p horus --no-deps`: exit 0, no warnings.
- Rendered check on target/doc/horus/prelude/struct.Topic.html: "NoBackpressure" 0 -> 2 occurrences; "This does NOT guarantee delivery on a broadcast 
```

## Notes from the implementer

CONFIRMED, with the finding's own corrections holding up:
- mod.rs:722 `pub(crate) struct RingTopic<T>` — the corrected prose was on an item that renders nowhere.
- The enum (mod.rs:569-591) has exactly Timeout and NoBackpressure; `Serialization` was phantom.
- header.rs:1211-1237: PodShm needs subs >= 2; the 1P/1C default is SpscShm and multi-producer is MpscShm, both backpressured (types.rs:60). So the original claim's "PodShm is the default" is indeed false, and my doc says "once a second subscriber attaches", not "by default".
- I re-read the vacuous test and confirmed it: one handle is 1P/1C, so `t.mode() != PodShm` always held and it returned before asserting.

ONE CORRECTION I MADE TO THE INHERITED PROSE. The inner doc said the refusal happens as soon as the topology flips. It does not, on the first call: `send_blocking` calls `initialize_backend()` (mod.rs:1925), which early-returns while the backend still matches the STALE `cached_mode`, then reads that stale mode for the guard — the epoch guard only fires later, inside phase 1's `try_send`. So the first `send_blocking` after a flip can still return `Ok(())`, and refusals start once the handle has resolved the change. My public doc says exactly that ("Once this handle has resolved that change (the first send or recv after it does)"), and the repaired test has to do a plain `tx.send(1)` before the assertion for the same reason. I did not change that behaviour — it is a latency-of-detection property, not a doc defect, but a reviewer may consider whether `send_blocking` should consult the header mode rather than the cached one.

VERIFIED BUT NOT FIXED — needs a decision. `SendBlockingError`'s own (well-written) doc renders nowhere: horus_core/src/lib.rs:20-23 marks `pub mod communication` as `#[doc(hidden)]`, and `horus`'s re-export inherits that, so neither target/doc/horus_core/communication/ nor target/doc/horus/communication/ is generated. The method signature's own `SendBlockingError` link on struct.Topic

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
