### PR TITLE
fix(rt): don't report SCHED_FIFO applied when no priority was given

### DIFF
--- a/horus_core/src/core/rt_config.rs
+++ b/horus_core/src/core/rt_config.rs
@@ -8,7 +8,7 @@
 //! # Example
 //!
 //! ```rust,ignore
-//! use horus_core::core::{RtConfig, RtScheduler};
+//! use horus_core::core::{RtApplyResult, RtConfig, RtScheduler};
 //!
 //! // Create RT configuration for a critical control loop
 //! let config = RtConfig::builder()
@@ -18,8 +18,13 @@
 //!     .cpu_affinity(&[2, 3])
 //!     .build();
 //!
-//! // Apply to current thread
-//! config.apply().expect("Failed to apply RT config");
+//! // Apply to current thread. A feature that could not be applied comes back
+//! // inside the Ok value, not as an Err, so the result has to be inspected —
+//! // `.expect()` alone will not tell you the thread missed SCHED_FIFO.
+//! match config.apply().expect("Failed to apply RT config") {
+//!     RtApplyResult::FullSuccess => {}
+//!     RtApplyResult::Degraded(reasons) => eprintln!("RT degraded: {:?}", reasons),
+//! }
 //! ```
 //!
 //! # Zero-Cost Abstraction
