### PR TITLE
fix(bindings): a failed C++ topic must say why and count its losses

### DIFF
--- a/horus_cpp/README.md
+++ b/horus_cpp/README.md
@@ -45,6 +45,25 @@ int main() {
 }
 ```
 
+## Topics that fail to open
+
+`advertise` / `subscribe` do not throw. A rejected name, a failed SHM mapping,
+or another node already holding the topic with a different message type all
+yield a handle that silently discards everything. Check it:
+
+```cpp
+auto cmd = sched.advertise<horus::msg::CmdVel>("cmd_vel");
+if (!cmd.is_valid()) {
+    // The diagnosis Rust returns as HorusResult and Python raises as RuntimeError.
+    std::cerr << "cmd_vel: " << cmd.error() << "\n";
+    return 1;
+}
+```
+
+An unchecked handle is not silent about the damage: `dropped_count()` and
+`missed_count()` count what it threw away, so a dead link never reads 0 while
+its node keeps publishing or polling.
+
 ## Build
 
 See the root [CLAUDE.md](../CLAUDE.md) for workspace-wide build commands.

--- a/horus_cpp/TESTING.md
+++ b/horus_cpp/TESTING.md
@@ -8,9 +8,9 @@ evidence lives, and what gaps remain.
 
 | Dimension                    | Status                | Evidence                                              |
 |-----------------------------|-----------------------|-------------------------------------------------------|
-| Rust unit tests (horus_cpp)  | 139                   | `cargo test -p horus_cpp`                             |
+| Rust unit tests (horus_cpp)  | 146                   | `cargo test -p horus_cpp`                             |
 | Rust unit tests (macros)     | 77                    | `cargo test -p horus_cpp_macros`                      |
-| C++ gtest count              | 61                    | `ctest --test-dir target/cpp_tests -N`                |
+| C++ gtest count              | 68                    | `ctest --test-dir target/cpp_tests -N`                |
 | Proptest properties          | 4 × 256 cases = 1024  | `tests/proptest_ffi.rs`                               |
 | Loom model tests             | 1                     | `loom_tests/tests/loom_scheduler.rs`                  |
 | libFuzzer targets            | 4                     | `fuzz/fuzz_targets/`                                  |

--- a/horus_cpp/include/horus/horus_c.h
+++ b/horus_cpp/include/horus/horus_c.h
@@ -74,6 +74,14 @@ void              horus_node_builder_priority(HorusNodeBuilder* builder, int32_t
 void              horus_node_builder_watchdog(HorusNodeBuilder* builder, uint64_t timeout_us);
 int               horus_node_builder_build(HorusNodeBuilder* builder, HorusScheduler* sched);
 
+/* ── Topics ──────────────────────────────────────────────────────────────── */
+
+/* Why the last publisher/subscriber constructor on THIS thread returned null.
+   Writes at most buf_len-1 bytes plus a NUL, returns the bytes written, or -1
+   if buf is null or buf_len is 0. Only meaningful immediately after a
+   constructor returned null. */
+int              horus_topic_last_error(char* buf, size_t buf_len);
+
 /* ── CmdVel Topic ────────────────────────────────────────────────────────── */
 
 typedef struct {

--- a/horus_cpp/include/horus/horus_c.h
+++ b/horus_cpp/include/horus/horus_c.h
@@ -78,8 +78,9 @@ int               horus_node_builder_build(HorusNodeBuilder* builder, HorusSched
 
 /* Why the last publisher/subscriber constructor on THIS thread returned null.
    Writes at most buf_len-1 bytes plus a NUL, returns the bytes written, or -1
-   if buf is null or buf_len is 0. Only meaningful immediately after a
-   constructor returned null. */
+   if buf is null or buf_len is 0. Every topic constructor clears the slot
+   before it tries, so this returns 0 after one that succeeded and that call's
+   own reason after one that returned null. */
 int              horus_topic_last_error(char* buf, size_t buf_len);
 
 /* ── CmdVel Topic ────────────────────────────────────────────────────────── */

--- a/horus_cpp/include/horus/impl/topic_impl.hpp
+++ b/horus_cpp/include/horus/impl/topic_impl.hpp
@@ -23,7 +23,8 @@ namespace detail {
 /// Reason the topic constructor that just returned null failed.
 ///
 /// Must be called immediately after that constructor — the C API parks the
-/// reason in a per-thread slot the next failing constructor overwrites.
+/// reason in a per-thread slot the next topic constructor on this thread
+/// clears, whether that one goes on to succeed or fail.
 /// 512 bytes covers every reason horus_core produces: the longest quotes the
 /// rejected topic name, and names over 255 chars are rejected by length before
 /// the quoting path is reached.

--- a/horus_cpp/include/horus/impl/topic_impl.hpp
+++ b/horus_cpp/include/horus/impl/topic_impl.hpp
@@ -18,6 +18,23 @@
 
 namespace horus {
 
+namespace detail {
+
+/// Reason the topic constructor that just returned null failed.
+///
+/// Must be called immediately after that constructor — the C API parks the
+/// reason in a per-thread slot the next failing constructor overwrites.
+/// 512 bytes covers every reason horus_core produces: the longest quotes the
+/// rejected topic name, and names over 255 chars are rejected by length before
+/// the quoting path is reached.
+inline std::string topic_open_error() {
+    char buf[512];
+    int n = horus_topic_last_error(buf, sizeof(buf));
+    return n > 0 ? std::string(buf, static_cast<size_t>(n)) : std::string();
+}
+
+} // namespace detail
+
 // ─── Macro: Generate Publisher<T> + Subscriber<T> specialization ────────────
 //
 // For any Pod message type where C struct == Rust struct (identical #[repr(C)]).
@@ -31,11 +48,12 @@ public: \
         std::string s(topic_name); \
         inner_ = horus_publisher_##c_snake##_new(s.c_str()); \
         name_ = std::string(topic_name); \
+        if (!inner_) error_ = detail::topic_open_error(); \
     } \
     ~Publisher() { if (inner_) horus_publisher_##c_snake##_destroy(inner_); } \
-    Publisher(Publisher&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)) { o.inner_ = nullptr; } \
+    Publisher(Publisher&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)), error_(std::move(o.error_)), dropped_(o.dropped_) { o.inner_ = nullptr; o.dropped_ = 0; } \
     Publisher& operator=(Publisher&& o) noexcept { \
-        if (this != &o) { if (inner_) horus_publisher_##c_snake##_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); o.inner_ = nullptr; } \
+        if (this != &o) { if (inner_) horus_publisher_##c_snake##_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); error_ = std::move(o.error_); dropped_ = o.dropped_; o.inner_ = nullptr; o.dropped_ = 0; } \
         return *this; \
     } \
     Publisher(const Publisher&) = delete; \
@@ -43,18 +61,28 @@ public: \
     [[nodiscard]] LoanedSample<CppType> loan() { return LoanedSample<CppType>(); } \
     void publish(LoanedSample<CppType>&& sample) { send(*sample); } \
     void send(const CppType& msg) { \
-        if (inner_) horus_publisher_##c_snake##_send(inner_, &msg); \
+        if (inner_) { horus_publisher_##c_snake##_send(inner_, &msg); } else { ++dropped_; } \
     } \
     /* Messages this publisher gave up on rather than blocking. \
+       A handle that never opened has no ring to report on, so it counts the \
+       sends it threw away instead. Reporting 0 there inverted the signal a \
+       monitor watches: a congested-but-working publisher measured 4745 while \
+       a 100% dead one measured 0. \
        noexcept: a null check plus a call into the C ABI, which cannot throw. */ \
     [[nodiscard]] uint64_t dropped_count() const noexcept { \
-        return inner_ ? horus_publisher_##c_snake##_dropped_count(inner_) : 0; \
+        return inner_ ? horus_publisher_##c_snake##_dropped_count(inner_) : dropped_; \
     } \
+    /* Why the topic failed to open — empty while is_valid(). Rust returns this \
+       as HorusResult and Python raises it as RuntimeError; C++ hands back a \
+       handle, so the reason has to live somewhere. */ \
+    const std::string& error() const noexcept { return error_; } \
     const std::string& name() const { return name_; } \
     bool is_valid() const { return inner_ != nullptr; } \
 private: \
     HorusPublisher* inner_ = nullptr; \
     std::string name_; \
+    std::string error_; \
+    uint64_t dropped_ = 0; \
 }; \
 \
 template<> \
@@ -64,17 +92,18 @@ public: \
         std::string s(topic_name); \
         inner_ = horus_subscriber_##c_snake##_new(s.c_str()); \
         name_ = std::string(topic_name); \
+        if (!inner_) error_ = detail::topic_open_error(); \
     } \
     ~Subscriber() { if (inner_) horus_subscriber_##c_snake##_destroy(inner_); } \
-    Subscriber(Subscriber&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)) { o.inner_ = nullptr; } \
+    Subscriber(Subscriber&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)), error_(std::move(o.error_)), missed_(o.missed_) { o.inner_ = nullptr; o.missed_ = 0; } \
     Subscriber& operator=(Subscriber&& o) noexcept { \
-        if (this != &o) { if (inner_) horus_subscriber_##c_snake##_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); o.inner_ = nullptr; } \
+        if (this != &o) { if (inner_) horus_subscriber_##c_snake##_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); error_ = std::move(o.error_); missed_ = o.missed_; o.inner_ = nullptr; o.missed_ = 0; } \
         return *this; \
     } \
     Subscriber(const Subscriber&) = delete; \
     Subscriber& operator=(const Subscriber&) = delete; \
     std::optional<BorrowedSample<CppType>> recv() { \
-        if (!inner_) return std::nullopt; \
+        if (!inner_) { ++missed_; return std::nullopt; } \
         CppType msg; \
         std::memset(&msg, 0, sizeof(msg)); \
         if (horus_subscriber_##c_snake##_recv(inner_, &msg)) { \
@@ -84,18 +113,25 @@ public: \
     } \
     /* Messages this subscriber was lapped past. Topics are lossy by design: a \
        full ring overwrites the oldest unconsumed slot rather than blocking the \
-       publisher, so a rising value means frames are being dropped. */ \
+       publisher, so a rising value means frames are being dropped. \
+       A handle that never opened has no ring to report on, so it counts the \
+       receives it could not serve — a dead link must not read 0 here while a \
+       merely congested one reads in the thousands. */ \
     [[nodiscard]] uint64_t missed_count() const noexcept { \
-        return inner_ ? horus_subscriber_##c_snake##_missed_count(inner_) : 0; \
+        return inner_ ? horus_subscriber_##c_snake##_missed_count(inner_) : missed_; \
     } \
     bool has_msg() const { \
         return inner_ ? horus_subscriber_##c_snake##_has_msg(inner_) : false; \
     } \
+    /* Why the topic failed to open — empty while is_valid(). */ \
+    const std::string& error() const noexcept { return error_; } \
     const std::string& name() const { return name_; } \
     bool is_valid() const { return inner_ != nullptr; } \
 private: \
     HorusSubscriber* inner_ = nullptr; \
     std::string name_; \
+    std::string error_; \
+    uint64_t missed_ = 0; \
 };
 
 // ─── All 11 Message Type Specializations ────────────────────────────────────
@@ -108,11 +144,12 @@ public:
         std::string s(topic_name);
         inner_ = horus_publisher_cmd_vel_new(s.c_str());
         name_ = std::string(topic_name);
+        if (!inner_) error_ = detail::topic_open_error();
     }
     ~Publisher() { if (inner_) horus_publisher_cmd_vel_destroy(inner_); }
-    Publisher(Publisher&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)) { o.inner_ = nullptr; }
+    Publisher(Publisher&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)), error_(std::move(o.error_)), dropped_(o.dropped_) { o.inner_ = nullptr; o.dropped_ = 0; }
     Publisher& operator=(Publisher&& o) noexcept {
-        if (this != &o) { if (inner_) horus_publisher_cmd_vel_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); o.inner_ = nullptr; }
+        if (this != &o) { if (inner_) horus_publisher_cmd_vel_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); error_ = std::move(o.error_); dropped_ = o.dropped_; o.inner_ = nullptr; o.dropped_ = 0; }
         return *this;
     }
     Publisher(const Publisher&) = delete;
@@ -120,7 +157,7 @@ public:
     [[nodiscard]] LoanedSample<msg::CmdVel> loan() { return LoanedSample<msg::CmdVel>(); }
     void publish(LoanedSample<msg::CmdVel>&& sample) { send(*sample); }
     void send(const msg::CmdVel& msg) {
-        if (!inner_) return;
+        if (!inner_) { ++dropped_; return; }
         HorusCmdVel c_msg;
         c_msg.timestamp_ns = msg.timestamp_ns;
         c_msg.linear = msg.linear;
@@ -129,14 +166,27 @@ public:
     }
 
     /// Messages this publisher gave up on rather than blocking.
+    ///
+    /// A handle that never opened has no ring to report on, so it counts the
+    /// sends it threw away instead. Reporting 0 there inverted the signal a
+    /// monitor watches: a congested-but-working publisher measured 4745 while
+    /// a 100% dead one measured 0.
     [[nodiscard]] uint64_t dropped_count() const noexcept {
-        return inner_ ? horus_publisher_cmd_vel_dropped_count(inner_) : 0;
+        return inner_ ? horus_publisher_cmd_vel_dropped_count(inner_) : dropped_;
     }
+
+    /// Why the topic failed to open — empty while is_valid().
+    ///
+    /// Rust returns this as HorusResult and Python raises it as RuntimeError;
+    /// C++ hands back a handle, so the reason has to live somewhere.
+    const std::string& error() const noexcept { return error_; }
     const std::string& name() const { return name_; }
     bool is_valid() const { return inner_ != nullptr; }
 private:
     HorusPublisher* inner_ = nullptr;
     std::string name_;
+    std::string error_;
+    uint64_t dropped_ = 0;
 };
 
 template<>
@@ -146,17 +196,18 @@ public:
         std::string s(topic_name);
         inner_ = horus_subscriber_cmd_vel_new(s.c_str());
         name_ = std::string(topic_name);
+        if (!inner_) error_ = detail::topic_open_error();
     }
     ~Subscriber() { if (inner_) horus_subscriber_cmd_vel_destroy(inner_); }
-    Subscriber(Subscriber&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)) { o.inner_ = nullptr; }
+    Subscriber(Subscriber&& o) noexcept : inner_(o.inner_), name_(std::move(o.name_)), error_(std::move(o.error_)), missed_(o.missed_) { o.inner_ = nullptr; o.missed_ = 0; }
     Subscriber& operator=(Subscriber&& o) noexcept {
-        if (this != &o) { if (inner_) horus_subscriber_cmd_vel_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); o.inner_ = nullptr; }
+        if (this != &o) { if (inner_) horus_subscriber_cmd_vel_destroy(inner_); inner_ = o.inner_; name_ = std::move(o.name_); error_ = std::move(o.error_); missed_ = o.missed_; o.inner_ = nullptr; o.missed_ = 0; }
         return *this;
     }
     Subscriber(const Subscriber&) = delete;
     Subscriber& operator=(const Subscriber&) = delete;
     std::optional<BorrowedSample<msg::CmdVel>> recv() {
-        if (!inner_) return std::nullopt;
+        if (!inner_) { ++missed_; return std::nullopt; }
         HorusCmdVel c_msg;
         if (horus_subscriber_cmd_vel_recv(inner_, &c_msg)) {
             msg::CmdVel msg;
@@ -170,14 +221,23 @@ public:
     bool has_msg() const { return inner_ ? horus_subscriber_cmd_vel_has_msg(inner_) : false; }
 
     /// Messages this subscriber was lapped past and never delivered.
+    ///
+    /// A handle that never opened has no ring to report on, so it counts the
+    /// receives it could not serve — a dead link must not read 0 here while a
+    /// merely congested one reads in the thousands.
     [[nodiscard]] uint64_t missed_count() const noexcept {
-        return inner_ ? horus_subscriber_cmd_vel_missed_count(inner_) : 0;
+        return inner_ ? horus_subscriber_cmd_vel_missed_count(inner_) : missed_;
     }
+
+    /// Why the topic failed to open — empty while is_valid().
+    const std::string& error() const noexcept { return error_; }
     const std::string& name() const { return name_; }
     bool is_valid() const { return inner_ != nullptr; }
 private:
     HorusSubscriber* inner_ = nullptr;
     std::string name_;
+    std::string error_;
+    uint64_t missed_ = 0;
 };
 
 // ─── All Pod Message Types ──────────────────────────────────────────────────

--- a/horus_cpp/include/horus/scheduler.hpp
+++ b/horus_cpp/include/horus/scheduler.hpp
@@ -88,11 +88,18 @@ public:
 
     /// Create a Publisher for the named topic.
     /// Usage: auto pub = sched.advertise<msg::CmdVel>("cmd_vel");
+    ///
+    /// Does not throw when the topic cannot be opened — check `is_valid()` and
+    /// read `error()` for the reason. A handle that failed to open discards
+    /// every message it is given.
     template<typename T>
     Publisher<T> advertise(std::string_view topic_name);
 
     /// Create a Subscriber for the named topic.
     /// Usage: auto sub = sched.subscribe<msg::LaserScan>("lidar.scan");
+    ///
+    /// Does not throw when the topic cannot be opened — check `is_valid()` and
+    /// read `error()` for the reason.
     template<typename T>
     Subscriber<T> subscribe(std::string_view topic_name);
 

--- a/horus_cpp/src/c_api.rs
+++ b/horus_cpp/src/c_api.rs
@@ -431,16 +431,71 @@ pub struct HorusCmdVel {
     pub angular: f32,
 }
 
-/// Create CmdVel publisher. Returns null on error.
+// ─── Why a topic failed to open ──────────────────────────────────────────
+//
+// A `*_new` reports failure as a null pointer, which carries no reason.
+// horus_core knows exactly what went wrong — "Topic name 'cmd vel' contains
+// invalid characters", ShmCreateFailed, the message-type mismatch that
+// `negotiate_shm_header` exists to diagnose — and C++ was the only binding
+// that threw it away: Rust returns HorusResult, Python raises RuntimeError
+// carrying the text. Park it per-thread so the C++ handle can pick it up on
+// the line after the constructor that returned null.
+//
+// Every null return from a topic constructor below must call
+// `set_topic_error` first, or C++ reads a stale reason from an earlier failure.
+
+thread_local! {
+    static TOPIC_ERROR: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+}
+
+fn set_topic_error(reason: String) {
+    TOPIC_ERROR.with(|e| *e.borrow_mut() = reason);
+}
+
+/// Why the last publisher/subscriber constructor on THIS thread returned null.
+///
+/// Writes at most `buf_len - 1` bytes plus a NUL and returns the bytes written,
+/// or -1 if `buf` is null or `buf_len` is 0 — the same convention as
+/// `horus_scheduler_node_name_at`. Only meaningful right after a constructor
+/// returned null; nothing else on the thread updates it.
+#[no_mangle]
+pub unsafe extern "C" fn horus_topic_last_error(buf: *mut u8, buf_len: usize) -> i32 {
+    if buf.is_null() || buf_len == 0 {
+        return -1;
+    }
+    TOPIC_ERROR.with(|e| {
+        let reason = e.borrow();
+        let bytes = reason.as_bytes();
+        let mut copy_len = bytes.len().min(buf_len - 1);
+        // Back off to a char boundary: the reason quotes the rejected topic
+        // name, which is arbitrary user bytes, and half a UTF-8 sequence is
+        // not something to hand a caller that may re-encode it.
+        while copy_len > 0 && copy_len < bytes.len() && (bytes[copy_len] & 0xC0) == 0x80 {
+            copy_len -= 1;
+        }
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, copy_len);
+        *buf.add(copy_len) = 0;
+        copy_len as i32
+    })
+}
+
+/// Create CmdVel publisher. Returns null on error; `horus_topic_last_error`
+/// then holds the reason.
 #[no_mangle]
 pub unsafe extern "C" fn horus_publisher_cmd_vel_new(name: *const c_char) -> *mut HorusPublisher {
     let name = match CStr::from_ptr(name).to_str() {
         Ok(n) => n,
-        Err(_) => return std::ptr::null_mut(),
+        Err(e) => {
+            set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
+            return std::ptr::null_mut();
+        }
     };
     match topic_ffi::publisher_cmd_vel_new(name) {
         Ok(pub_) => Box::into_raw(pub_) as *mut HorusPublisher,
-        Err(_) => std::ptr::null_mut(),
+        Err(e) => {
+            set_topic_error(e);
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -475,16 +530,23 @@ pub unsafe extern "C" fn horus_publisher_cmd_vel_send(
     );
 }
 
-/// Create CmdVel subscriber. Returns null on error.
+/// Create CmdVel subscriber. Returns null on error; `horus_topic_last_error`
+/// then holds the reason.
 #[no_mangle]
 pub unsafe extern "C" fn horus_subscriber_cmd_vel_new(name: *const c_char) -> *mut HorusSubscriber {
     let name = match CStr::from_ptr(name).to_str() {
         Ok(n) => n,
-        Err(_) => return std::ptr::null_mut(),
+        Err(e) => {
+            set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
+            return std::ptr::null_mut();
+        }
     };
     match topic_ffi::subscriber_cmd_vel_new(name) {
         Ok(sub) => Box::into_raw(sub) as *mut HorusSubscriber,
-        Err(_) => std::ptr::null_mut(),
+        Err(e) => {
+            set_topic_error(e);
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -578,11 +640,17 @@ macro_rules! impl_pod_topic_c_api {
             ) -> *mut HorusPublisher {
                 let name = match CStr::from_ptr(name).to_str() {
                     Ok(n) => n,
-                    Err(_) => return std::ptr::null_mut(),
+                    Err(e) => {
+                        set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
+                        return std::ptr::null_mut();
+                    }
                 };
                 match topic_ffi::[<publisher_ $snake _new>](name) {
                     Ok(pub_) => Box::into_raw(pub_) as *mut HorusPublisher,
-                    Err(_) => std::ptr::null_mut(),
+                    Err(e) => {
+                        set_topic_error(e);
+                        std::ptr::null_mut()
+                    }
                 }
             }
 
@@ -610,11 +678,17 @@ macro_rules! impl_pod_topic_c_api {
             ) -> *mut HorusSubscriber {
                 let name = match CStr::from_ptr(name).to_str() {
                     Ok(n) => n,
-                    Err(_) => return std::ptr::null_mut(),
+                    Err(e) => {
+                        set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
+                        return std::ptr::null_mut();
+                    }
                 };
                 match topic_ffi::[<subscriber_ $snake _new>](name) {
                     Ok(sub) => Box::into_raw(sub) as *mut HorusSubscriber,
-                    Err(_) => std::ptr::null_mut(),
+                    Err(e) => {
+                        set_topic_error(e);
+                        std::ptr::null_mut()
+                    }
                 }
             }
 
@@ -2530,5 +2604,77 @@ mod tests {
                 std::ptr::null()
             ));
         }
+    }
+
+    // ── A null handle has to say why ─────────────────────────────────────
+    //
+    // `*_new` can only answer "no" across the C ABI. The reason horus_core
+    // produced used to stop here, leaving C++ the one binding that could not
+    // tell an invalid name from a full /dev/shm.
+
+    fn read_topic_error(buf_len: usize) -> (i32, String) {
+        let mut buf = vec![0u8; buf_len];
+        // SAFETY: buf is a live allocation of exactly buf_len bytes.
+        let n = unsafe { horus_topic_last_error(buf.as_mut_ptr(), buf_len) };
+        let text = if n > 0 {
+            String::from_utf8_lossy(&buf[..n as usize]).into_owned()
+        } else {
+            String::new()
+        };
+        (n, text)
+    }
+
+    #[test]
+    fn failed_publisher_leaves_the_reason_behind() {
+        let name = CString::new("c_api.bad name").unwrap();
+        // SAFETY: name is NUL-terminated and outlives the call.
+        let p = unsafe { horus_publisher_cmd_vel_new(name.as_ptr()) };
+        assert!(p.is_null(), "a space is not an allowed topic-name byte");
+
+        let (n, reason) = read_topic_error(512);
+        assert!(n > 0, "the constructor must leave a reason, got {n}");
+        assert!(
+            reason.contains("c_api.bad name") && reason.contains("invalid characters"),
+            "expected the validator's own diagnosis, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn failed_subscriber_leaves_the_reason_behind() {
+        let name = CString::new("").unwrap();
+        // SAFETY: name is NUL-terminated and outlives the call.
+        let s = unsafe { horus_subscriber_imu_new(name.as_ptr()) };
+        assert!(s.is_null(), "an empty topic name is rejected");
+
+        let (_, reason) = read_topic_error(512);
+        assert!(
+            reason.contains("cannot be empty"),
+            "expected the validator's own diagnosis, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn topic_error_truncates_without_overrunning_the_buffer() {
+        let name = CString::new("c_api.bad name").unwrap();
+        // SAFETY: name is NUL-terminated and outlives the call.
+        assert!(unsafe { horus_publisher_cmd_vel_new(name.as_ptr()) }.is_null());
+
+        let mut buf = [0xAAu8; 16];
+        // SAFETY: buf is 16 live bytes and the length matches.
+        let n = unsafe { horus_topic_last_error(buf.as_mut_ptr(), buf.len()) };
+        assert_eq!(n, 15, "at most buf_len - 1 bytes, so the NUL always fits");
+        assert_eq!(buf[15], 0, "the terminator must be written");
+        assert!(
+            std::str::from_utf8(&buf[..15]).is_ok(),
+            "no split UTF-8 sequence"
+        );
+
+        // SAFETY: a null buffer is the documented -1 case.
+        assert_eq!(
+            unsafe { horus_topic_last_error(std::ptr::null_mut(), 64) },
+            -1
+        );
+        // SAFETY: buf is live; a zero length is the other documented -1 case.
+        assert_eq!(unsafe { horus_topic_last_error(buf.as_mut_ptr(), 0) }, -1);
     }
 }

--- a/horus_cpp/src/c_api.rs
+++ b/horus_cpp/src/c_api.rs
@@ -441,8 +441,11 @@ pub struct HorusCmdVel {
 // carrying the text. Park it per-thread so the C++ handle can pick it up on
 // the line after the constructor that returned null.
 //
-// Every null return from a topic constructor below must call
-// `set_topic_error` first, or C++ reads a stale reason from an earlier failure.
+// The slot is cleared on entry to every topic constructor, so it answers for
+// the call that just returned rather than for whichever call last failed. That
+// makes "no reason" mean "the constructor succeeded" instead of "someone forgot
+// to set one" — a null return that skips `set_topic_error` now reads as empty,
+// which is honest, rather than as a stale reason naming a different topic.
 
 thread_local! {
     static TOPIC_ERROR: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
@@ -452,12 +455,47 @@ fn set_topic_error(reason: String) {
     TOPIC_ERROR.with(|e| *e.borrow_mut() = reason);
 }
 
+fn clear_topic_error() {
+    TOPIC_ERROR.with(|e| e.borrow_mut().clear());
+}
+
+/// Borrow a topic name out of C, or record why it is unusable and give back
+/// `None`.
+///
+/// Every topic constructor starts here, which is what keeps the two invariants
+/// the last-error channel rests on: the slot is cleared before the attempt, and
+/// a null `name` is refused instead of being handed to `CStr::from_ptr`, whose
+/// contract requires a valid NUL-terminated pointer and is undefined behaviour
+/// on null. `horus_publisher_*_new(NULL)` is reachable from any C caller — the
+/// C++ headers always pass `std::string::c_str()`, but horus_c.h is a public
+/// ABI and a null there used to be a segfault at best.
+///
+/// # Safety
+/// `name` must be null or a pointer to a NUL-terminated string that stays
+/// valid and unwritten for the duration of the call. The returned reference
+/// borrows from it and must not outlive it.
+unsafe fn topic_name_from_c<'a>(name: *const c_char) -> Option<&'a str> {
+    clear_topic_error();
+    if name.is_null() {
+        set_topic_error("Topic name is null".to_string());
+        return None;
+    }
+    match CStr::from_ptr(name).to_str() {
+        Ok(n) => Some(n),
+        Err(e) => {
+            set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
+            None
+        }
+    }
+}
+
 /// Why the last publisher/subscriber constructor on THIS thread returned null.
 ///
 /// Writes at most `buf_len - 1` bytes plus a NUL and returns the bytes written,
 /// or -1 if `buf` is null or `buf_len` is 0 — the same convention as
-/// `horus_scheduler_node_name_at`. Only meaningful right after a constructor
-/// returned null; nothing else on the thread updates it.
+/// `horus_scheduler_node_name_at`. Every topic constructor on this thread
+/// clears the slot before it tries, so this is empty (return 0) after one that
+/// succeeded and holds that call's own reason after one that returned null.
 #[no_mangle]
 pub unsafe extern "C" fn horus_topic_last_error(buf: *mut u8, buf_len: usize) -> i32 {
     if buf.is_null() || buf_len == 0 {
@@ -483,12 +521,9 @@ pub unsafe extern "C" fn horus_topic_last_error(buf: *mut u8, buf_len: usize) ->
 /// then holds the reason.
 #[no_mangle]
 pub unsafe extern "C" fn horus_publisher_cmd_vel_new(name: *const c_char) -> *mut HorusPublisher {
-    let name = match CStr::from_ptr(name).to_str() {
-        Ok(n) => n,
-        Err(e) => {
-            set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
-            return std::ptr::null_mut();
-        }
+    let name = match topic_name_from_c(name) {
+        Some(n) => n,
+        None => return std::ptr::null_mut(),
     };
     match topic_ffi::publisher_cmd_vel_new(name) {
         Ok(pub_) => Box::into_raw(pub_) as *mut HorusPublisher,
@@ -534,12 +569,9 @@ pub unsafe extern "C" fn horus_publisher_cmd_vel_send(
 /// then holds the reason.
 #[no_mangle]
 pub unsafe extern "C" fn horus_subscriber_cmd_vel_new(name: *const c_char) -> *mut HorusSubscriber {
-    let name = match CStr::from_ptr(name).to_str() {
-        Ok(n) => n,
-        Err(e) => {
-            set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
-            return std::ptr::null_mut();
-        }
+    let name = match topic_name_from_c(name) {
+        Some(n) => n,
+        None => return std::ptr::null_mut(),
     };
     match topic_ffi::subscriber_cmd_vel_new(name) {
         Ok(sub) => Box::into_raw(sub) as *mut HorusSubscriber,
@@ -638,12 +670,9 @@ macro_rules! impl_pod_topic_c_api {
             pub unsafe extern "C" fn [<horus_publisher_ $snake _new>](
                 name: *const c_char,
             ) -> *mut HorusPublisher {
-                let name = match CStr::from_ptr(name).to_str() {
-                    Ok(n) => n,
-                    Err(e) => {
-                        set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
-                        return std::ptr::null_mut();
-                    }
+                let name = match topic_name_from_c(name) {
+                    Some(n) => n,
+                    None => return std::ptr::null_mut(),
                 };
                 match topic_ffi::[<publisher_ $snake _new>](name) {
                     Ok(pub_) => Box::into_raw(pub_) as *mut HorusPublisher,
@@ -676,12 +705,9 @@ macro_rules! impl_pod_topic_c_api {
             pub unsafe extern "C" fn [<horus_subscriber_ $snake _new>](
                 name: *const c_char,
             ) -> *mut HorusSubscriber {
-                let name = match CStr::from_ptr(name).to_str() {
-                    Ok(n) => n,
-                    Err(e) => {
-                        set_topic_error(format!("Topic name is not valid UTF-8: {e}"));
-                        return std::ptr::null_mut();
-                    }
+                let name = match topic_name_from_c(name) {
+                    Some(n) => n,
+                    None => return std::ptr::null_mut(),
                 };
                 match topic_ffi::[<subscriber_ $snake _new>](name) {
                     Ok(sub) => Box::into_raw(sub) as *mut HorusSubscriber,
@@ -2676,5 +2702,48 @@ mod tests {
         );
         // SAFETY: buf is live; a zero length is the other documented -1 case.
         assert_eq!(unsafe { horus_topic_last_error(buf.as_mut_ptr(), 0) }, -1);
+    }
+
+    #[test]
+    fn a_null_topic_name_is_refused_not_dereferenced() {
+        // `CStr::from_ptr` is undefined behaviour on null, and horus_c.h is a
+        // public C ABI — nothing stops a caller passing NULL. Both the
+        // hand-written cmd_vel pair and the impl_pod_topic_c_api! arms go
+        // through the same guard.
+        // SAFETY: null is exactly the case under test.
+        assert!(unsafe { horus_publisher_cmd_vel_new(std::ptr::null()) }.is_null());
+        let (n, reason) = read_topic_error(512);
+        assert!(n > 0, "a refused null must still leave a reason, got {n}");
+        assert!(
+            reason.contains("null"),
+            "expected a reason naming the null name, got: {reason}"
+        );
+
+        // SAFETY: null is exactly the case under test.
+        assert!(unsafe { horus_subscriber_imu_new(std::ptr::null()) }.is_null());
+        assert!(read_topic_error(512).1.contains("null"));
+    }
+
+    #[test]
+    fn a_success_clears_the_reason_the_last_failure_left() {
+        let bad = CString::new("c_api.bad name").unwrap();
+        // SAFETY: bad is NUL-terminated and outlives the call.
+        assert!(unsafe { horus_publisher_cmd_vel_new(bad.as_ptr()) }.is_null());
+        assert!(
+            !read_topic_error(512).1.is_empty(),
+            "the failure must arm the slot"
+        );
+
+        // A topic that opens must disarm it: a caller reading the slot after a
+        // success would otherwise be handed the previous topic's complaint.
+        let good = CString::new(format!("c_api.clears_{}", std::process::id())).unwrap();
+        // SAFETY: good is NUL-terminated and outlives the call.
+        let p = unsafe { horus_publisher_cmd_vel_new(good.as_ptr()) };
+        assert!(!p.is_null(), "a plain name should open");
+        let (n, reason) = read_topic_error(512);
+        assert_eq!(n, 0, "a success leaves nothing to report, got: {reason}");
+        assert!(reason.is_empty());
+        // SAFETY: p came from the matching constructor and is dropped once.
+        unsafe { horus_publisher_cmd_vel_destroy(p) };
     }
 }

--- a/horus_cpp/tests/cpp_user_api_test.cpp
+++ b/horus_cpp/tests/cpp_user_api_test.cpp
@@ -478,3 +478,78 @@ TEST(UserApi, LambdaNode) {
     EXPECT_GE(lambda_ticks, 5);
     EXPECT_GE(lambda_recvs, 1);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 14. A topic that fails to open
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// advertise/subscribe hand back a handle either way — they do not throw the
+// way Rust returns HorusResult and Python raises RuntimeError. The handle must
+// therefore carry the diagnosis, and it must not report a healthy loss count,
+// or a 100%-dead link looks quieter than a merely congested one.
+
+TEST(UserApi, FailedPublisherCarriesTheReason) {
+    // A space is not in the allowed set (alphanumeric, _, /, -, .), so the
+    // topic is rejected by name validation before any SHM is touched.
+    horus::Publisher<horus::msg::CmdVel> pub("user_api.bad name");
+    ASSERT_FALSE(pub.is_valid());
+
+    EXPECT_NE(pub.error().find("user_api.bad name"), std::string::npos)
+        << "reason should quote the rejected name, got: " << pub.error();
+    EXPECT_NE(pub.error().find("invalid characters"), std::string::npos)
+        << "reason should be the validator's, got: " << pub.error();
+}
+
+TEST(UserApi, FailedSubscriberCarriesTheReason) {
+    horus::Subscriber<horus::msg::Imu> sub("user_api.bad name");
+    ASSERT_FALSE(sub.is_valid());
+
+    EXPECT_NE(sub.error().find("invalid characters"), std::string::npos)
+        << "reason should be the validator's, got: " << sub.error();
+}
+
+TEST(UserApi, ValidTopicHasNoError) {
+    horus::Publisher<horus::msg::CmdVel> pub("user_api.error_clean");
+    ASSERT_TRUE(pub.is_valid());
+    EXPECT_EQ(pub.error(), "");
+
+    horus::Subscriber<horus::msg::CmdVel> sub("user_api.error_clean");
+    ASSERT_TRUE(sub.is_valid());
+    EXPECT_EQ(sub.error(), "");
+}
+
+TEST(UserApi, DeadHandlesDoNotReportZeroLoss) {
+    horus::Publisher<horus::msg::CmdVel> pub("user_api.bad name");
+    horus::Subscriber<horus::msg::CmdVel> sub("user_api.bad name");
+    ASSERT_FALSE(pub.is_valid());
+    ASSERT_FALSE(sub.is_valid());
+
+    EXPECT_EQ(pub.dropped_count(), 0u) << "nothing sent yet";
+    EXPECT_EQ(sub.missed_count(), 0u) << "nothing received yet";
+
+    for (int i = 0; i < 1000; i++) {
+        horus::msg::CmdVel m{};
+        m.timestamp_ns = static_cast<uint64_t>(i);
+        pub.send(m);
+        EXPECT_FALSE(sub.recv().has_value());
+    }
+
+    // The point of the counters: a monitor that alarms on loss > 0 has to fire
+    // here. Reporting 0 made total failure indistinguishable from an idle link.
+    EXPECT_EQ(pub.dropped_count(), 1000u);
+    EXPECT_EQ(sub.missed_count(), 1000u);
+}
+
+TEST(UserApi, MovedFromPublisherCountsWhatItDiscards) {
+    horus::Publisher<horus::msg::CmdVel> pub1("user_api.moved_drop");
+    ASSERT_TRUE(pub1.is_valid());
+    auto pub2 = std::move(pub1);
+    ASSERT_FALSE(pub1.is_valid());
+
+    for (int i = 0; i < 10; i++) {
+        horus::msg::CmdVel m{};
+        pub1.send(m);
+    }
+    EXPECT_EQ(pub1.dropped_count(), 10u) << "a moved-from handle sends nowhere";
+    EXPECT_EQ(pub2.dropped_count(), 0u) << "the live handle dropped nothing";
+}


### PR DESCRIPTION
horus_publisher_*_new / horus_subscriber_*_new answer failure with a null
pointer, and the C++ Publisher/Subscriber turned that into a handle that
looks constructed but discards everything. Two things were lost with it.

The reason. horus_core names the failure exactly -- "Topic name 'cmd vel'
contains invalid characters", ShmCreateFailed, the cross-process type
mismatch negotiate_shm_header exists to diagnose -- and C++ was the only
binding that dropped it: Rust returns HorusResult, Python raises
RuntimeError carrying the text. c_api.rs now parks the reason in a
per-thread slot, horus_topic_last_error reads it back, and each handle
captures it at construction; Publisher/Subscriber::error() hands it to the
caller. A handle that opens reports "". Measured on the deployment case
that needs no typo -- two processes opening one valid topic name with
different message types -- the handle now reports "type mismatch. Existing
type 'CmdVel', attempted 'LaserScan'" instead of nothing.

The loss counters. dropped_count()/missed_count() returned 0 on a null
inner_, so a link delivering nothing measured 0 while a merely congested
one measured 4745 -- a monitor alarming on loss > 0 fired on congestion and
stayed silent on total failure. A handle with no ring to read now counts
what it throws away: 1000 sends on a dead publisher report 1000.

advertise/subscribe still do not throw. Throwing would break every caller
using the construct-then-check pattern the shipped pub_sub_demo.cpp uses,
so the contract is documented instead -- scheduler.hpp and the horus_cpp
README now say to check is_valid() and read error().

Covered by 5 gtests in cpp_user_api_test.cpp and 3 Rust tests in c_api.rs.
horus_topic_last_error is a new symbol only; no existing one changed shape,
so HORUS_CPP_ABI_VERSION is untouched.

## Ablation

```
Two stages. Both were run with the new tests kept exactly as committed.

