### PR TITLE
fix(cpp): refuse to start on a malformed params.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ and `Unreleased` is left empty rather than deleted.
 
 ## Unreleased
 
+### Fixed
+
+- **cpp** — a malformed `.horus/config/params.yaml` no longer downgrades a C++
+  node to the built-in safety limits. `horus::Params` was the only one of the
+  three bindings that started anyway: Rust's `RuntimeParams::new()` returns
+  `Err` and Python's `Params()` raises, but the C++ constructor took
+  `unwrap_or_default()` and served `max_speed = 1.0` and
+  `emergency_stop_distance = 0.3` under the operator's name, with no channel to
+  tell the caller. `horus_params_new` now returns `NULL` on that path and the
+  `horus::Params` constructor throws `horus::Error`.
+
 ## [0.4.0] — 2026-08-22
 
 The first release since 0.2.2 (2026-07-19). **0.3.0 was tagged and never

--- a/horus_cpp/fuzz/fuzz_targets/fuzz_params.rs
+++ b/horus_cpp/fuzz/fuzz_targets/fuzz_params.rs
@@ -10,6 +10,8 @@ fuzz_target!(|data: &[u8]| {
     let val_bytes = if split < data.len() { &data[split + 1..] } else { &[][..] };
     let Ok(key) = std::str::from_utf8(key_bytes) else { return };
     let Ok(val) = std::str::from_utf8(val_bytes) else { return };
-    let p = horus_cpp::params_new();
+    // None only when a malformed .horus/config/params.yaml sits under the fuzz
+    // working directory, which is not what this target is exercising.
+    let Some(p) = horus_cpp::params_new() else { return };
     let _ = horus_cpp::params_set(&p, key, val);
 });

--- a/horus_cpp/include/horus/horus_c.h
+++ b/horus_cpp/include/horus/horus_c.h
@@ -526,6 +526,8 @@ void             horus_pointcloud_destroy(HorusPointCloud* pc);
 
 typedef struct HorusParams HorusParams;
 
+/* Returns NULL if .horus/config/params.yaml exists but is unreadable or
+   malformed; the reason is written to stderr. */
 HorusParams* horus_params_new(void);
 void         horus_params_destroy(HorusParams* params);
 int          horus_params_get_f64(const HorusParams* params, const char* key, double* out);

--- a/horus_cpp/include/horus/params.hpp
+++ b/horus_cpp/include/horus/params.hpp
@@ -1,7 +1,7 @@
 // RuntimeParams — dynamic configuration for nodes.
 //
 // Usage:
-//   auto params = horus::Params();
+//   auto params = horus::Params();          // throws horus::Error on a bad params.yaml
 //   params.set("max_speed", 1.5);
 //   params.set("enabled", true);
 //   params.set("name", "robot1");
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "horus_c.h"
+#include "error.hpp"
 #include <cstdint>
 #include <string>
 #include <optional>
