### PR TITLE
docs(scheduler): list the errors tick_once/run really return

### DIFF
--- a/horus_core/src/error.rs
+++ b/horus_core/src/error.rs
@@ -259,7 +259,13 @@ pub enum NodeError {
     #[error("Node '{node}' init failed: {reason}")]
     InitFailed { node: String, reason: String },
 
-    /// Node `tick()` returned an error.
+    /// A node's per-tick work failed.
+    ///
+    /// The scheduler never produces this: [`Node::tick`](crate::core::Node::tick) returns
+    /// `()`, so a tick body has no error channel, and a panic inside one is caught and
+    /// surfaces as [`HorusError::Internal`] out of `Scheduler::tick_once()`. The variant
+    /// is for code that drives a fallible per-tick step of its own — a bridge, a driver
+    /// poll — and wants the failure attributed to a named node.
     #[error("Node '{node}' tick failed: {reason}")]
     TickFailed { node: String, reason: String },
 
@@ -1123,7 +1129,7 @@ impl HorusError {
             Self::Node(NodeError::InitFailed { .. }) =>
                 Some("Node initialization returned an error. Check node logs for details. Run: horus log -n <node_name>"),
             Self::Node(NodeError::TickFailed { .. }) =>
-                Some("Node tick() returned an error. Check node logs for details. Run: horus log -n <node_name>"),
+                Some("A node's per-tick work reported a failure. Check node logs for details. Run: horus log -n <node_name>"),
 
             // === NotFound ===
             Self::NotFound(NotFoundError::Frame { .. } | NotFoundError::ParentFrame { .. }) =>

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -2302,8 +2302,11 @@ impl Scheduler {
     ///   policy escalated (message `"Fatal node failure during tick_once"`); and a safety
     ///   monitor latching during this tick — watchdog expiry, external e-stop (message
     ///   `"Emergency stop triggered during tick_once"`). Both mean the robot needs
-    ///   safing and neither is retryable, so branch on the variant, not on the text:
-    ///   `message` is diagnostic, not a stable discriminator.
+    ///   safing and neither is retryable, so the variant alone is the whole contract:
+    ///   treat every `Internal` out of `tick_once()` as fatal and stop the loop. Do
+    ///   **not** try to tell the two causes apart in code — they share one variant, and
+    ///   `message` is diagnostic text, not a stable discriminator. It is for the log
+    ///   line and the operator, not for a `match`.
     ///
     /// A failing `init()` is **not** in that list. The scheduler prints the error and
     /// leaves the node in its error state (at fatal severity it also stops the scheduler),

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -2285,16 +2285,25 @@ impl Scheduler {
     ///
     /// # Errors
     ///
-    /// - [`ValidationError::InvalidValue`](crate::error::ValidationError::InvalidValue) —
-    ///   two nodes were added under the same name. Recorded by `build()`, reported here.
-    /// - [`ResourceError::Unsupported`](crate::error::ResourceError::Unsupported) —
-    ///   `require_rt()` was set and real-time could not be fully acquired.
-    /// - [`HorusError::Internal`](crate::error::HorusError::Internal) `"Fatal node failure during
-    ///   tick_once"` — a node's `tick()` panicked and its failure policy said stop, or an
-    ///   RT budget/deadline policy escalated to an emergency stop.
-    /// - [`HorusError::Internal`](crate::error::HorusError::Internal) `"Emergency stop triggered
-    ///   during tick_once"` — a safety monitor latched during this tick (watchdog expiry,
-    ///   external e-stop). The robot needs safing; this is not a retryable tick error.
+    /// A caller receives the umbrella [`HorusError`](crate::error::HorusError), so the
+    /// arms below are the shapes to match; the wrapped sub-error is the discriminator.
+    ///
+    /// - [`HorusError::InvalidInput`](crate::error::HorusError::InvalidInput) wrapping
+    ///   [`ValidationError::InvalidValue`](crate::error::ValidationError::InvalidValue)
+    ///   with `field == "node name"` — two nodes were added under the same name.
+    ///   Recorded by `build()`, reported here.
+    /// - [`HorusError::Resource`](crate::error::HorusError::Resource) wrapping
+    ///   [`ResourceError::Unsupported`](crate::error::ResourceError::Unsupported) with
+    ///   `feature == "Real-time scheduling"` — `require_rt()` was set and real-time could
+    ///   not be fully acquired.
+    /// - [`HorusError::Internal`](crate::error::HorusError::Internal) — the tick did not
+    ///   complete and the loop must not continue. Two conditions reach it: a node's
+    ///   `tick()` panicked and its failure policy said stop, or an RT budget/deadline
+    ///   policy escalated (message `"Fatal node failure during tick_once"`); and a safety
+    ///   monitor latching during this tick — watchdog expiry, external e-stop (message
+    ///   `"Emergency stop triggered during tick_once"`). Both mean the robot needs
+    ///   safing and neither is retryable, so branch on the variant, not on the text:
+    ///   `message` is diagnostic, not a stable discriminator.
     ///
     /// A failing `init()` is **not** in that list. The scheduler prints the error and
     /// leaves the node in its error state (at fatal severity it also stops the scheduler),
@@ -2516,12 +2525,24 @@ impl Scheduler {
     ///
     /// # Errors
     ///
-    /// - [`ValidationError::InvalidValue`](crate::error::ValidationError::InvalidValue) —
-    ///   two nodes were added under the same name. Recorded by `build()`, reported here.
-    /// - [`ResourceError::Unsupported`](crate::error::ResourceError::Unsupported) —
-    ///   `require_rt()` was set and real-time could not be fully acquired.
-    /// - [`HorusError::Contextual`](crate::error::HorusError::Contextual) — the scheduler's tokio
-    ///   runtime could not be created.
+    /// A caller receives the umbrella [`HorusError`](crate::error::HorusError), so the
+    /// arms below are the shapes to match; the wrapped sub-error is the discriminator.
+    ///
+    /// - [`HorusError::InvalidInput`](crate::error::HorusError::InvalidInput) wrapping
+    ///   [`ValidationError::InvalidValue`](crate::error::ValidationError::InvalidValue)
+    ///   with `field == "node name"` — two nodes were added under the same name.
+    ///   Recorded by `build()`, reported here.
+    /// - [`HorusError::Resource`](crate::error::HorusError::Resource) wrapping
+    ///   [`ResourceError::Unsupported`](crate::error::ResourceError::Unsupported) with
+    ///   `feature == "Real-time scheduling"` — `require_rt()` was set and real-time could
+    ///   not be fully acquired.
+    /// - [`HorusError::Contextual`](crate::error::HorusError::Contextual) — startup failed
+    ///   before the tick loop ever ran, with `source` carrying the cause. Two sites
+    ///   produce it: the scheduler's tokio runtime could not be created (message
+    ///   `"creating scheduler tokio runtime"`), and the RT executor refused to start
+    ///   (message `"starting RT executor thread pool"`) — two RT chains pinned to the
+    ///   same CPU, which `check_core_collisions()` rejects rather than start chains that
+    ///   cannot both meet their deadlines. No node has ticked when either is returned.
     ///
     /// Everything else the loop meets is handled in-place, so `Ok(())` is the return for
     /// an ordinary shutdown *and* for an abnormal one: a failing `init()` is printed and

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -2285,9 +2285,22 @@ impl Scheduler {
     ///
     /// # Errors
     ///
-    /// - [`NodeError::InitPanic`] — a node panicked during first-call `init()`
-    /// - [`NodeError::InitFailed`] — a node's `init()` returned an error
-    /// - [`NodeError::TickFailed`] — a node's `tick()` returned an error
+    /// - [`ValidationError::InvalidValue`](crate::error::ValidationError::InvalidValue) —
+    ///   two nodes were added under the same name. Recorded by `build()`, reported here.
+    /// - [`ResourceError::Unsupported`](crate::error::ResourceError::Unsupported) —
+    ///   `require_rt()` was set and real-time could not be fully acquired.
+    /// - [`HorusError::Internal`](crate::error::HorusError::Internal) `"Fatal node failure during
+    ///   tick_once"` — a node's `tick()` panicked and its failure policy said stop, or an
+    ///   RT budget/deadline policy escalated to an emergency stop.
+    /// - [`HorusError::Internal`](crate::error::HorusError::Internal) `"Emergency stop triggered
+    ///   during tick_once"` — a safety monitor latched during this tick (watchdog expiry,
+    ///   external e-stop). The robot needs safing; this is not a retryable tick error.
+    ///
+    /// A failing `init()` is **not** in that list. The scheduler prints the error and
+    /// leaves the node in its error state (at fatal severity it also stops the scheduler),
+    /// so `Ok(())` here does not mean every node initialized. Nor can a node's tick body
+    /// report an error: [`Node::tick`](crate::core::Node::tick) returns `()`, and a panic
+    /// inside it is caught and routed through the node's failure policy above.
     ///
     /// # Example
     /// ```rust,ignore
@@ -2503,10 +2516,19 @@ impl Scheduler {
     ///
     /// # Errors
     ///
-    /// - [`NodeError::InitPanic`] — a node panicked during `init()`
-    /// - [`NodeError::InitFailed`] — a node's `init()` returned an error
-    /// - [`ResourceError::Unsupported`] — `require_rt()` was set but RT is unavailable
-    /// - [`ConfigError`] — invalid scheduler configuration detected during finalization
+    /// - [`ValidationError::InvalidValue`](crate::error::ValidationError::InvalidValue) —
+    ///   two nodes were added under the same name. Recorded by `build()`, reported here.
+    /// - [`ResourceError::Unsupported`](crate::error::ResourceError::Unsupported) —
+    ///   `require_rt()` was set and real-time could not be fully acquired.
+    /// - [`HorusError::Contextual`](crate::error::HorusError::Contextual) — the scheduler's tokio
+    ///   runtime could not be created.
+    ///
+    /// Everything else the loop meets is handled in-place, so `Ok(())` is the return for
+    /// an ordinary shutdown *and* for an abnormal one: a failing `init()` is printed and
+    /// the node left in its error state, and an emergency stop (watchdog expiry, external
+    /// e-stop, Ctrl+C) breaks the loop and shuts down cleanly rather than erroring. Drive
+    /// the loop with [`tick_once()`](Self::tick_once) instead if the caller needs an
+    /// emergency stop reported as an `Err`.
     pub fn run(&mut self) -> HorusResult<()> {
         self.run_with_filter(None, None)
     }

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -5860,3 +5860,172 @@ fn a_zero_copy_publisher_is_attributed_under_a_real_scheduler() {
          (none)\""
     );
 }
+
+// ============================================================================
+// Error-contract Tests
+// ============================================================================
+
+/// The `# Errors` section of the doc comment attached to `signature`, taken from
+/// the scheduler source itself.
+///
+/// Panics if the text between the `# Errors` heading and the signature contains
+/// anything but doc lines and attributes — that would mean the heading belongs
+/// to an earlier item and the caller is asserting against the wrong function.
+fn errors_section(signature: &str) -> &'static str {
+    const SOURCE: &str = include_str!("mod.rs");
+    assert_eq!(
+        SOURCE.matches(signature).count(),
+        1,
+        "`{signature}` must occur exactly once in scheduler/mod.rs for this test to \
+         know which doc block it is reading"
+    );
+    let sig_at = SOURCE.find(signature).expect("signature counted above");
+    let errors_at = SOURCE[..sig_at]
+        .rfind("/// # Errors")
+        .unwrap_or_else(|| panic!("`{signature}` has no `# Errors` section"));
+    let section = &SOURCE[errors_at..sig_at];
+    for line in section.lines() {
+        let trimmed = line.trim_start();
+        assert!(
+            trimmed.is_empty() || trimmed.starts_with("///") || trimmed.starts_with("#["),
+            "the `# Errors` heading nearest `{signature}` is not part of its doc block \
+             (stray line: {line:?})"
+        );
+    }
+    section
+}
+
+/// `tick_once()`'s `# Errors` list is public API — `Scheduler` is in
+/// `horus::prelude` and a caller writes their `match` arms from it. It used to
+/// name `InitPanic`, `InitFailed` and `TickFailed`, none of which the function
+/// can return: `initialize_filtered_nodes()` prints every init error and returns
+/// `()`, and `Node::tick` is `fn tick(&mut self);`, so `TickFailed` has no
+/// producer anywhere in the crate. The errors it does return — including the one
+/// that means the emergency stop fired — were undocumented, so following that
+/// list gave you three dead arms and a silent fallthrough on the e-stop.
+///
+/// Prose has no compiler, so this is the check.
+#[test]
+fn test_tick_once_errors_doc_lists_only_reachable_errors() {
+    let section = errors_section("pub fn tick_once(&mut self)");
+
+    for unreachable in ["InitPanic", "InitFailed", "TickFailed"] {
+        assert!(
+            !section.contains(unreachable),
+            "`tick_once()` documents `{unreachable}`, which it cannot return.\n{section}"
+        );
+    }
+
+    for real in [
+        "ValidationError::InvalidValue",
+        "ResourceError::Unsupported",
+        "Fatal node failure",
+        "Emergency stop triggered",
+    ] {
+        assert!(
+            section.contains(real),
+            "`tick_once()` returns `{real}` and does not document it.\n{section}"
+        );
+    }
+}
+
+/// Same defect in `run()`'s list: two unreachable init variants plus a
+/// `ConfigError` that nothing on the `run()` path constructs, while the
+/// duplicate-node-name error it really returns (pinned by
+/// `test_duplicate_node_names_are_refused`) was missing.
+#[test]
+fn test_run_errors_doc_lists_only_reachable_errors() {
+    let section = errors_section("pub fn run(&mut self)");
+
+    for unreachable in ["InitPanic", "InitFailed", "ConfigError"] {
+        assert!(
+            !section.contains(unreachable),
+            "`run()` documents `{unreachable}`, which it cannot return.\n{section}"
+        );
+    }
+
+    for real in [
+        "ValidationError::InvalidValue",
+        "ResourceError::Unsupported",
+    ] {
+        assert!(
+            section.contains(real),
+            "`run()` returns `{real}` and does not document it.\n{section}"
+        );
+    }
+}
+
+/// The behaviour the doc above now claims, asserted against the real scheduler so
+/// the two cannot drift apart: a failed `init()` does not reach the caller, and a
+/// duplicate node name reaches it as `InvalidValue { field: "node name" }`.
+#[test]
+fn test_tick_once_error_contract_matches_behavior() {
+    let _guard = lock_scheduler();
+
+    struct FailingInitNode;
+    impl Node for FailingInitNode {
+        fn name(&self) -> &str {
+            "contract_bad_init"
+        }
+        fn init(&mut self) -> crate::error::HorusResult<()> {
+            Err(crate::HorusError::Node(
+                crate::error::NodeError::InitFailed {
+                    node: "contract_bad_init".to_string(),
+                    reason: "deliberate".to_string(),
+                },
+            ))
+        }
+        fn tick(&mut self) {}
+    }
+
+    let mut scheduler = Scheduler::new();
+    scheduler.add(FailingInitNode).order(0).build();
+    assert!(
+        scheduler.tick_once().is_ok(),
+        "an init() failure is reported by log line and node state, never by tick_once()"
+    );
+
+    let mut scheduler = Scheduler::new();
+    scheduler
+        .add(CounterNode::new("contract_dup"))
+        .order(0)
+        .build();
+    scheduler
+        .add(CounterNode::new("contract_dup"))
+        .order(1)
+        .build();
+    let err = scheduler
+        .tick_once()
+        .expect_err("a duplicate node name must fail the tick");
+    assert!(
+        matches!(
+            err,
+            crate::error::HorusError::InvalidInput(
+                crate::error::ValidationError::InvalidValue { ref field, .. }
+            ) if field == "node name"
+        ),
+        "expected the documented InvalidValue {{ field: \"node name\" }}, got: {err:?}"
+    );
+
+    let mut scheduler = Scheduler::new();
+    scheduler
+        .add(PanickingNode::new(
+            "contract_fatal",
+            0,
+            Arc::new(AtomicUsize::new(0)),
+        ))
+        .order(0)
+        .failure_policy(FailurePolicy::Fatal)
+        .build();
+    let err = scheduler
+        .tick_once()
+        .expect_err("a fatal node failure must fail the tick");
+    assert!(
+        matches!(
+            err,
+            crate::error::HorusError::Internal { ref message, .. }
+                if message.contains("Fatal node failure")
+        ),
+        "expected the documented Internal(\"Fatal node failure during tick_once\"), got: {err:?}"
+    );
+}

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -5990,7 +5990,14 @@ fn test_tick_once_error_contract_matches_behavior() {
     }
 
     let mut scheduler = Scheduler::new();
-    scheduler.add(FailingInitNode).order(0).build();
+    // `.build()` is unwrapped, not dropped: if registration failed, the scheduler
+    // below would be empty and `tick_once().is_ok()` would hold for the one reason
+    // this assertion must never accept — that no init() ran at all.
+    scheduler
+        .add(FailingInitNode)
+        .order(0)
+        .build()
+        .expect("the failing-init node must be registered for the assertion to mean anything");
     assert!(
         scheduler.tick_once().is_ok(),
         "an init() failure is reported by log line and node state, never by tick_once()"
@@ -6000,11 +6007,13 @@ fn test_tick_once_error_contract_matches_behavior() {
     scheduler
         .add(CounterNode::new("contract_dup"))
         .order(0)
-        .build();
+        .build()
+        .expect("the first node registers cleanly; the clash is recorded on the second");
     scheduler
         .add(CounterNode::new("contract_dup"))
         .order(1)
-        .build();
+        .build()
+        .expect("a duplicate name is recorded for tick_once(), not rejected by build()");
     let err = scheduler
         .tick_once()
         .expect_err("a duplicate node name must fail the tick");
@@ -6027,7 +6036,8 @@ fn test_tick_once_error_contract_matches_behavior() {
         ))
         .order(0)
         .failure_policy(FailurePolicy::Fatal)
-        .build();
+        .build()
+        .expect("the panicking node must be registered for the tick to have anything to fail on");
     let err = scheduler
         .tick_once()
         .expect_err("a fatal node failure must fail the tick");

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -5865,30 +5865,35 @@ fn a_zero_copy_publisher_is_attributed_under_a_real_scheduler() {
 // Error-contract Tests
 // ============================================================================
 
-/// The `# Errors` section of the doc comment attached to `signature`, taken from
+/// The `# Errors` section of the doc comment attached to `anchor`, taken from
 /// the scheduler source itself.
 ///
-/// Panics if the text between the `# Errors` heading and the signature contains
-/// anything but doc lines and attributes — that would mean the heading belongs
-/// to an earlier item and the caller is asserting against the wrong function.
-fn errors_section(signature: &str) -> &'static str {
+/// `anchor` is the item's name plus its opening paren (`"pub fn run("`) and
+/// nothing more, so a receiver change, an added return type or `where` clause,
+/// or a signature wrapped across lines does not move it. Two assertions keep the
+/// lookup honest instead: the anchor must appear exactly once in the file, and
+/// the text between the `# Errors` heading and it must be doc lines and
+/// attributes only — anything else means the heading belongs to an earlier item
+/// and the caller would be asserting against the wrong function. Both failures
+/// are loud, so this cannot silently read the wrong doc block.
+fn errors_section(anchor: &str) -> &'static str {
     const SOURCE: &str = include_str!("mod.rs");
     assert_eq!(
-        SOURCE.matches(signature).count(),
+        SOURCE.matches(anchor).count(),
         1,
-        "`{signature}` must occur exactly once in scheduler/mod.rs for this test to \
+        "`{anchor}` must occur exactly once in scheduler/mod.rs for this test to \
          know which doc block it is reading"
     );
-    let sig_at = SOURCE.find(signature).expect("signature counted above");
+    let sig_at = SOURCE.find(anchor).expect("anchor counted above");
     let errors_at = SOURCE[..sig_at]
         .rfind("/// # Errors")
-        .unwrap_or_else(|| panic!("`{signature}` has no `# Errors` section"));
+        .unwrap_or_else(|| panic!("`{anchor}` has no `# Errors` section"));
     let section = &SOURCE[errors_at..sig_at];
     for line in section.lines() {
         let trimmed = line.trim_start();
         assert!(
             trimmed.is_empty() || trimmed.starts_with("///") || trimmed.starts_with("#["),
-            "the `# Errors` heading nearest `{signature}` is not part of its doc block \
+            "the `# Errors` heading nearest `{anchor}` is not part of its doc block \
              (stray line: {line:?})"
         );
     }
@@ -5907,7 +5912,7 @@ fn errors_section(signature: &str) -> &'static str {
 /// Prose has no compiler, so this is the check.
 #[test]
 fn test_tick_once_errors_doc_lists_only_reachable_errors() {
-    let section = errors_section("pub fn tick_once(&mut self)");
+    let section = errors_section("pub fn tick_once(");
 
     for unreachable in ["InitPanic", "InitFailed", "TickFailed"] {
         assert!(
@@ -5917,7 +5922,9 @@ fn test_tick_once_errors_doc_lists_only_reachable_errors() {
     }
 
     for real in [
+        "HorusError::InvalidInput",
         "ValidationError::InvalidValue",
+        "HorusError::Resource",
         "ResourceError::Unsupported",
         "Fatal node failure",
         "Emergency stop triggered",
@@ -5935,7 +5942,7 @@ fn test_tick_once_errors_doc_lists_only_reachable_errors() {
 /// `test_duplicate_node_names_are_refused`) was missing.
 #[test]
 fn test_run_errors_doc_lists_only_reachable_errors() {
-    let section = errors_section("pub fn run(&mut self)");
+    let section = errors_section("pub fn run(");
 
     for unreachable in ["InitPanic", "InitFailed", "ConfigError"] {
         assert!(
@@ -5945,8 +5952,12 @@ fn test_run_errors_doc_lists_only_reachable_errors() {
     }
 
     for real in [
+        "HorusError::InvalidInput",
         "ValidationError::InvalidValue",
+        "HorusError::Resource",
         "ResourceError::Unsupported",
+        "HorusError::Contextual",
+        "starting RT executor thread pool",
     ] {
         assert!(
             section.contains(real),
@@ -6027,5 +6038,134 @@ fn test_tick_once_error_contract_matches_behavior() {
                 if message.contains("Fatal node failure")
         ),
         "expected the documented Internal(\"Fatal node failure during tick_once\"), got: {err:?}"
+    );
+}
+
+/// `run()`'s doc promises the opposite return from `tick_once()`'s for the same
+/// event: an emergency stop breaks the loop and the call comes back `Ok(())`,
+/// where `tick_once()` reports it as `Internal("Emergency stop triggered …")`.
+/// That asymmetry is the whole reason a caller picks one entry point over the
+/// other, so it is asserted rather than described.
+///
+/// The stop is fired the way horus_net fires it on link loss —
+/// `trigger_external_emergency_stop`, through the global hook `finalize_config`
+/// installs. `finalize_and_init()` runs first so the hook is live before the
+/// trigger; it is guarded by `self.initialized`, so `run_for` below re-enters an
+/// already-finalized scheduler and the latch survives into the loop.
+///
+/// The elapsed-time assertion is what makes this non-vacuous: without it the
+/// test would also pass if the loop simply ran its duration out.
+#[test]
+fn test_run_reports_an_emergency_stop_as_ok() {
+    let _guard = lock_scheduler();
+
+    struct EstopNode;
+    impl Node for EstopNode {
+        fn name(&self) -> &str {
+            "contract_estop"
+        }
+        fn tick(&mut self) {}
+    }
+
+    let mut scheduler = Scheduler::new()
+        .tick_rate(100_u64.hz())
+        .watchdog(500_u64.ms());
+    // A per-node watchdog registers the node as critical, which is what enables
+    // the safety monitor the external hook latches.
+    scheduler
+        .add(EstopNode)
+        .watchdog(100_u64.ms())
+        .build()
+        .unwrap();
+    scheduler.finalize_and_init();
+    assert!(
+        !scheduler
+            .monitor
+            .safety
+            .as_ref()
+            .expect("a per-node watchdog enables the safety monitor")
+            .is_emergency_stop(),
+        "no emergency stop before the trigger"
+    );
+
+    crate::scheduling::safety_monitor::trigger_external_emergency_stop(
+        "error-contract test: external e-stop".to_string(),
+    );
+    assert!(
+        scheduler
+            .monitor
+            .safety
+            .as_ref()
+            .unwrap()
+            .is_emergency_stop(),
+        "the external trigger must latch this scheduler's monitor"
+    );
+
+    let started = Instant::now();
+    let result = scheduler.run_for(5_u64.secs());
+    let elapsed = started.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "run() reports an emergency stop as a clean shutdown, never as an Err: {result:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "the e-stop must break the loop, not let it run the duration out (took {elapsed:?})"
+    );
+}
+
+/// The second `HorusError::Contextual` `run()` documents. The first — a tokio
+/// runtime that will not build — has no seam to force from a test; this one
+/// does, and it is the one a user actually meets: two RT chains pinned to the
+/// same CPU. `check_core_collisions()` refuses before a single RT thread is
+/// spawned, so the test needs no RT privileges and no CPU 0 affinity.
+///
+/// Without this the doc's claim about the RT-executor path would be prose only
+/// — which is the exact failure mode this PR exists to fix.
+#[test]
+fn test_run_reports_a_refused_rt_executor_as_contextual() {
+    if std::env::var("HORUS_RT_ALLOW_CORE_SHARING")
+        .is_ok_and(|v| !v.is_empty() && v != "0" && v != "false")
+    {
+        // The operator opted into shared RT cores; the refusal is by design off.
+        return;
+    }
+    let _guard = lock_scheduler();
+
+    struct RtNode(&'static str);
+    impl Node for RtNode {
+        fn name(&self) -> &str {
+            self.0
+        }
+        fn tick(&mut self) {}
+    }
+
+    // `.rate()` promotes each node to ExecutionClass::Rt, and each RT node is its
+    // own chain — so this is two chains explicitly naming CPU 0.
+    let mut scheduler = Scheduler::new().tick_rate(100_u64.hz());
+    scheduler
+        .add(RtNode("contract_rt_a"))
+        .rate(50_u64.hz())
+        .core(0)
+        .build()
+        .unwrap();
+    scheduler
+        .add(RtNode("contract_rt_b"))
+        .rate(50_u64.hz())
+        .core(0)
+        .build()
+        .unwrap();
+
+    let err = scheduler
+        .run_for(200_u64.ms())
+        .expect_err("two RT chains on one core must refuse to start");
+    assert!(
+        matches!(
+            err,
+            crate::error::HorusError::Contextual { ref message, .. }
+                if message == "starting RT executor thread pool"
+        ),
+        "expected the documented Contextual(\"starting RT executor thread pool\"), got: {err:?}"
     );
 }


### PR DESCRIPTION
`Scheduler::tick_once`'s `# Errors` named `NodeError::InitPanic`,
`NodeError::InitFailed` and `NodeError::TickFailed`. None of the three can come
out of it. `finalize_and_init()` returns `()` and `initialize_filtered_nodes()`
swallows every init error (prints it, transitions the node to error/crashed, and
on fatal severity calls `self.stop()` and returns), so no init error reaches a
caller; `Node::tick` is `fn tick(&mut self);`, so `TickFailed` has no producer
anywhere in the workspace — only its definition, its Display arm and one unit
test.

Meanwhile every error the function does return was undocumented: the
duplicate-node-name `ValidationError::InvalidValue`, the `require_rt()`
`ResourceError::Unsupported`, and two `HorusError::Internal`s — "Fatal node
failure during tick_once" and "Emergency stop triggered during tick_once".
`Scheduler` is in `horus::prelude`, so a caller matching the documented contract
wrote three dead arms and fell through on the one that means the emergency stop
fired. `run()`'s list had the same defect plus a `ConfigError` that nothing on
its path constructs, and omitted the duplicate-name error it does return (pinned
by `test_duplicate_node_names_are_refused`).

Both lists are replaced with what the code returns, `run()` gains the note that
an e-stop is an `Ok(())` there (it breaks the loop; `tick_once()` is the surface
that reports it as `Err`), and `NodeError::TickFailed`'s doc no longer describes
a fallible `tick()` the trait does not have. The variant itself is left alone:
`#[non_exhaustive]` blocks downstream exhaustive matching but not downstream
construction, so removing it would be a breaking change.

Three tests: two read the `# Errors` block back out of `scheduler/mod.rs` and
assert it names no unreachable variant and every real one (prose has no
compiler), and one drives the real scheduler to show the three claims hold — a
failing `init()` returns `Ok(())`, duplicate names return
`InvalidValue { field: "node name" }`, and a panicking tick under
`FailurePolicy::Fatal` returns `Internal("Fatal node failure during tick_once")`.

## Ablation

```
Reverted ONLY the two production files (`git checkout -- horus_core/src/scheduling/scheduler/mod.rs horus_core/src/error.rs`), kept all three new tests (`git diff --stat` then showed only `horus_core/src/scheduling/scheduler/tests.rs | 169 +++`), and ran:

  cargo test -p horus_core --lib -- scheduler::tests::test_tick_once_errors scheduler::tests::test_run_errors scheduler::tests::test_tick_once_error_contract

EXACT output (tail):

failures:

---- scheduling::scheduler::tests::test_run_errors_doc_lists_only_reachable_errors stdout ----

thread 'scheduling::scheduler::tests::test_run_errors_doc_lists_only_reachable_errors' (1993872) panicked at horus_core/src/scheduling/scheduler/tests.rs:5941:9:
`run()` documents `InitPanic`, which it cannot return.
/// # Errors
    ///
    /// - [`NodeError::InitPanic`] — a node panicked during `init()`
    /// - [`NodeError::InitFailed`] — a node's `init()` returned an error
    /// - [`ResourceError::Unsupported`] — `require_rt()` was set but RT is unavailable
    /// - [`ConfigError`] — invalid scheduler configuration detected during finalization
    
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- scheduling::scheduler::tests::test_tick_once_errors_doc_lists_only_reachable_errors stdout ----

thread 'scheduling::scheduler::tests::test_tick_once_errors_doc_lists_only_reachable_errors' (1993874) panicked at horus_core/src/scheduling/scheduler/tests.rs:5913:9:
`tick_once()` documents `InitPanic`, which it cannot return.
/// # Errors
    ///
    /// - [`NodeError::InitPanic`] — a node panicked during first-call `init()`
    /// - [`NodeError::InitFailed`] — a node's `init()` returned an error
    /// - [`NodeError::TickFailed`] — a node's `tick()` returned an error
    ///
    /// # Example
    /// ```rust,ignore
    /// let mut scheduler = Scheduler::new()
    ///     .tick_rate(100_u64.hz());
    ///
    /// scheduler.add(MyNode::new()).build()?;
    ///
    /// // Simulation loop
    /// loop {
    ///     sim.step_physics(dt);
    ///     scheduler.tick_once()?;
    ///     sim.render();
    /// }
    /// ```
    


failures:
    scheduling::scheduler::tests::test_run_errors_doc_lists_only_reachable_errors
    scheduling::scheduler::tests::test_tick_once_errors_doc_lists_only_reachable_errors

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 2501 filtered out; finished in 0.04s

error: test failed, to rerun pass `-p horus_core --lib`

Production change then restored from the /tmp backups; `git diff --stat` back to 3 files, 206 insertions, 9 deletions, and the full
```

## Tests

```
All in the worktree /home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-15.

- `cargo test -p horus_core --lib` (full crate suite): **2500 passed, 0 failed, 4 ignored** (56.02s). Run 4 times total; 3 green, 1 run had a single unrelated flake — see notes.
- `cargo test -p horus_core --lib scheduler::tests::`: **181 passed, 0 failed** (31.80s) — 178 pre-existing + my 3.
- `cargo test -p horus_core --lib error::`: **100 passed, 0 failed**.
- New tests alone (`test_tick_once_errors_doc_lists_only_reachable_errors`, `test_run_errors_doc_lists_only_reachable_errors`, `test_tick_once_error_contract_matches_behavior`): **3 passed, 0 failed**; with the production change ablated: **1 passed, 2 failed** (output above).
- `cargo fmt --all -- --check`: clean (exit 0).
- `cargo clippy -p horus_core --lib --all-features` and `cargo clippy -p horus_core --lib --tests`: zero warnings, zero errors.
- `cargo doc -p horus_core --no-deps` after touching both files: "Documenting horus_core v0.4.0 / Finished", **no rustdoc warnings** — every new intra-doc link resolves (the old `[`NodeError::InitPanic`]`-style short links had no `NodeError` import in scheduler/mod.rs, so the replacements use explicit `crate::error::…` targets).
```

## Notes from the implementer

Confirmed the finding myself before touching anything, and it holds:
- `tick_once` (mod.rs:2306 pre-change) calls `finalize_and_init` (2238) which returns `()`; that calls `initialize_filtered_nodes` (3208), also `()`, whose Err arm (3273-3303) prints, transitions the node to error/crashed, and on `Severity::Fatal` calls `self.stop()` and returns. No init error can escape either entry point.
- `Node::tick` is `fn tick(&mut self);` at core/node.rs:992. Workspace-wide grep for `TickFailed` outside target/: error.rs:264 (definition), 1125 (help arm), 1494-1506 (one unit test), plus the doc line I removed. Zero production constructors, and no other trait in the workspace has a fallible tick.
- `run()`'s `ConfigError` claim: the only `ConfigError` constructions in the scheduler (mod.rs:1719, 1755, 1782) are in `add_critical_node`, `set_tick_budget` and `set_os_priority` — none on the `run()` path. `finalize_config` returns `()`.

What I verified at runtime vs. by reading:
- Runtime-verified (in `test_tick_once_error_contract_matches_behavior`): init failure → `Ok(())`; duplicate names → `InvalidValue { field: "node name" }`; panicking tick under `FailurePolicy::Fatal` → `Internal("Fatal node failure during tick_once")`.
- Read-only: the `"Emergency stop triggered during tick_once"` return (mod.rs:2416, reached via `check_safety_monitors()`), and `run()`'s `Contextual` return from a failed tokio-runtime build. I traced both but did not force either at runtime — no existing test covers them either. If a reviewer wants those pinned, a watchdog-expiry test driving `tick_once` would do it.

Honest limits of the tests:
- The behaviour test passes with or without the doc change; it is the anchor that keeps the new prose true, not the thing that bites. The two source-scraping tests are what fail on ablation. They assert on a fixed list of variant names and message fragments, so they catch exactly the regression that happened (an unreachable variant named, a real one dropped) — t

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