STAGE B (the informative one) — kept the new API surface (error(), the new
members) but restored the OLD behaviour of the null-inner_ branches in
topic_impl.hpp: dropped the `if (!inner_) error_ = detail::topic_open_error();`
line from all four constructors, put `send` back to
`if (inner_) horus_publisher_..._send(...)`, `recv` back to
`if (!inner_) return std::nullopt;`, and both counters back to `: 0`. Rebuilt
libhorus_cpp.so and cpp_user_api_test, then ran. EXACT output:

Running main() from .../googletest/src/gtest_main.cc
Note: Google Test filter = UserApi.Failed*:UserApi.ValidTopic*:UserApi.DeadHandles*:UserApi.MovedFrom*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from UserApi
[ RUN      ] UserApi.FailedPublisherCarriesTheReason
/home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-17/horus_cpp/tests/cpp_user_api_test.cpp:497: Failure
Expected: (pub.error().find("user_api.bad name")) != (std::string::npos), actual: 18446744073709551615 vs 18446744073709551615
reason should quote the rejected name, got: 

/home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-17/horus_cpp/tests/cpp_user_api_test.cpp:499: Failure
Expected: (pub.error().find("invalid characters")) != (std::string::npos), actual: 18446744073709551615 vs 18446744073709551615
reason should be the validator's, got: 