@@ -143,7 +148,12 @@ impl RtConfigBuilder {
     ///
     /// - [`RtScheduler::Normal`]: Standard Linux scheduler (SCHED_OTHER)
     /// - [`RtScheduler::Fifo`]: Real-time FIFO (SCHED_FIFO)
-    /// - [`RtScheduler::RoundRobin`]: Real-time round-robin (SCHED_RR)
+    ///
+    /// [`RtScheduler::Fifo`] must be paired with [`priority()`](Self::priority):
+    /// `sched_setscheduler` takes the RT priority in the same call, so a policy
+    /// with no priority cannot be applied and
+    /// [`apply()`](RtConfig::apply) reports it as
+    /// [`RtDegradation::SchedulerDegraded`].
     pub fn scheduler(mut self, scheduler: RtScheduler) -> Self {
         self.scheduler = scheduler;
         self
@@ -239,26 +249,52 @@ impl RtConfig {
             }
         }
 
-        // Apply scheduler and priority via horus_sys
-        if let Some(priority) = self.priority {
-            if self.scheduler != RtScheduler::Normal {
-                let actual =
-                    priority.clamp(kernel_info.min_rt_priority, kernel_info.max_rt_priority);
-                match horus_sys::rt::set_realtime_priority(actual) {
-                    Ok(()) => {
-                        if actual != priority {
-                            degradations.push(RtDegradation::PriorityClamped {
-                                requested: priority,
-                                actual,
-                            });
+        // Apply scheduler and priority via horus_sys.
+        //
+        // The policy test is the OUTER branch on purpose. It used to be nested
+        // inside `if let Some(priority)`, so a config built as
+        // `.scheduler(Fifo)` with no `.priority()` fell through both arms:
+        // set_realtime_priority is the only call here that issues
+        // sched_setscheduler, so no syscall was attempted at all (straced: zero
+        // sched_setscheduler for that config, versus one for the same config
+        // with a priority) and apply() still answered FullSuccess on a
+        // PREEMPT_RT box. The caller believed its control loop was on
+        // SCHED_FIFO while the thread stayed on SCHED_OTHER.
+        if self.scheduler != RtScheduler::Normal {
+            match self.priority {
+                Some(priority) => {
+                    let actual =
+                        priority.clamp(kernel_info.min_rt_priority, kernel_info.max_rt_priority);
+                    match horus_sys::rt::set_realtime_priority(actual) {
+                        Ok(()) => {
+                            if actual != priority {
+                                degradations.push(RtDegradation::PriorityClamped {
+                                    requested: priority,
+                                    actual,
+                                });
+                            }
+                        }
+                        Err(e) => {
+                            let msg = format!("Scheduler setup failed: {}", e);
+                            degradations.push(RtDegradation::SchedulerDegraded(msg.clone()));
+                            if self.warn_on_degradation {
+                                crate::terminal::print_line(&format!("Warning: {}", msg));
+                            }
                         }
                     }
-                    Err(e) => {
-                        let msg = format!("Scheduler setup failed: {}", e);
-                        degradations.push(RtDegradation::SchedulerDegraded(msg.clone()));
-                        if self.warn_on_degradation {
-                            crate::terminal::print_line(&format!("Warning: {}", msg));
-                        }
+                }
+                // No priority to hand sched_setscheduler, and inventing one
+                // would put a robot thread on an RT class the operator never
+                // chose. Report the policy as not applied instead.
+                None => {
+                    let msg = format!(
+                        "{:?} scheduler requested without a priority; thread left on \
+                         the normal scheduler (add .priority({}..={}))",
+                        self.scheduler, kernel_info.min_rt_priority, kernel_info.max_rt_priority
+                    );
+                    degradations.push(RtDegradation::SchedulerDegraded(msg.clone()));
+                    if self.warn_on_degradation {
+                        crate::terminal::print_line(&format!("Warning: {}", msg));
                     }
                 }
             }
@@ -641,6 +677,52 @@ mod tests {
         let result = config.apply();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), RtApplyResult::FullSuccess);
+    }
+
+    /// `apply()` must never claim a scheduling policy it did not set.
+    ///
+    /// `set_realtime_priority` is the only call in `apply()` that issues
+    /// sched_setscheduler, and it needs a priority, so `.scheduler(Fifo)` with
+    /// no `.priority()` cannot change the thread's policy. The scheduler branch
+    /// used to sit inside the priority branch, so that config was a silent
+    /// no-op that still returned `FullSuccess` on a PREEMPT_RT kernel.
+    ///
+    /// Asserting on `SchedulerDegraded` specifically keeps the test meaningful
+    /// off PREEMPT_RT too, where the old code returned `Degraded([NoPreemptRt])`
+    /// — degraded for a reason that says nothing about the missing policy.
+    #[test]
+    fn test_rt_scheduler_without_priority_is_reported_degraded() {
+        // Own thread: apply() mutates the caller's scheduling class, and on a
+        // privileged box the rest of the suite must not inherit it.
+        std::thread::spawn(|| {
+            let config = RtConfig::builder().scheduler(RtScheduler::Fifo).build();
+            let result = config.apply().expect("apply() has no error path today");
+
+            let degradations = match result {
+                RtApplyResult::Degraded(d) => d,
+                RtApplyResult::FullSuccess => panic!(
+                    "scheduler(Fifo) with no priority reported FullSuccess, \
+                     but no sched_setscheduler was issued"
+                ),
+            };
+            assert!(
+                degradations
+                    .iter()
+                    .any(|d| matches!(d, RtDegradation::SchedulerDegraded(_))),
+                "expected SchedulerDegraded for a policy that was never applied, got {:?}",
+                degradations
+            );
+
+            // The report matches the thread: still on the normal scheduler.
+            let (policy, _) = RtConfig::get_current_scheduler().unwrap();
+            assert_eq!(
+                policy,
+                RtScheduler::Normal,
+                "thread should still be SCHED_OTHER after a no-op RT config"
+            );
+        })
+        .join()
+        .unwrap();
     }
 
     #[test]

--- a/horus_core/src/core/rt_config.rs
+++ b/horus_core/src/core/rt_config.rs
@@ -251,15 +251,13 @@ impl RtConfig {
 
         // Apply scheduler and priority via horus_sys.
         //
-        // The policy test is the OUTER branch on purpose. It used to be nested
-        // inside `if let Some(priority)`, so a config built as
-        // `.scheduler(Fifo)` with no `.priority()` fell through both arms:
-        // set_realtime_priority is the only call here that issues
-        // sched_setscheduler, so no syscall was attempted at all (straced: zero
-        // sched_setscheduler for that config, versus one for the same config
-        // with a priority) and apply() still answered FullSuccess on a
-        // PREEMPT_RT box. The caller believed its control loop was on
-        // SCHED_FIFO while the thread stayed on SCHED_OTHER.
+        // Invariant: never report a policy as applied unless sched_setscheduler
+        // was attempted. set_realtime_priority is the only call here that
+        // issues it and it needs a priority, so the policy test has to stay the
+        // OUTER branch — nested inside `if let Some(priority)` it made
+        // `.scheduler(Fifo)` with no priority a silent no-op that still
+        // returned FullSuccess. Missing priority => SchedulerDegraded; see
+        // test_rt_scheduler_without_priority_is_reported_degraded.
         if self.scheduler != RtScheduler::Normal {
             match self.priority {
                 Some(priority) => {
@@ -276,10 +274,7 @@ impl RtConfig {
                         }
                         Err(e) => {
                             let msg = format!("Scheduler setup failed: {}", e);
-                            degradations.push(RtDegradation::SchedulerDegraded(msg.clone()));
-                            if self.warn_on_degradation {
-                                crate::terminal::print_line(&format!("Warning: {}", msg));
-                            }
+                            degradations.push(self.scheduler_degraded(msg));
                         }
                     }
                 }
@@ -288,14 +283,12 @@ impl RtConfig {
                 // chose. Report the policy as not applied instead.
                 None => {
                     let msg = format!(
-                        "{:?} scheduler requested without a priority; thread left on \
-                         the normal scheduler (add .priority({}..={}))",
+                        "{:?} scheduler requested without a priority; no sched_setscheduler \
+                         was issued, so the thread's scheduling policy is unchanged \
+                         (add .priority({}..={}))",
                         self.scheduler, kernel_info.min_rt_priority, kernel_info.max_rt_priority
                     );
-                    degradations.push(RtDegradation::SchedulerDegraded(msg.clone()));
-                    if self.warn_on_degradation {
-                        crate::terminal::print_line(&format!("Warning: {}", msg));
-                    }
+                    degradations.push(self.scheduler_degraded(msg));
                 }
             }
         }
@@ -316,6 +309,18 @@ impl RtConfig {
         } else {
             Ok(RtApplyResult::Degraded(degradations))
         }
+    }
+
+    /// Warn about a scheduler degradation (when enabled) and return it to push.
+    ///
+    /// Returning the variant instead of pushing it keeps the message owned by a
+    /// single place, so neither caller has to clone the `String` just to print
+    /// it first.
+    fn scheduler_degraded(&self, msg: String) -> RtDegradation {
+        if self.warn_on_degradation {
+            crate::terminal::print_line(&format!("Warning: {}", msg));
+        }
+        RtDegradation::SchedulerDegraded(msg)
     }
 }
 
@@ -713,7 +718,8 @@ mod tests {
                 degradations
             );
 
-            // The report matches the thread: still on the normal scheduler.
+            // And no policy change was attempted: this freshly spawned thread
+            // inherited SCHED_OTHER and is still on it.
             let (policy, _) = RtConfig::get_current_scheduler().unwrap();
             assert_eq!(
                 policy,

--- a/horus_core/src/core/rt_config.rs
+++ b/horus_core/src/core/rt_config.rs
@@ -700,6 +700,16 @@ mod tests {
         // Own thread: apply() mutates the caller's scheduling class, and on a
         // privileged box the rest of the suite must not inherit it.
         std::thread::spawn(|| {
+            // Capture the inherited state instead of assuming SCHED_OTHER: a
+            // spawned thread inherits the creating thread's policy and priority
+            // (pthread_create defaults to PTHREAD_INHERIT_SCHED), so a suite
+            // launched under `chrt -f` — which scripts/setup-realtime.sh grants
+            // this user — starts here on SCHED_FIFO. The invariant under test is
+            // "apply() left the scheduling state alone", not "the state is
+            // Normal", and hard-coding the latter fails the test on exactly the
+            // RT-capable box the feature exists for.
+            let before = RtConfig::get_current_scheduler().unwrap();
+
             let config = RtConfig::builder().scheduler(RtScheduler::Fifo).build();
             let result = config.apply().expect("apply() has no error path today");
 
@@ -718,13 +728,16 @@ mod tests {
                 degradations
             );
 
-            // And no policy change was attempted: this freshly spawned thread
-            // inherited SCHED_OTHER and is still on it.
-            let (policy, _) = RtConfig::get_current_scheduler().unwrap();
+            // And no policy change was attempted: both the policy and the RT
+            // priority are exactly what this thread inherited. Comparing the
+            // whole tuple is safe because nothing else in apply() issues
+            // sched_setscheduler/sched_setparam.
+            let after = RtConfig::get_current_scheduler().unwrap();
             assert_eq!(
-                policy,
-                RtScheduler::Normal,
-                "thread should still be SCHED_OTHER after a no-op RT config"
+                after, before,
+                "apply() changed the thread's scheduling state ({:?} -> {:?}) \
+                 for a config it reported as never applied",
+                before, after
             );
         })
         .join()


### PR DESCRIPTION
`RtConfig::apply()` nested the scheduler-policy test inside the priority
test, so `RtConfig::builder().scheduler(RtScheduler::Fifo).build().apply()`
fell through both arms. `horus_sys::rt::set_realtime_priority` is the only
call in `apply()` that issues sched_setscheduler, so that config attempted
no syscall at all, and on a PREEMPT_RT kernel `apply()` still answered
`Ok(FullSuccess)` — "All requested features were applied successfully" —
while the thread stayed on SCHED_OTHER. Off PREEMPT_RT the caller got
`Degraded([NoPreemptRt])`, degraded for a reason that says nothing about
the policy that was never set.

Measured with strace on the test binary: `.scheduler(Fifo)` alone issues
0 sched_setscheduler calls; `.scheduler(Fifo).priority(50)` issues exactly
1 (`sched_setscheduler(0, SCHED_FIFO, [50])`).

The policy test is now the outer branch. With no priority there is nothing
to hand sched_setscheduler, and inventing a default would put a robot
thread on an RT class the operator never chose, so `apply()` pushes
`RtDegradation::SchedulerDegraded` naming the missing `.priority()`
instead. FullSuccess can no longer be returned for a policy that was not
applied.

`RtConfigBuilder::scheduler()`'s docs also listed an `RtScheduler::RoundRobin`
variant that does not exist; replaced with the priority requirement. The
module example's `config.apply().expect(...)` implied failures surface as
`Err`, which they never do — it now matches on the `Ok` value.

No behaviour change for any in-tree caller: the only internal construction
(scheduling/scheduler/mod.rs:1563) always pairs `.scheduler(Fifo)` with
`.priority(50)`.

## Ablation

```
Reverted ONLY the production hunk in `RtConfig::apply()` (restored the
nested `if let Some(priority) { if self.scheduler != Normal { ... } }`),
kept the new test and the doc changes.

$ cargo test -p horus_core --lib \
    core::rt_config::tests::test_rt_scheduler_without_priority_is_reported_degraded -- --exact

     Running unittests src/lib.rs (target/debug/deps/horus_core-084e9e0d5e0fa763)

running 1 test
test core::rt_config::tests::test_rt_scheduler_without_priority_is_reported_degraded ... FAILED

failures:

---- core::rt_config::tests::test_rt_scheduler_without_priority_is_reported_degraded stdout ----

thread '<unnamed>' (1847758) panicked at horus_core/src/core/rt_config.rs:692:13:
expected SchedulerDegraded for a policy that was never applied, got [NoPreemptRt]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'core::rt_config::tests::test_rt_scheduler_without_priority_is_reported_degraded' (1847757) panicked at horus_core/src/core/rt_config.rs:709:10:
called `Result::unwrap()` on an `Err` value: Any { .. }


failures:
    core::rt_config::tests::test_rt_scheduler_without_priority_is_reported_degraded

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2502 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p horus_core --lib`

Independent syscall measurement, taken against that same ablated binary
(a throwaway control test applying `.scheduler(Fifo).priority(50)` was
added for the measurement and removed afterwards — it is not in the diff):

$ strace -f -e trace=sched_setscheduler -o st_nopri.txt   <bin> ...without_priority... --exact
$ strace -f -e trace=sched_setscheduler -o st_withpri.txt <bin> ...control_fifo_with_priority... --exact
=== no priority: scheduler(Fifo) alone ===
0
=== control: scheduler(Fifo).priority(50) ===
1
1848320 sched_setscheduler(0, SCHED_FIFO, [50]) = -1 EPERM (Operation not permitted)

Zero syscalls for the no-priority config proves the silent no-op is not an
EPERM that got reported: the call is never attempted. Production change
then restored; the test passes again (see tests_run).
```

## Tests

```
Fixed tree, on Linux 7.0.0-30-generic (non-PREEMPT_RT, unprivileged: `ulimit -r` = 0, 12 cores):

- `cargo test -p horus_core --lib` → test result: ok. 2498 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 71.20s. All 9 `core::rt_config::tests::*` pass, including the new `test_rt_scheduler_without_priority_is_reported_degraded`.
- `cargo test -p horus --test documentation_contract` (the only test outside horus_core that touches `RtConfig`/`RtScheduler`) → test result: ok. 1 passed; 0 failed.
- `cargo clippy -p horus_core --lib --tests` → `Finished dev profile`, exit 0, no warnings.
- `cargo fmt --all` → clean; `git diff --stat` afterwards shows only `horus_core/src/core/rt_config.rs` (104 insertions, 22 deletions).

Ablated tree: 1 failed / 0 passed on the new test (output pasted in `ablation`).
```

## Notes from the implementer

CONFIRMED the finding independently before fixing. `horus_sys::rt::set_realtime_priority` (horus_sys/src/rt/linux.rs:51-70) is the sole `sched_setscheduler(0, SCHED_FIFO, ...)` reachable from `RtConfig::apply()`, and it sat behind `if let Some(priority)`. strace on the pre-fix binary measured 0 syscalls for `.scheduler(Fifo)` alone vs 1 for `.scheduler(Fifo).priority(50)`.

What I could NOT verify directly:
- The `Ok(FullSuccess)` outcome itself. This box is not PREEMPT_RT, so `NoPreemptRt` is always pushed and pre-fix `apply()` returned `Degraded([NoPreemptRt])` here. `FullSuccess` on a PREEMPT_RT kernel follows from the code (`degradations` would be empty), but I did not observe it on real RT hardware. I deliberately wrote the test to assert on the presence of `SchedulerDegraded` rather than on `!= FullSuccess`, so it bites on both kernel types — that is what made the ablation fail here at all.
- I did not run horus_core's ~150 integration-test binaries. `grep -rln "RtConfig\|RtScheduler\|RtDegradation" horus_core/tests/ horus/tests/ examples/` matched exactly one file (horus/tests/documentation_contract.rs), which I ran.

Design choice I made, and the alternative I rejected: the finding offered "apply a documented default RT priority" or "push SchedulerDegraded". I chose the degradation. Applying an invented priority would silently promote a thread to SCHED_FIFO at a priority the operator never picked — on a robot that is a new failure mode (an RT thread that spins can starve the system), and it would change what the API *does*, not just what it *reports*. The degradation path changes no syscall behaviour at all; it only stops `apply()` claiming success for work it did not do. If a maintainer prefers the default-priority semantics, that is a one-line change in the same `None` arm, but it is their call, not mine.

Left alone on purpose:
- `apply()`'s `Result` return type. It has no `Err` path today, but per the finding's own correction that is a forward-compatibil

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