@@ -18,7 +19,18 @@ namespace horus {
 
 class Params {
 public:
-    Params() : handle_(horus_params_new()) {}
+    // A .horus/config/params.yaml that exists but does not parse is a hard
+    // error, the same as it already is in Rust (RuntimeParams::new returns Err)
+    // and Python (Params() raises). Constructing anyway would hand back the
+    // built-in limits — max_speed 1.0, emergency_stop_distance 0.3 — under the
+    // operator's name, and get<T>(key, default) gives the caller no way to tell
+    // those apart from the values in the file.
+    Params() : handle_(horus_params_new()) {
+        if (!handle_) {
+            throw Error(".horus/config/params.yaml exists but could not be read "
+                        "or parsed (reason on stderr) — fix the file or remove it");
+        }
+    }
     ~Params() { if (handle_) horus_params_destroy(handle_); }
 
     // Move only

--- a/horus_cpp/src/c_api.rs
+++ b/horus_cpp/src/c_api.rs
@@ -1128,10 +1128,14 @@ pub struct HorusParams {
     _opaque: [u8; 0],
 }
 
-/// Create a new params store.
+/// Create a new params store. Returns null if `.horus/config/params.yaml`
+/// exists but could not be read or parsed; the reason is on stderr.
 #[no_mangle]
 pub extern "C" fn horus_params_new() -> *mut HorusParams {
-    Box::into_raw(params_ffi::params_new()) as *mut HorusParams
+    match params_ffi::params_new() {
+        Some(p) => Box::into_raw(p) as *mut HorusParams,
+        None => std::ptr::null_mut(),
+    }
 }
 
 /// Destroy params store.

--- a/horus_cpp/src/e2e_tests.rs
+++ b/horus_cpp/src/e2e_tests.rs
@@ -233,7 +233,16 @@ mod tests {
     fn e2e_params_pipeline() {
         use crate::params_ffi::*;
 
-        let params = params_new().expect("no params.yaml in the test working directory");
+        // `None` only if a malformed or unreadable .horus/config/params.yaml
+        // exists under the directory cargo ran this test from; refusing there
+        // is the behaviour under test in tests/params_malformed_yaml.rs, which
+        // owns its own cwd. Chdir'ing here instead would be process-global and
+        // race the other tests in this binary, which libtest runs in parallel.
+        let params = params_new().expect(
+            "params_new refused: fix or remove the malformed \
+             .horus/config/params.yaml under the test working directory \
+             (reason on stderr above)",
+        );
 
         // Set various types
         params_set_f64(&params, "max_speed", 2.5).unwrap();

--- a/horus_cpp/src/e2e_tests.rs
+++ b/horus_cpp/src/e2e_tests.rs
@@ -233,7 +233,7 @@ mod tests {
     fn e2e_params_pipeline() {
         use crate::params_ffi::*;
 
-        let params = params_new();
+        let params = params_new().expect("no params.yaml in the test working directory");
 
         // Set various types
         params_set_f64(&params, "max_speed", 2.5).unwrap();

--- a/horus_cpp/src/params_ffi.rs
+++ b/horus_cpp/src/params_ffi.rs
@@ -101,15 +101,40 @@ pub fn params_has(params: &FfiParams, key: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// No `.horus/config/params.yaml` under the test working directory, so
-    /// `params_new` cannot fail here.
+    /// These tests exercise the getters and setters, not the constructor, but
+    /// `params_new` is the only way to build an `FfiParams` from outside this
+    /// module: `RuntimeParams` has no path-taking constructor, and its
+    /// `Default` is `new().unwrap_or_else(..)`, which reads the same
+    /// cwd-relative file. So they inherit its dependency on the ambient
+    /// `.horus/config/params.yaml` being absent or well-formed.
+    ///
+    /// Deliberately NOT addressed by chdir'ing to a temp directory:
+    /// `set_current_dir` is process-global and libtest runs this binary's tests
+    /// on parallel threads, several of which do cwd-relative I/O — every
+    /// `params_set_*` below appends to `.horus/logs/param_changes.log`. A chdir
+    /// from one test thread would redirect the others' writes. The malformed
+    /// file is covered instead by `tests/params_malformed_yaml.rs`, a separate
+    /// binary that owns the process cwd.
     fn params() -> Box<FfiParams> {
-        params_new().expect("params_new failed with no params.yaml present")
+        params_new().unwrap_or_else(|| {
+            panic!(
+                "params_new returned None: a malformed or unreadable \
+                 .horus/config/params.yaml exists under the directory cargo ran \
+                 this test from (reason on stderr above). Fix or remove that \
+                 file — this test is about the accessors, not the config file."
+            )
+        })
     }
 
     #[test]
     fn create_params() {
-        assert!(params_new().is_some());
+        assert!(
+            params_new().is_some(),
+            "params_new refused to build a store: a malformed or unreadable \
+             .horus/config/params.yaml exists under the directory cargo ran this \
+             test from (reason on stderr above). The refusal itself is the \
+             intended behaviour and is covered by tests/params_malformed_yaml.rs."
+        );
     }
 
     #[test]

--- a/horus_cpp/src/params_ffi.rs
+++ b/horus_cpp/src/params_ffi.rs
@@ -9,11 +9,29 @@ pub struct FfiParams {
     inner: RuntimeParams,
 }
 
-/// Create a new empty params store.
-pub fn params_new() -> Box<FfiParams> {
-    Box::new(FfiParams {
-        inner: RuntimeParams::new().unwrap_or_default(),
-    })
+/// Create a new params store. Returns `None` if `.horus/config/params.yaml`
+/// exists but cannot be read or parsed.
+///
+/// This used to be `RuntimeParams::new().unwrap_or_default()`, the only one of
+/// the 13 `RuntimeParams` construction sites in the workspace that swallowed
+/// the error — `horus_manager` (including the `horus run` launcher) and
+/// `horus_py` all propagate it. `RuntimeParams::default()` scopes its fallback
+/// to "a caller that reached Default has no way to handle the error", which is
+/// not true here: the C ABI can return null. The cost of the escape hatch was
+/// that a typo in params.yaml restored the built-in `max_speed = 1.0` and
+/// `emergency_stop_distance = 0.3` under the operator's name, with no way for
+/// a C++ caller to tell that had happened.
+///
+/// The reason goes to stderr because the C ABI carries no error channel; the
+/// `horus::Params` constructor turns the null into a `horus::Error`.
+pub fn params_new() -> Option<Box<FfiParams>> {
+    match RuntimeParams::new() {
+        Ok(inner) => Some(Box::new(FfiParams { inner })),
+        Err(e) => {
+            horus_core::terminal::eprint_line(&format!("[PARAMS] {e}"));
+            None
+        }
+    }
 }
 
 /// Get a parameter value as JSON string. Returns None if not found.
@@ -83,49 +101,55 @@ pub fn params_has(params: &FfiParams, key: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// No `.horus/config/params.yaml` under the test working directory, so
+    /// `params_new` cannot fail here.
+    fn params() -> Box<FfiParams> {
+        params_new().expect("params_new failed with no params.yaml present")
+    }
+
     #[test]
     fn create_params() {
-        let _p = params_new();
+        assert!(params_new().is_some());
     }
 
     #[test]
     fn set_and_get_f64() {
-        let p = params_new();
+        let p = params();
         params_set_f64(&p, "max_speed", 1.5).unwrap();
         assert_eq!(params_get_f64(&p, "max_speed"), Some(1.5));
     }
 
     #[test]
     fn set_and_get_i64() {
-        let p = params_new();
+        let p = params();
         params_set_i64(&p, "count", 42).unwrap();
         assert_eq!(params_get_i64(&p, "count"), Some(42));
     }
 
     #[test]
     fn set_and_get_bool() {
-        let p = params_new();
+        let p = params();
         params_set_bool(&p, "enabled", true).unwrap();
         assert_eq!(params_get_bool(&p, "enabled"), Some(true));
     }
 
     #[test]
     fn set_and_get_string() {
-        let p = params_new();
+        let p = params();
         params_set_string(&p, "name", "robot1").unwrap();
         assert_eq!(params_get_string(&p, "name"), Some("robot1".to_string()));
     }
 
     #[test]
     fn get_missing_returns_none() {
-        let p = params_new();
+        let p = params();
         assert_eq!(params_get_f64(&p, "missing"), None);
         assert!(!params_has(&p, "missing"));
     }
 
     #[test]
     fn set_and_get_json() {
-        let p = params_new();
+        let p = params();
         params_set(&p, "config", r#"{"a": 1, "b": "hello"}"#).unwrap();
         let json = params_get(&p, "config");
         assert!(json.is_some());
@@ -136,14 +160,14 @@ mod tests {
 
     #[test]
     fn has_returns_true_after_set() {
-        let p = params_new();
+        let p = params();
         params_set_f64(&p, "x", 1.0).unwrap();
         assert!(params_has(&p, "x"));
     }
 
     #[test]
     fn invalid_json_returns_error() {
-        let p = params_new();
+        let p = params();
         let result = params_set(&p, "bad", "not json{");
         assert!(result.is_err());
     }

--- a/horus_cpp/tests/params_malformed_yaml.rs
+++ b/horus_cpp/tests/params_malformed_yaml.rs
@@ -5,18 +5,21 @@
 //! Its own test binary on purpose: `RuntimeParams::new` resolves the parameter
 //! file relative to the process working directory, and `set_current_dir` is
 //! process-global, so this cannot share a binary with tests running in parallel
-//! next to it. Cargo runs test binaries one at a time, so this one owns the
-//! process cwd for as long as it holds it.
+//! next to it. Alone in a binary it owns the process cwd outright, and no
+//! ordering guarantee from the test runner is needed for that: every other test
+//! binary is a separate process with its own cwd, so they cannot see this one's
+//! chdir whether the runner interleaves them or not.
 
 use horus_cpp::{params_get_f64, params_new};
 use std::path::PathBuf;
 
-/// Enters a scratch directory and guarantees the process cwd is restored, and
-/// the directory removed, even if the test panics while inside it.
+/// Enters a scratch directory and restores the process cwd on the way out, even
+/// if the test panics while inside it. Removing the directory afterwards is
+/// best effort; the cwd restore is not — see `Drop`.
 ///
 /// Order matters on drop: the cwd is restored BEFORE the directory is removed,
 /// so the process is never left sitting in a deleted working directory, where
-/// every later relative path — including the next test binary's — fails.
+/// every later relative path in this process fails.
 struct ScratchCwd {
     previous: PathBuf,
     dir: PathBuf,
@@ -33,8 +36,29 @@ impl ScratchCwd {
 
 impl Drop for ScratchCwd {
     fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.previous);
+        let restored = std::env::set_current_dir(&self.previous);
+
+        // Removing the scratch directory stays best effort. It is named per
+        // pid and nanosecond, so a leaked one is inert and never adopted by a
+        // later run; failing the test over it would turn an already-decided
+        // result red for a reason the test does not assert.
         let _ = std::fs::remove_dir_all(&self.dir);
+
+        // The cwd is not best effort. A silent failure here leaves the whole
+        // process in the scratch directory — deleted, after the line above —
+        // and every relative path the rest of this binary touches then fails
+        // somewhere far from the cause. That is exactly the confusing
+        // follow-on failure this guard exists to prevent, so say it here.
+        // Not while unwinding, though: a panic during a panic aborts the
+        // process and buries the assertion failure that started it.
+        if !std::thread::panicking() {
+            restored.unwrap_or_else(|e| {
+                panic!(
+                    "could not restore the working directory to {}: {e}",
+                    self.previous.display()
+                )
+            });
+        }
     }
 }
 

--- a/horus_cpp/tests/params_malformed_yaml.rs
+++ b/horus_cpp/tests/params_malformed_yaml.rs
@@ -5,25 +5,67 @@
 //! Its own test binary on purpose: `RuntimeParams::new` resolves the parameter
 //! file relative to the process working directory, and `set_current_dir` is
 //! process-global, so this cannot share a binary with tests running in parallel
-//! next to it.
+//! next to it. Cargo runs test binaries one at a time, so this one owns the
+//! process cwd for as long as it holds it.
 
 use horus_cpp::{params_get_f64, params_new};
+use std::path::PathBuf;
+
+/// Enters a scratch directory and guarantees the process cwd is restored, and
+/// the directory removed, even if the test panics while inside it.
+///
+/// Order matters on drop: the cwd is restored BEFORE the directory is removed,
+/// so the process is never left sitting in a deleted working directory, where
+/// every later relative path — including the next test binary's — fails.
+struct ScratchCwd {
+    previous: PathBuf,
+    dir: PathBuf,
+}
+
+impl ScratchCwd {
+    fn enter(dir: PathBuf) -> Self {
+        let previous = std::env::current_dir().expect("current working directory is readable");
+        std::env::set_current_dir(&dir)
+            .unwrap_or_else(|e| panic!("cannot enter {}: {e}", dir.display()));
+        Self { previous, dir }
+    }
+}
+
+impl Drop for ScratchCwd {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.previous);
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// A directory this run has to itself. The pid separates concurrent instances
+/// of this binary; the timestamp additionally separates this run from a stale
+/// directory an earlier killed run left behind under a since-recycled pid,
+/// which `create_dir_all` would otherwise silently adopt.
+fn scratch_dir() -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "horus_cpp_params_malformed_{}_{nanos}",
+        std::process::id()
+    ))
+}
 
 #[test]
 fn params_new_refuses_malformed_params_yaml() {
-    let dir =
-        std::env::temp_dir().join(format!("horus_cpp_params_malformed_{}", std::process::id()));
+    let dir = scratch_dir();
     let config = dir.join(".horus").join("config");
     std::fs::create_dir_all(&config).unwrap();
     // Unterminated flow sequence: serde_yaml rejects it, and it is the shape of
     // typo an operator makes editing limits by hand.
     std::fs::write(config.join("params.yaml"), "max_speed: [1.0\n").unwrap();
 
-    let previous = std::env::current_dir().unwrap();
-    std::env::set_current_dir(&dir).unwrap();
-    let params = params_new();
-    std::env::set_current_dir(&previous).unwrap();
-    let _ = std::fs::remove_dir_all(&dir);
+    let params = {
+        let _cwd = ScratchCwd::enter(dir.clone());
+        params_new()
+    }; // cwd restored and `dir` removed here, panic or not.
 
     // Name what the caller would otherwise have been handed: the built-in
     // `max_speed` of 1.0, which is looser than whatever the operator wrote.

--- a/horus_cpp/tests/params_malformed_yaml.rs
+++ b/horus_cpp/tests/params_malformed_yaml.rs
@@ -1,0 +1,38 @@
+//! A malformed `.horus/config/params.yaml` must stop a C++ node from starting.
+//!
+//! Run: cargo test --no-default-features -p horus_cpp --test params_malformed_yaml
+//!
+//! Its own test binary on purpose: `RuntimeParams::new` resolves the parameter
+//! file relative to the process working directory, and `set_current_dir` is
+//! process-global, so this cannot share a binary with tests running in parallel
+//! next to it.
+
+use horus_cpp::{params_get_f64, params_new};
+
+#[test]
+fn params_new_refuses_malformed_params_yaml() {
+    let dir =
+        std::env::temp_dir().join(format!("horus_cpp_params_malformed_{}", std::process::id()));
+    let config = dir.join(".horus").join("config");
+    std::fs::create_dir_all(&config).unwrap();
+    // Unterminated flow sequence: serde_yaml rejects it, and it is the shape of
+    // typo an operator makes editing limits by hand.
+    std::fs::write(config.join("params.yaml"), "max_speed: [1.0\n").unwrap();
+
+    let previous = std::env::current_dir().unwrap();
+    std::env::set_current_dir(&dir).unwrap();
+    let params = params_new();
+    std::env::set_current_dir(&previous).unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // Name what the caller would otherwise have been handed: the built-in
+    // `max_speed` of 1.0, which is looser than whatever the operator wrote.
+    let served = params.as_ref().and_then(|p| params_get_f64(p, "max_speed"));
+    assert!(
+        params.is_none(),
+        "params_new built a store from a malformed params.yaml, serving \
+         max_speed={served:?} from the built-in safety limits. Rust \
+         (RuntimeParams::new) and Python (Params()) both refuse to start here; \
+         the C++ bindings must too."
+    );
+}


### PR DESCRIPTION
`params_ffi::params_new` was `RuntimeParams::new().unwrap_or_default()` — the
only one of the 13 `RuntimeParams` construction sites in the workspace that
swallowed the error. `horus_manager` (nine sites, including the `horus run`
launcher), both Rust examples and `horus_py` all propagate it, and
`RuntimeParams::new` documents why: "Failing startup is recoverable; running
with limits nobody chose is not."

`RuntimeParams::default()` scopes its fallback to "a caller that reached
Default has no way to handle the error". The FFI layer is not such a caller —
the C ABI can return null, which is what every sibling constructor in
`c_api.rs` already does. The cost of the escape hatch was that a typo in
`.horus/config/params.yaml` restored the built-in `max_speed = 1.0` and
`emergency_stop_distance = 0.3` under the operator's name, and a C++ caller
could not tell: `horus_params_new` had no failure return, and the getters
null-check and fall through to the caller-supplied default, so even a null
handle would have degraded silently. The stderr warning it did emit was
self-contradictory, pairing the inner "Refusing to start on built-in defaults"
with the outer "Falling back to BUILT-IN DEFAULTS".

`params_new` now returns `Option<Box<FfiParams>>` and prints the real reason
once; `horus_params_new` returns NULL on that path; and `horus::Params()`
throws `horus::Error`, the pattern `Scheduler::Scheduler` already uses. C++ now
behaves like Rust and Python on a bad parameter file.

## Ablation

```
Reverted ONLY the production behaviour in `horus_cpp/src/params_ffi.rs`, keeping
the `Option<Box<FfiParams>>` signature so the new test still compiles (a pure
textual revert would have made the test fail to build, which proves less):

    pub fn params_new() -> Option<Box<FfiParams>> {
        // ABLATION: original swallowing behaviour restored.
        Some(Box::new(FfiParams {
            inner: RuntimeParams::new().unwrap_or_default(),
        }))
    }

The test file, `c_api.rs`, `params.hpp` and `horus_c.h` were left at their fixed
state. `cargo test --no-default-features -p horus_cpp --test params_malformed_yaml`:

    Finished `test` profile [unoptimized + debuginfo] target(s) in 5m 23s
         Running tests/params_malformed_yaml.rs (target/debug/deps/params_malformed_yaml-9be94a9819e04f57)

    running 1 test
    [PARAMS] Failed to initialize RuntimeParams: Invalid input: parameter file .horus/config/params.yaml is malformed: did not find expected ',' or ']' at line 2 column 1, while parsing a flow sequence at line 1 column 12. Refusing to start on built-in defaults — fix the file or remove it.. Falling back to BUILT-IN DEFAULTS — any values in .horus/config/params.yaml are NOT in effect.
    test params_new_refuses_malformed_params_yaml ... FAILED

    failures:

    ---- params_new_refuses_malformed_params_yaml stdout ----

    thread 'params_new_refuses_malformed_params_yaml' (1881706) panicked at horus_cpp/tests/params_malformed_yaml.rs:31:5:
    params_new built a store from a malformed params.yaml, serving max_speed=Some(1.0) from the built-in safety limits. Rust (RuntimeParams::new) and Python (Params()) both refuse to start here; the C++ bindings must too.
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


    failures:
        params_new_refuses_malformed_params_yaml

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

    error: test failed, to rerun pass `-p horus_cpp --test params_malformed_yaml`

Note the ablation output also reproduces the self-contradictory message the
finding described ("Refusing to start on built-in defaults" immediately followed
by "Falling back to BUILT-IN DEFAULTS"), and shows the caller being served
max_speed=1.0 from the built-ins. Production change then restored from a saved
copy and the file re-verified byte-for-byte against the fixed version.
```

## Tests

```
All from the worktree /home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-16.

1. `cargo test --no-default-features -p horus_cpp` (whole crate, with fix):
   - lib unit tests: 143 passed, 0 failed, 1 ignored (includes the 10 rewritten
     `params_ffi::tests`, `e2e_tests::tests::e2e_params_pipeline`,
     `c_api_params_lifecycle`, `c_api_params_all_types`, and
     `layout_contract::tests::cpp_headers_satisfy_the_contract`, which parses the
     C++ headers I edited)
   - tests/params_malformed_yaml.rs: 1 passed, 0 failed  (new)
   - tests/proptest_ffi.rs: 4 passed, 0 failed
   - doc-tests: 0
   Total 148 passed, 0 failed, 1 ignored.

2. Ablation run of the new test: 0 passed, 1 failed (output above).

3. `cargo clippy --no-default-features -p horus_cpp --all-targets -- -D warnings`
   → exit 0, no warnings.

4. `cargo fmt --all -- --check` → exit 0.

5. `cargo build --no-default-features -p horus_cpp` → exit 0 (staticlib, cdylib,
   rlib).

6. `cargo check --manifest-path horus_cpp/fuzz/Cargo.toml` → clean (the fuzz
   crate is NOT a workspace member, so clippy/test above do not cover it; this is
   how I verified the `fuzz_params.rs` edit compiles). Its `Cargo.lock` was
   refreshed as a side effect and I reverted it, so it is not in the diff.

7. Real C++ end-to-end probe (not part of the diff; source in the scratchpad at
   /tmp/claude-1000/-home-neos-softmata/822523d0-05fe-4676-a353-d31ab6bdc2b3/scratchpad/params_probe.cpp).
   Compiled with `g++ -std=c++17 -Ihor
```

## Notes from the implementer

CONFIRMED THE FINDING FIRST. `horus_cpp/src/params_ffi.rs:15` was
`RuntimeParams::new().unwrap_or_default()`. I re-grepped every `RuntimeParams::new`
/ `RuntimeParams::default` site in the tree: this was the only one that swallowed
the error. `horus_py/src/params.rs:38` propagates via `map_err(to_py_err)`;
`horus_core/src/params.rs:147-161` makes a bad file a hard error with the
rationale "Failing startup is recoverable; running with limits nobody chose is
not"; `params.rs:643-665` scopes `Default`'s swallow to "a caller that reached
Default has no way to handle the error". The finding's correction is also right:
the failure was never silent — `eprint_line` fired — but the message
contradicted itself and there was no programmatic channel.

WHAT I DELIBERATELY DID NOT DO, and why:
- The finding suggested keeping the old behaviour under a new
  `horus_params_new_permissive` entry point. I did not add it. No caller in the
  tree wants it, and adding a supported way to boot a robot on limits nobody
  chose re-opens the defect under a friendlier name. Easy to add later if a real
  caller appears.
- I did not add `explicit operator bool()` to `horus::Params` (the finding's
  fallback option). With the constructor throwing, a live `Params` always has a
  non-null handle, so it would only distinguish a moved-from object. The other
  wrappers that carry it (ServiceClient, pool types) do so because their
  constructors do NOT throw.

BEHAVIOUR CHANGE A HUMAN SHOULD SIGN OFF ON: `horus::Params()` now throws where
it previously always succeeded. I judged this in scope because it is precisely
the parity the finding is about and it only fires where Rust and Python already
refuse — but it is a user-visible C++ API behaviour change, and any C++ node
constructing `Params` outside a try block will now terminate on a bad
params.yaml instead of running on the built-ins. That is the intent; flagging it
so the reviewer sees it rather than discovers it. The C ABI signature is
unchanged (`

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