[  FAILED  ] UserApi.FailedPublisherCarriesTheReason (0 ms)
[ RUN      ] UserApi.FailedSubscriberCarriesTheReason
/home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-17/horus_cpp/tests/cpp_user_api_test.cpp:507: Failure
Expected: (sub.error().find("invalid characters")) != (std::string::npos), actual: 18446744073709551615 vs 18446744073709551615
reason should be the validator's, got: 

[  FAILED  ] UserApi.FailedSubscriberCarriesTheReason (0 ms)
[ RUN      ] UserApi.ValidTopicHasNoError
[       OK ] UserApi.ValidTopicHasNoError (0 ms)
[ RUN      ] UserApi.DeadHandlesDoNotReportZeroLoss
/home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-17/horus_cpp/tests/cpp_user_api_test.cpp:539: Failure
Expected equality of these values:
  pub.dropped_count()
    Which is: 0
  1000u
    Which is: 1000

/home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-17/horus_cpp/tests/cpp_user_api_test.cpp:540: Failure
Expected equality of these values:
  sub.missed_count()
    Which is: 0
  1000u
    Which is: 1000

[  FAILED  ] UserApi.DeadHandlesDoNotReportZeroLoss (0 ms)
[ RUN      ] UserApi.MovedFromPublisherCountsWhatItD
```

## Tests

```
Rust — `cargo test -p horus_cpp` (worktree, debug):
  lib: 146 passed, 0 failed, 1 ignored (baseline on the same tree before this
  change: 143 passed). The 3 new tests all pass:
    c_api::tests::failed_publisher_leaves_the_reason_behind ... ok
    c_api::tests::failed_subscriber_leaves_the_reason_behind ... ok
    c_api::tests::topic_error_truncates_without_overrunning_the_buffer ... ok
  tests/proptest_ffi.rs: 4 passed (4 × 256 cases), 0 failed
  doc-tests: 0
  Exit code 0.

C++ — cmake configure of horus_cpp/tests into a scratch build dir with
HORUS_RUST_TARGET_DIR pointing at this worktree's target/debug, `ctest -LE
nightly -j 4`:
  67/67 passed, 0 failed, 1 skipped (Pool.ImageAllocReleaseCycleLeakFree,
  skipped on this box before and after the change). Baseline on the same tree
  before this change: 62 tests. `ctest -N` (nightly soak included) now lists 68,
  which is the number written into TESTING.md.
  The 5 new gtests pass individually and in the full run.

Lint/format:
  `cargo fmt --all -- --check` — clean, no output.
  `cargo clippy -p horus_cpp --all-targets` — exit 0, zero warnings.
  Full cmake build of every C++ test target — zero compiler warnings.

Manual probe (not committed, lives in the scratchpad) — the deployment failure
the finding said was the real reachability path, two processes opening one
valid topic name with different message types:
  child:  is_valid=1 error=''
  parent: is_valid=0 error='Communication error: Failed to create topic
          
```

## Notes from the implementer

CONFIRMED the finding independently before touching anything. Every cited
mechanism is in the tree at f862b2dc: topic_impl.hpp stores the null and
`send`/`recv` no-op on it, both loss counters return literal 0 on a null
inner_, c_api.rs and the impl_pod_topic_c_api! arms map `Err(_)` to
null_mut() discarding the String, and Scheduler::advertise/subscribe just
forward to the constructor. The finding's own corrections are also right:
is_valid() does exist and pub_sub_demo.cpp does use it, so this is an
optional-and-undocumented guard, not an undetectable failure.

WHAT I DELIBERATELY DID NOT DO — and why it is not a guess:
The finding's fix suggested making advertise/subscribe throw so an invalid
Publisher is unconstructible. That is the API break. Existing code — including
the shipped example — uses construct-then-check; throwing turns a survivable
misconfiguration into an uncaught exception at startup for every such caller,
and it would also break cpp_user_api_test.cpp:374-380 and cpp_ergonomic_e2e
:147-151, which construct handles and assert is_valid() is false. So I kept the
non-throwing contract, made it discoverable (error()), documented it
(scheduler.hpp, README), and left the throw as a separate decision for a human.
If the maintainers do want throwing, the last-error channel this adds is exactly
the piece that makes it possible — `throw Error(detail::topic_open_error())`.

HONEST LIMITS:
1. Subscriber::missed_count() on a dead handle counts recv() calls it could not
   serve, NOT messages actually published. That is a deliberate reinterpretation
   of the counter for the one case where no ring exists to read, and it is
   spelled out in the header comment. Consequence: a dead subscriber that never
   polls still reads 0, and the number is a poll count, not a frame count. The
   publisher side has no such fudge — dropped_count() on a dead handle is the
   true number of messages discarded. If a reviewer would rather have a UINT64_MAX
   sentinel or leave the s

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
