### PR TITLE
fix(pool): a pool file this build disagrees with must error, not panic every tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,12 @@ and `Unreleased` is left empty rather than deleted.
   `TensorHandle::from_shape` panicked instead of returning the `HorusResult`
   they advertise. Inside a scheduler tick the panic was swallowed by
   `catch_unwind` — the node entered ticks, completed none, and the process
-  still exited 0.
+  still exited 0. The paths with no error channel to propagate into
+  (`Topic::<Tensor>::recv_handle`, the spill read/write paths,
+  `TopicMessage::try_from_wire`) answer `None` instead, and say why: one
+  throttled `warn` per faulted topic per second, carrying the number of
+  occurrences it suppressed, so a faulted topic is not delivered to an
+  operator as an idle one.
 
 ## [0.4.0] — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,33 @@ and `Unreleased` is left empty rather than deleted.
 
 ## Unreleased
 
+### Breaking
+
+- **core** — `Topic::<Tensor>::pool()` (`#[doc(hidden)]`, but `pub`) returns
+  `HorusResult<Arc<TensorPool>>` where it returned `Arc<TensorPool>`. A pool
+  file left behind by a build with a different `POOL_VERSION` or geometry can
+  be neither opened nor recreated, and the infallible signature had only one
+  way to say so: a panic, on the per-frame allocation path, out of constructors
+  that already return `HorusResult`. There is no compatible spelling of the old
+  signature that does not keep that panic. Callers add `?`; the neighbouring
+  methods a caller is more likely to hold — `alloc_tensor`, `send_handle`,
+  `recv_handle` — are unchanged, and no caller of `pool()` exists outside
+  `horus_core` in this workspace. Pre-1.0, so it rides in the minor slot, as
+  0.4.0's break did.
+
+### Fixed
+
+- **core** — a tensor pool file this build disagrees with is now an error
+  rather than a panic. `TensorPool::drop` never unlinks and the filename
+  carries no version, so an in-place upgrade across a `POOL_VERSION` bump
+  leaves a file the next run can neither open nor recreate; the registry
+  `.expect()`ed on that, so `Topic::new`, `Image::new`, `PointCloud::new`,
+  `DepthImage::new`, `CostMap::new`, `OccupancyGrid::new` and
+  `TensorHandle::from_shape` panicked instead of returning the `HorusResult`
+  they advertise. Inside a scheduler tick the panic was swallowed by
+  `catch_unwind` — the node entered ticks, completed none, and the process
+  still exited 0.
+
 ## [0.4.0] — 2026-08-22
 
 The first release since 0.2.2 (2026-07-19). **0.3.0 was tagged and never

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -276,7 +276,7 @@ fn spill_to_pool<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static
 ) -> Option<SpillDescriptor> {
     use crate::types::{Device, TensorDtype};
 
-    let pool = topic.get_or_create_spill_pool();
+    let pool = topic.get_or_create_spill_pool()?;
     let tensor = pool
         .alloc(&[bytes.len() as u64], TensorDtype::U8, Device::cpu())
         .ok()?;
@@ -1027,7 +1027,9 @@ fn deserialize_spill_slot<T: DeserializeOwned>(
 /// for the SP/MP backends; FanoutShm uses `read_spilled_retained` instead.
 fn read_spilled_once<T: DeserializeOwned>(spill: SpillDescriptor, topic_name: &str) -> Option<T> {
     let tensor = spill.to_tensor();
-    let pool = super::pool_registry::get_or_create_pool(topic_name);
+    // No usable pool => the payload is unreachable => a counted miss, the same
+    // answer this returns for a superseded slot. It used to be a panic.
+    let pool = super::pool_registry::get_or_create_pool(topic_name).ok()?;
     // Pin the slot across the read, exactly as `read_spilled_retained` does.
     //
     // "There is exactly one reader" was true and still is; what it did not cover
@@ -1068,7 +1070,8 @@ fn read_spilled_retained<T: DeserializeOwned>(
     topic_name: &str,
 ) -> Option<T> {
     let tensor = spill.to_tensor();
-    let pool = super::pool_registry::get_or_create_pool(topic_name);
+    // No usable pool => the payload is unreachable => a counted miss.
+    let pool = super::pool_registry::get_or_create_pool(topic_name).ok()?;
     // Pin the slot for the read. Err => superseded + freed => clean miss.
     if pool.try_retain(&tensor).is_err() {
         return None;
@@ -1163,11 +1166,15 @@ pub(super) fn send_fanout_shm<T: Clone + Send + Sync + Serialize + DeserializeOw
                 // `try_retain` around their read (`read_spilled_retained`), so a
                 // release here can never tear an in-progress read. Evict BEFORE the
                 // alloc so the pool always has a free slot for the new spill.
-                let pool = topic.get_or_create_spill_pool();
-                let window = (local.cached_capacity as usize).max(1);
-                while local.spill_keepalive.len() >= window {
-                    if let Some(old) = local.spill_keepalive.pop_front() {
-                        pool.release(&old);
+                // No pool => nothing was ever spilled on this handle, so there
+                // is nothing to evict; `spill_to_pool` below returns `None` for
+                // the same reason and the `None` arm sends inline.
+                if let Some(pool) = topic.get_or_create_spill_pool() {
+                    let window = (local.cached_capacity as usize).max(1);
+                    while local.spill_keepalive.len() >= window {
+                        if let Some(old) = local.spill_keepalive.pop_front() {
+                            pool.release(&old);
+                        }
                     }
                 }
                 // Hoisted out of the `match` scrutinee so the shared borrow of

--- a/horus_core/src/communication/topic/dispatch.rs
+++ b/horus_core/src/communication/topic/dispatch.rs
@@ -1027,9 +1027,11 @@ fn deserialize_spill_slot<T: DeserializeOwned>(
 /// for the SP/MP backends; FanoutShm uses `read_spilled_retained` instead.
 fn read_spilled_once<T: DeserializeOwned>(spill: SpillDescriptor, topic_name: &str) -> Option<T> {
     let tensor = spill.to_tensor();
-    // No usable pool => the payload is unreachable => a counted miss, the same
-    // answer this returns for a superseded slot. It used to be a panic.
-    let pool = super::pool_registry::get_or_create_pool(topic_name).ok()?;
+    // No usable pool => the payload is unreachable => a miss, the same answer
+    // this returns for a superseded slot. It used to be a panic. Unlike a
+    // superseded slot it is a permanent fault, so it is reported (throttled per
+    // topic) rather than left to look like an idle topic.
+    let pool = super::pool_registry::pool_or_report(topic_name)?;
     // Pin the slot across the read, exactly as `read_spilled_retained` does.
     //
     // "There is exactly one reader" was true and still is; what it did not cover
@@ -1070,8 +1072,9 @@ fn read_spilled_retained<T: DeserializeOwned>(
     topic_name: &str,
 ) -> Option<T> {
     let tensor = spill.to_tensor();
-    // No usable pool => the payload is unreachable => a counted miss.
-    let pool = super::pool_registry::get_or_create_pool(topic_name).ok()?;
+    // No usable pool => the payload is unreachable => a miss, reported for the
+    // same reason as in `read_spilled_once`.
+    let pool = super::pool_registry::pool_or_report(topic_name)?;
     // Pin the slot for the read. Err => superseded + freed => clean miss.
     if pool.try_retain(&tensor).is_err() {
         return None;

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2356,19 +2356,24 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
     /// seed (FNV-1a hash), so publisher and subscriber processes converge on
     /// the same shared memory file.
     ///
+    /// `None` when the pool cannot be opened or created — a pool file left by a
+    /// different `POOL_VERSION` or geometry. Spilling is an optimisation for
+    /// messages larger than a ring slot, so the caller falls back to the inline
+    /// send it already has for a full pool, rather than panicking mid-tick.
+    ///
     /// # Safety
     /// Must be called from the owning thread (Topic is !Sync for mutation).
     /// Uses UnsafeCell — same single-thread guarantee as all other dispatch code.
-    pub(crate) fn get_or_create_spill_pool(&self) -> Arc<TensorPool> {
+    pub(crate) fn get_or_create_spill_pool(&self) -> Option<Arc<TensorPool>> {
         // SAFETY: single-thread ownership — Topic<T> is !Send+!Sync for mutation.
         // UnsafeCell access is safe because dispatch functions run on the owning thread.
         let pool_ref = unsafe { &mut *self.spill_pool.get() };
         if let Some(pool) = pool_ref {
-            return Arc::clone(pool);
+            return Some(Arc::clone(pool));
         }
-        let pool = pool_registry::get_or_create_pool(&self.name);
+        let pool = pool_registry::get_or_create_pool(&self.name).ok()?;
         *pool_ref = Some(Arc::clone(&pool));
-        pool
+        Some(pool)
     }
 
     /// Migration check — reads `migration_epoch` from the SHM header and calls
@@ -3829,7 +3834,7 @@ impl<T: TopicMessage> Topic<T> {
         self.pool
             .as_ref()
             .cloned()
-            .unwrap_or_else(pool_registry::global_pool)
+            .unwrap_or_else(pool_registry::fallback_pool)
     }
 
     /// Publish a new pool-backed keep-alive (on `self.pool`) and release the
@@ -4077,7 +4082,7 @@ where
         let name_str: String = name.into();
         let ring = RingTopic::new(name_str)?;
         let pool = if T::needs_pool() {
-            Some(pool_registry::global_pool())
+            Some(pool_registry::global_pool()?)
         } else {
             None
         };
@@ -4141,7 +4146,7 @@ where
         let name_str: String = name.into();
         let ring = RingTopic::new_with_kind(name_str, topic_kind)?;
         let pool = if T::needs_pool() {
-            Some(pool_registry::global_pool())
+            Some(pool_registry::global_pool()?)
         } else {
             None
         };
@@ -4173,7 +4178,7 @@ where
     pub fn with_capacity(name: &str, capacity: u32, slot_size: Option<usize>) -> HorusResult<Self> {
         let ring = RingTopic::with_capacity(name, capacity, slot_size)?;
         let pool = if T::needs_pool() {
-            Some(pool_registry::global_pool())
+            Some(pool_registry::global_pool()?)
         } else {
             None
         };
@@ -4407,8 +4412,13 @@ impl Topic<DepthImage> {
 
 impl Topic<Tensor> {
     /// Get or create the auto-managed tensor pool for this topic.
+    ///
+    /// Fallible for the same reason [`Topic::new`] is: a pool file left behind
+    /// by a build with a different `POOL_VERSION` or geometry cannot be opened
+    /// *or* recreated, and this used to turn that into a panic on the
+    /// per-frame allocation path.
     #[doc(hidden)]
-    pub fn pool(&self) -> Arc<TensorPool> {
+    pub fn pool(&self) -> HorusResult<Arc<TensorPool>> {
         pool_registry::get_or_create_pool(self.ring.name())
     }
 
@@ -4420,7 +4430,7 @@ impl Topic<Tensor> {
         dtype: crate::types::TensorDtype,
         device: crate::types::Device,
     ) -> HorusResult<crate::memory::TensorHandle> {
-        let pool = self.pool();
+        let pool = self.pool()?;
         crate::memory::TensorHandle::alloc(pool, shape, dtype, device)
     }
 
@@ -4438,7 +4448,9 @@ impl Topic<Tensor> {
     pub fn recv_handle(&self) -> Option<crate::memory::TensorHandle> {
         self.register_sub("Tensor");
         let tensor = self.ring.recv()?;
-        let pool = self.pool();
+        // An unusable pool reads as "nothing to receive" — `recv_handle` already
+        // returns `None` for a superseded slot, and the caller polls again.
+        let pool = self.pool().ok()?;
         // Take a generation-guarded reference so each subscriber owns its own: a
         // co-subscriber dropping its handle cannot free the slot out from under
         // us. `Err` => the slot was superseded (drop-oldest) before we read it

--- a/horus_core/src/communication/topic/mod.rs
+++ b/horus_core/src/communication/topic/mod.rs
@@ -2371,7 +2371,7 @@ impl<T: Clone + Send + Sync + Serialize + DeserializeOwned + 'static> RingTopic<
         if let Some(pool) = pool_ref {
             return Some(Arc::clone(pool));
         }
-        let pool = pool_registry::get_or_create_pool(&self.name).ok()?;
+        let pool = pool_registry::pool_or_report(&self.name)?;
         *pool_ref = Some(Arc::clone(&pool));
         Some(pool)
     }
@@ -4449,8 +4449,10 @@ impl Topic<Tensor> {
         self.register_sub("Tensor");
         let tensor = self.ring.recv()?;
         // An unusable pool reads as "nothing to receive" — `recv_handle` already
-        // returns `None` for a superseded slot, and the caller polls again.
-        let pool = self.pool().ok()?;
+        // returns `None` for a superseded slot, and the caller polls again. It
+        // is not the same fault, though, so it is not left silent: the caller
+        // polling a faulted topic forever gets a throttled line naming it.
+        let pool = pool_registry::pool_or_report(self.ring.name())?;
         // Take a generation-guarded reference so each subscriber owns its own: a
         // co-subscriber dropping its handle cannot free the slot out from under
         // us. `Err` => the slot was superseded (drop-oldest) before we read it

--- a/horus_core/src/communication/topic/pool_registry.rs
+++ b/horus_core/src/communication/topic/pool_registry.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 
+use crate::error::HorusResult;
 use crate::memory::{TensorPool, TensorPoolConfig};
 
 lazy_static! {
@@ -53,22 +54,39 @@ fn auto_pool_config() -> TensorPoolConfig {
 /// When creating a new pool, GPU hardware is auto-detected and the optimal
 /// allocator backend is selected (managed memory on Jetson, pinned memory
 /// on discrete GPU, mmap on CPU-only).
-pub(crate) fn get_or_create_pool(topic_name: &str) -> Arc<TensorPool> {
+///
+/// # Errors
+///
+/// Returns the error from `TensorPool::new` when neither opening nor creating
+/// the pool works. Both fail together whenever the file on disk disagrees with
+/// this process: a `POOL_VERSION` mismatch, a geometry mismatch, or a file
+/// shorter than this process's geometry. That disagreement is not exotic —
+/// `TensorPool::drop` never unlinks and the filename carries no version, so an
+/// in-place upgrade across any of the four `POOL_VERSION` bumps leaves a
+/// poisoned file behind for the next run to find.
+///
+/// This used to `.expect()`, which turned every one of those into a panic on
+/// the per-frame allocation path, out of constructors (`Topic::new`,
+/// `Image::new`, ...) that return `HorusResult` and so advertise an error
+/// channel the panic bypassed. Inside a tick `NodeRunner::run_tick`'s
+/// `catch_unwind` swallowed it — a measured run had the camera node enter 8
+/// ticks, complete 0, and the process still exit 0 — and outside one it killed
+/// the process.
+pub(crate) fn get_or_create_pool(topic_name: &str) -> HorusResult<Arc<TensorPool>> {
     let mut pools = TOPIC_POOLS.lock();
     if let Some(pool) = pools.get(topic_name) {
-        return Arc::clone(pool);
+        return Ok(Arc::clone(pool));
     }
 
     let pid = pool_id_from_name(topic_name);
 
     let pool = Arc::new(match TensorPool::open(pid) {
         Ok(p) => p,
-        Err(_) => TensorPool::new(pid, auto_pool_config())
-            .expect("failed to create tensor pool for topic"),
+        Err(_) => TensorPool::new(pid, auto_pool_config())?,
     });
 
     pools.insert(topic_name.to_string(), Arc::clone(&pool));
-    pool
+    Ok(pool)
 }
 
 /// Get or create a device-specific tensor pool for a topic name.
@@ -80,8 +98,29 @@ const GLOBAL_POOL_NAME: &str = "__horus_global__";
 ///
 /// Used by `Image::new()`, `PointCloud::new()`, `DepthImage::new()` when
 /// creating types outside of a Topic context. Also used by Python bindings.
-pub(crate) fn global_pool() -> Arc<TensorPool> {
+pub(crate) fn global_pool() -> HorusResult<Arc<TensorPool>> {
     get_or_create_pool(GLOBAL_POOL_NAME)
+}
+
+/// The pool a pool-backed handle falls back to when it carries none.
+///
+/// Unreachable for the types that call it: `Topic::<T>::new` builds the pool
+/// for every `T::needs_pool()` type before the handle exists and `Clone` copies
+/// it, so an `Image`/`PointCloud`/`DepthImage`/`CostMap`/`TensorHandle` handle
+/// reaches `from_wire` or a keep-alive publish with `Some(pool)` — and by then
+/// the pool has already been opened once, so this call hits the cache above
+/// rather than the file.
+///
+/// It exists only because `TopicMessage::from_wire` returns `Self`: it has no
+/// error channel to propagate into, and giving it one would change a trait
+/// every message type implements. Every caller that *does* have a channel —
+/// `try_from_wire`, the constructors, the spill paths — takes the fallible
+/// [`global_pool`] instead.
+pub(crate) fn fallback_pool() -> Arc<TensorPool> {
+    global_pool().expect(
+        "a pool-backed handle always carries its pool (Topic::new builds it), so the \
+         global pool was already opened successfully before this point",
+    )
 }
 
 #[cfg(test)]
@@ -106,5 +145,80 @@ mod tests {
     fn test_pool_id_nonzero() {
         let id = pool_id_from_name("");
         assert_ne!(id, 0);
+    }
+
+    /// A pool file this process disagrees with must be an error, not a panic.
+    ///
+    /// `TensorPool::drop` never unlinks and the filename carries no version, so
+    /// a pool file outlives the process that made it, and an in-place upgrade
+    /// across a `POOL_VERSION` bump leaves one behind for the next run to find
+    /// (a stale 1 GB `tensor_pool_1` was sitting in the default namespace on the
+    /// machine this was written on). Both halves of `get_or_create_pool` then
+    /// fail on it, which is what the planted file below reproduces: `open()`
+    /// rejects the header version, and the `TensorPool::new` fallback rejects
+    /// the geometry the older build laid the file out with.
+    ///
+    /// The `.expect()` this replaces made that a panic out of `Topic::new`,
+    /// `Image::new` and friends — all of which return `HorusResult` — and it
+    /// fired on every call, because the failure happens before `pools.insert`
+    /// and so is never cached. Inside a scheduler tick `catch_unwind` swallowed
+    /// it and the node produced nothing while the process still exited 0;
+    /// outside one it killed the process.
+    ///
+    /// NOTE: without the fix this test does not fail on an assert — it panics
+    /// inside `get_or_create_pool`, which is the defect itself.
+    #[test]
+    fn a_pool_file_this_build_disagrees_with_errors_instead_of_panicking() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        let topic = "__horus_test_pool_registry_version_mismatch__";
+        let pid = pool_id_from_name(topic);
+        let path = crate::memory::platform::shm_base_dir()
+            .join("tensors")
+            .join(format!("tensor_pool_{}", pid));
+        let _ = std::fs::remove_file(&path);
+
+        // Plant a real, fully initialized pool whose geometry is NOT
+        // `auto_pool_config()`'s, then let it drop — the file stays.
+        {
+            let config = TensorPoolConfig {
+                pool_size: 64 * 1024,
+                max_slots: 4,
+                ..TensorPoolConfig::default()
+            };
+            TensorPool::new(pid, config).expect("planting the stale pool file");
+        }
+
+        // Age it by one `POOL_VERSION`. `PoolHeader` is `repr(C)` with
+        // `magic: u64` first, so `version: u32` sits at offset 8.
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .expect("reopening the planted pool file");
+            let mut version = [0u8; 4];
+            f.seek(SeekFrom::Start(8)).expect("seek to header version");
+            f.read_exact(&mut version).expect("read header version");
+            let older = u32::from_le_bytes(version).wrapping_sub(1);
+            f.seek(SeekFrom::Start(8)).expect("seek to header version");
+            f.write_all(&older.to_le_bytes())
+                .expect("write header version");
+            f.flush().expect("flush header version");
+        }
+
+        let result = get_or_create_pool(topic);
+        let _ = std::fs::remove_file(&path);
+
+        let err = result
+            .err()
+            .expect("a pool file from another POOL_VERSION must fail, not open");
+        // Nothing was cached, so the next caller gets the same error rather
+        // than a half-built pool.
+        assert!(
+            !TOPIC_POOLS.lock().contains_key(topic),
+            "a pool that could not be opened must not be registered: {}",
+            err
+        );
     }
 }

--- a/horus_core/src/communication/topic/pool_registry.rs
+++ b/horus_core/src/communication/topic/pool_registry.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 
-use crate::error::HorusResult;
+use crate::error::{HorusContext, HorusResult};
 use crate::memory::{TensorPool, TensorPoolConfig};
 
 lazy_static! {
@@ -57,8 +57,14 @@ fn auto_pool_config() -> TensorPoolConfig {
 ///
 /// # Errors
 ///
-/// Returns the error from `TensorPool::new` when neither opening nor creating
-/// the pool works. Both fail together whenever the file on disk disagrees with
+/// Returns an error when neither opening nor creating the pool works, carrying
+/// *both* halves: the `TensorPool::open` failure as context and the
+/// `TensorPool::new` failure as its cause. The two say different things — the
+/// first names why the file on disk was rejected (header magic, `POOL_VERSION`),
+/// the second only what the recreate attempt tripped over (geometry, size) —
+/// and it is usually the first that identifies the stale file.
+///
+/// Both fail together whenever the file on disk disagrees with
 /// this process: a `POOL_VERSION` mismatch, a geometry mismatch, or a file
 /// shorter than this process's geometry. That disagreement is not exotic —
 /// `TensorPool::drop` never unlinks and the filename carries no version, so an
@@ -82,7 +88,18 @@ pub(crate) fn get_or_create_pool(topic_name: &str) -> HorusResult<Arc<TensorPool
 
     let pool = Arc::new(match TensorPool::open(pid) {
         Ok(p) => p,
-        Err(_) => TensorPool::new(pid, auto_pool_config())?,
+        // Keep the `open` error. When both halves fail on the same stale file
+        // they fail for different reasons, and `open`'s is the one that names
+        // the file as stale — dropping it left the caller with only the
+        // recreate error ("exists but is only N bytes"), which reads like a
+        // race with a concurrent creator rather than a leftover from an older
+        // build. `horus_context_with` only allocates on the error path.
+        Err(open_err) => TensorPool::new(pid, auto_pool_config()).horus_context_with(|| {
+            format!(
+                "tensor pool for topic '{topic_name}' (pool_id {pid}): the existing pool \
+                 file could not be opened ({open_err}), and creating it failed too"
+            )
+        })?,
     });
 
     pools.insert(topic_name.to_string(), Arc::clone(&pool));
@@ -171,12 +188,32 @@ mod tests {
     fn a_pool_file_this_build_disagrees_with_errors_instead_of_panicking() {
         use std::io::{Read, Seek, SeekFrom, Write};
 
-        let topic = "__horus_test_pool_registry_version_mismatch__";
+        /// Unlinks the planted file however this test leaves — including the
+        /// panic it exists to rule out, which is the one exit that would
+        /// otherwise leave a poisoned pool file in the namespace.
+        struct Planted(std::path::PathBuf);
+        impl Drop for Planted {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+
+        // Per-process name. A test binary's SHM namespace is keyed on the cargo
+        // *target directory* (`shm::cargo_test_namespace`), not on the process,
+        // so two runs out of one target dir share it — and this test plants,
+        // corrupts and unlinks a fixed path. The pid keeps concurrent runs off
+        // each other's file.
+        let topic = format!(
+            "__horus_test_pool_registry_version_mismatch_{}__",
+            std::process::id()
+        );
+        let topic = topic.as_str();
         let pid = pool_id_from_name(topic);
         let path = crate::memory::platform::shm_base_dir()
             .join("tensors")
             .join(format!("tensor_pool_{}", pid));
         let _ = std::fs::remove_file(&path);
+        let _planted = Planted(path.clone());
 
         // Plant a real, fully initialized pool whose geometry is NOT
         // `auto_pool_config()`'s, then let it drop — the file stays.
@@ -208,11 +245,26 @@ mod tests {
         }
 
         let result = get_or_create_pool(topic);
-        let _ = std::fs::remove_file(&path);
 
         let err = result
             .err()
             .expect("a pool file from another POOL_VERSION must fail, not open");
+
+        // Both halves of the failure reach the caller. `open`'s is the one that
+        // identifies the file as stale ("version mismatch: expected 4, got 3");
+        // `new`'s only reports the geometry the second attempt tripped over,
+        // which on its own reads like a race with a concurrent creator.
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("version mismatch"),
+            "the `open` failure names the file as stale and must survive into \
+             the error the caller sees: {rendered}"
+        );
+        assert!(
+            rendered.contains("Caused by:"),
+            "the `new` failure must survive too, as the cause: {rendered}"
+        );
+
         // Nothing was cached, so the next caller gets the same error rather
         // than a half-built pool.
         assert!(

--- a/horus_core/src/communication/topic/pool_registry.rs
+++ b/horus_core/src/communication/topic/pool_registry.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 
-use crate::error::{HorusContext, HorusResult};
+use crate::error::{HorusContext, HorusError, HorusResult};
 use crate::memory::{TensorPool, TensorPoolConfig};
 
 lazy_static! {
@@ -119,6 +119,125 @@ pub(crate) fn global_pool() -> HorusResult<Arc<TensorPool>> {
     get_or_create_pool(GLOBAL_POOL_NAME)
 }
 
+/// [`global_pool`] for a caller with no error channel. See [`pool_or_report`].
+pub(crate) fn global_pool_or_report() -> Option<Arc<TensorPool>> {
+    pool_or_report(GLOBAL_POOL_NAME)
+}
+
+/// [`get_or_create_pool`] for the callers that have no error channel to
+/// propagate into: `recv_handle`, the spill paths, `try_from_wire`. They answer
+/// `None`, which at the call site means "no message" — so an unusable pool,
+/// which is a permanent configuration fault, arrives looking exactly like an
+/// idle topic, and the caller polls forever with nothing to go on.
+///
+/// That is the same invisibility the panic this replaced had (swallowed by
+/// `run_tick`'s `catch_unwind`, node completing no ticks, process exiting 0),
+/// and this module's neighbours already refuse it: a dropped message on the
+/// abandoned-claim path is counted *and* "said out loud, because 'my control
+/// topic has a hole in it' is not something an operator should have to go
+/// looking for a counter to discover". So say it.
+///
+/// Nothing is cached on the failure path, so the failure recurs on every call —
+/// at tick rate. Hence the throttle in [`report_unusable_pool`].
+pub(crate) fn pool_or_report(topic_name: &str) -> Option<Arc<TensorPool>> {
+    match get_or_create_pool(topic_name) {
+        Ok(pool) => Some(pool),
+        Err(err) => {
+            report_unusable_pool(topic_name, &err);
+            None
+        }
+    }
+}
+
+/// One line per topic per window. Fast enough that an operator watching a
+/// terminal sees the fault immediately, slow enough that a 1 kHz subscriber
+/// cannot outrun the log.
+const REPORT_WINDOW_MS: u64 = 1_000;
+
+/// Throttle state for [`report_unusable_pool`], keyed by topic name.
+///
+/// Per topic, not per call site. `hlog_every!` keeps its timestamp in a
+/// `static` at the expansion point, and every caller here funnels through one
+/// helper — so a call-site gate would let the first broken topic silence every
+/// other broken topic, which is worse than no throttle at all, because the one
+/// that got through looks like the only one in trouble. `DiagThrottle` exists
+/// in the scheduler for exactly this reason.
+///
+/// Only ever touched on the failure path.
+struct PoolReport {
+    /// Wall clock of the last line emitted for this topic, ms since the epoch.
+    /// `0` is "never reported" and always emits, so a fault is never delayed.
+    last_ms: u64,
+    /// Failures swallowed since that line.
+    suppressed: u64,
+}
+
+lazy_static! {
+    static ref POOL_REPORTS: Mutex<HashMap<String, PoolReport>> = Mutex::new(HashMap::new());
+}
+
+/// `Some(suppressed_since_the_last_line)` when this failure should be emitted.
+///
+/// Takes `now_ms` rather than reading the clock so the test is deterministic.
+fn allow_report(topic_name: &str, now_ms: u64) -> Option<u64> {
+    let mut reports = POOL_REPORTS.lock();
+    let entry = reports.entry(topic_name.to_string()).or_insert(PoolReport {
+        last_ms: 0,
+        suppressed: 0,
+    });
+    if entry.last_ms != 0 && now_ms.saturating_sub(entry.last_ms) < REPORT_WINDOW_MS {
+        entry.suppressed = entry.suppressed.saturating_add(1);
+        return None;
+    }
+    entry.last_ms = now_ms;
+    Some(std::mem::take(&mut entry.suppressed))
+}
+
+/// What the operator reads. Split out from the `log::warn!` so a test can hold
+/// it to its claims without installing a logger.
+///
+/// Carries the suppressed count for the same reason `DiagThrottle` does:
+/// throttling may hide the volume of the output, never the volume of the fault.
+fn unusable_pool_message(
+    topic_name: &str,
+    pool_id: u32,
+    suppressed: u64,
+    err: &HorusError,
+) -> String {
+    let also = if suppressed == 0 {
+        String::new()
+    } else {
+        format!(" ({suppressed} further failures suppressed since the last line)")
+    };
+    format!(
+        "Topic '{topic_name}': its tensor pool (pool_id {pool_id}) can be neither \
+         opened nor created, so every message that needs it is being \
+         DROPPED{also} — the topic is faulted, not idle. This does not clear \
+         by itself: {err}"
+    )
+}
+
+/// Say an unusable pool out loud, at most once per [`REPORT_WINDOW_MS`] per
+/// topic.
+///
+/// Cold by construction — reached only when the pool file on disk disagrees
+/// with this build — so the clock read, the map lookup and the formatting are
+/// paid by a robot that is already producing nothing.
+#[cold]
+#[inline(never)]
+fn report_unusable_pool(topic_name: &str, err: &HorusError) {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    if let Some(suppressed) = allow_report(topic_name, now_ms) {
+        log::warn!(
+            "{}",
+            unusable_pool_message(topic_name, pool_id_from_name(topic_name), suppressed, err)
+        );
+    }
+}
+
 /// The pool a pool-backed handle falls back to when it carries none.
 ///
 /// Unreachable for the types that call it: `Topic::<T>::new` builds the pool
@@ -129,10 +248,12 @@ pub(crate) fn global_pool() -> HorusResult<Arc<TensorPool>> {
 /// rather than the file.
 ///
 /// It exists only because `TopicMessage::from_wire` returns `Self`: it has no
-/// error channel to propagate into, and giving it one would change a trait
-/// every message type implements. Every caller that *does* have a channel —
-/// `try_from_wire`, the constructors, the spill paths — takes the fallible
-/// [`global_pool`] instead.
+/// error channel to propagate into at all, not even an `Option`, and giving it
+/// one would change a trait every message type implements. Every other caller
+/// has somewhere to put the failure — the constructors take the fallible
+/// [`global_pool`]; `try_from_wire` and the spill paths take
+/// [`global_pool_or_report`] / [`pool_or_report`], which answer `None` and say
+/// why.
 pub(crate) fn fallback_pool() -> Arc<TensorPool> {
     global_pool().expect(
         "a pool-backed handle always carries its pool (Topic::new builds it), so the \
@@ -186,6 +307,7 @@ mod tests {
     /// inside `get_or_create_pool`, which is the defect itself.
     #[test]
     fn a_pool_file_this_build_disagrees_with_errors_instead_of_panicking() {
+        use crate::memory::tensor_pool::HEADER_VERSION_OFFSET as VERSION_OFFSET;
         use std::io::{Read, Seek, SeekFrom, Write};
 
         /// Unlinks the planted file however this test leaves — including the
@@ -226,8 +348,10 @@ mod tests {
             TensorPool::new(pid, config).expect("planting the stale pool file");
         }
 
-        // Age it by one `POOL_VERSION`. `PoolHeader` is `repr(C)` with
-        // `magic: u64` first, so `version: u32` sits at offset 8.
+        // Age it by one `POOL_VERSION`. The offset comes from the struct
+        // (`offset_of!`), not from a literal, so a header field added ahead of
+        // `version` moves the write instead of leaving this corrupting a
+        // neighbouring field and failing on the assertions below.
         {
             let mut f = std::fs::OpenOptions::new()
                 .read(true)
@@ -235,10 +359,12 @@ mod tests {
                 .open(&path)
                 .expect("reopening the planted pool file");
             let mut version = [0u8; 4];
-            f.seek(SeekFrom::Start(8)).expect("seek to header version");
+            f.seek(SeekFrom::Start(VERSION_OFFSET))
+                .expect("seek to header version");
             f.read_exact(&mut version).expect("read header version");
             let older = u32::from_le_bytes(version).wrapping_sub(1);
-            f.seek(SeekFrom::Start(8)).expect("seek to header version");
+            f.seek(SeekFrom::Start(VERSION_OFFSET))
+                .expect("seek to header version");
             f.write_all(&older.to_le_bytes())
                 .expect("write header version");
             f.flush().expect("flush header version");
@@ -271,6 +397,96 @@ mod tests {
             !TOPIC_POOLS.lock().contains_key(topic),
             "a pool that could not be opened must not be registered: {}",
             err
+        );
+
+        // And the wrapper the no-error-channel callers use (`recv_handle`, the
+        // spill paths) answers `None` on the same file rather than panicking or
+        // handing back a pool it could not open.
+        assert!(
+            pool_or_report(topic).is_none(),
+            "pool_or_report must refuse a pool file this build disagrees with"
+        );
+    }
+
+    /// The throttle that keeps the report above from following a 1 kHz
+    /// subscriber into the log.
+    ///
+    /// Failures are not cached — `get_or_create_pool` returns before
+    /// `pools.insert` — so a faulted topic fails on *every* call, which is what
+    /// makes the throttle load-bearing rather than decorative.
+    #[test]
+    fn an_unusable_pool_is_reported_once_per_window_and_carries_what_it_hid() {
+        let topic = format!("__horus_test_pool_report_window_{}__", std::process::id());
+        let t = topic.as_str();
+
+        // The first occurrence always speaks: a fault is never delayed by up to
+        // a window the first time it happens.
+        assert_eq!(allow_report(t, 10_000), Some(0));
+        for i in 1..REPORT_WINDOW_MS {
+            assert_eq!(allow_report(t, 10_000 + i), None);
+        }
+        // The next line through carries the count, so the throttle hides the
+        // volume of the output and never the volume of the fault.
+        assert_eq!(
+            allow_report(t, 10_000 + REPORT_WINDOW_MS),
+            Some(REPORT_WINDOW_MS - 1)
+        );
+        // ...and the count resets once reported.
+        assert_eq!(allow_report(t, 10_000 + 2 * REPORT_WINDOW_MS), Some(0));
+    }
+
+    /// Per topic, not per call site.
+    ///
+    /// Every caller funnels through one helper, so a call-site gate
+    /// (`hlog_every!`) would let the first broken topic silence the rest — and
+    /// the survivor would read as the only topic in trouble. Same reason the
+    /// scheduler has `DiagThrottle` instead.
+    #[test]
+    fn one_faulted_topic_does_not_silence_another() {
+        let pid = std::process::id();
+        let a = format!("__horus_test_pool_report_a_{pid}__");
+        let b = format!("__horus_test_pool_report_b_{pid}__");
+
+        assert_eq!(allow_report(&a, 20_000), Some(0));
+        assert_eq!(allow_report(&a, 20_001), None);
+        assert_eq!(
+            allow_report(&b, 20_001),
+            Some(0),
+            "a second faulted topic must still be able to report itself"
+        );
+    }
+
+    /// The line an operator actually reads has to distinguish the fault from
+    /// the "no message" it is delivered as, and carry the cause.
+    #[test]
+    fn the_report_names_the_topic_the_fault_and_the_cause() {
+        let err = HorusError::Config(crate::error::ConfigError::Other(
+            "Tensor pool version mismatch: expected 4, got 3".to_string(),
+        ));
+
+        let quiet = unusable_pool_message("camera.rgb", 4242, 0, &err);
+        assert!(quiet.contains("camera.rgb"), "{quiet}");
+        assert!(
+            quiet.contains("4242"),
+            "the pool_id names the file: {quiet}"
+        );
+        assert!(
+            quiet.contains("DROPPED") && quiet.contains("not idle"),
+            "the whole point is that this is not an empty topic: {quiet}"
+        );
+        assert!(
+            quiet.contains("version mismatch: expected 4, got 3"),
+            "the cause must survive into the line: {quiet}"
+        );
+        assert!(
+            !quiet.contains("suppressed"),
+            "nothing was suppressed, so nothing to report: {quiet}"
+        );
+
+        let throttled = unusable_pool_message("camera.rgb", 4242, 999, &err);
+        assert!(
+            throttled.contains("999") && throttled.contains("suppressed"),
+            "a throttled line must still report the volume of the fault: {throttled}"
         );
     }
 }

--- a/horus_core/src/communication/topic/tensor_ext.rs
+++ b/horus_core/src/communication/topic/tensor_ext.rs
@@ -36,7 +36,7 @@
 use std::sync::Arc;
 
 #[cfg(test)]
-use super::pool_registry::get_or_create_pool;
+use super::pool_registry::{get_or_create_pool, pool_or_report};
 #[cfg(test)]
 use super::RingTopic;
 #[cfg(test)]
@@ -91,7 +91,9 @@ impl RingTopic<Tensor> {
     /// is available.
     pub fn recv_handle(&self) -> Option<TensorHandle> {
         let tensor = self.recv()?;
-        let pool = self.pool().ok()?;
+        // `None` here means "no usable pool", not "no message" — reported,
+        // throttled per topic, rather than dropped in silence.
+        let pool = pool_or_report(self.name())?;
         // from_owned: the sender already incremented the refcount for us.
         // Validates pool_id match; returns None if descriptor belongs to a
         // different pool (prevents refcount corruption).

--- a/horus_core/src/communication/topic/tensor_ext.rs
+++ b/horus_core/src/communication/topic/tensor_ext.rs
@@ -54,7 +54,7 @@ impl RingTopic<Tensor> {
     /// or creates a new one backed by shared memory. Subsequent calls return
     /// the cached pool. The pool is shared across all `Topic<Tensor>`
     /// instances with the same name within this process.
-    pub fn pool(&self) -> Arc<TensorPool> {
+    pub fn pool(&self) -> HorusResult<Arc<TensorPool>> {
         get_or_create_pool(self.name())
     }
 
@@ -68,7 +68,7 @@ impl RingTopic<Tensor> {
         dtype: TensorDtype,
         device: Device,
     ) -> HorusResult<TensorHandle> {
-        let pool = self.pool();
+        let pool = self.pool()?;
         TensorHandle::alloc(pool, shape, dtype, device)
     }
 
@@ -91,7 +91,7 @@ impl RingTopic<Tensor> {
     /// is available.
     pub fn recv_handle(&self) -> Option<TensorHandle> {
         let tensor = self.recv()?;
-        let pool = self.pool();
+        let pool = self.pool().ok()?;
         // from_owned: the sender already incremented the refcount for us.
         // Validates pool_id match; returns None if descriptor belongs to a
         // different pool (prevents refcount corruption).
@@ -140,8 +140,8 @@ mod tests {
     fn test_pool_shared_across_calls() {
         let topic: RingTopic<Tensor> = RingTopic::new("test.tensor_ext_shared_pool").unwrap();
 
-        let pool1 = topic.pool();
-        let pool2 = topic.pool();
+        let pool1 = topic.pool().expect("first pool open");
+        let pool2 = topic.pool().expect("second pool open");
 
         // Same Arc (same pool_id)
         assert_eq!(pool1.pool_id(), pool2.pool_id());

--- a/horus_core/src/communication/topic/topic_message.rs
+++ b/horus_core/src/communication/topic/topic_message.rs
@@ -29,7 +29,7 @@ use crate::types::{
     PointCloudDescriptor, Tensor,
 };
 
-use super::pool_registry::{fallback_pool, global_pool};
+use super::pool_registry::{fallback_pool, global_pool_or_report};
 
 /// Defines how a type is transported through Topic's ring buffer.
 ///
@@ -127,7 +127,7 @@ macro_rules! impl_pool_backed_topic_message {
                     // `needs_pool()` type — `pool` is always `Some` here.
                     let p = match pool.as_ref().cloned() {
                         Some(p) => p,
-                        None => global_pool().ok()?,
+                        None => global_pool_or_report()?,
                     };
                     // Generation-guarded retain so each subscriber owns its own
                     // reference. `Err` => the slot was freed/reallocated since the
@@ -182,7 +182,7 @@ impl TopicMessage for CostMap {
     fn try_from_wire(wire: CostMapDescriptor, pool: &Option<Arc<TensorPool>>) -> Option<Self> {
         let p = match pool.as_ref().cloned() {
             Some(p) => p,
-            None => global_pool().ok()?,
+            None => global_pool_or_report()?,
         };
         // Dual-tensor: retain BOTH. If the second is already stale, unwind the
         // first so we don't leak it, and report the message as missed.
@@ -225,7 +225,7 @@ impl TopicMessage for TensorHandle {
     fn try_from_wire(wire: Tensor, pool: &Option<Arc<TensorPool>>) -> Option<Self> {
         let p = match pool.as_ref().cloned() {
             Some(p) => p,
-            None => global_pool().ok()?,
+            None => global_pool_or_report()?,
         };
         if p.try_retain(&wire).is_err() {
             return None;

--- a/horus_core/src/communication/topic/topic_message.rs
+++ b/horus_core/src/communication/topic/topic_message.rs
@@ -29,7 +29,7 @@ use crate::types::{
     PointCloudDescriptor, Tensor,
 };
 
-use super::pool_registry::global_pool;
+use super::pool_registry::{fallback_pool, global_pool};
 
 /// Defines how a type is transported through Topic's ring buffer.
 ///
@@ -116,13 +116,19 @@ macro_rules! impl_pool_backed_topic_message {
 
                 #[inline]
                 fn from_wire(wire: $Descriptor, pool: &Option<Arc<TensorPool>>) -> Self {
-                    let p = pool.as_ref().cloned().unwrap_or_else(global_pool);
+                    let p = pool.as_ref().cloned().unwrap_or_else(fallback_pool);
                     <$Type>::from_owned(wire, p)
                 }
 
                 #[inline]
                 fn try_from_wire(wire: $Descriptor, pool: &Option<Arc<TensorPool>>) -> Option<Self> {
-                    let p = pool.as_ref().cloned().unwrap_or_else(global_pool);
+                    // `Option<Self>` is an error channel, so use it: an unusable
+                    // global pool reads as a miss, not a panic. Unreachable for a
+                    // `needs_pool()` type — `pool` is always `Some` here.
+                    let p = match pool.as_ref().cloned() {
+                        Some(p) => p,
+                        None => global_pool().ok()?,
+                    };
                     // Generation-guarded retain so each subscriber owns its own
                     // reference. `Err` => the slot was freed/reallocated since the
                     // message was published (superseded under drop-oldest) =>
@@ -168,13 +174,16 @@ impl TopicMessage for CostMap {
 
     #[inline]
     fn from_wire(wire: CostMapDescriptor, pool: &Option<Arc<TensorPool>>) -> Self {
-        let p = pool.as_ref().cloned().unwrap_or_else(global_pool);
+        let p = pool.as_ref().cloned().unwrap_or_else(fallback_pool);
         CostMap::from_owned(wire, p)
     }
 
     #[inline]
     fn try_from_wire(wire: CostMapDescriptor, pool: &Option<Arc<TensorPool>>) -> Option<Self> {
-        let p = pool.as_ref().cloned().unwrap_or_else(global_pool);
+        let p = match pool.as_ref().cloned() {
+            Some(p) => p,
+            None => global_pool().ok()?,
+        };
         // Dual-tensor: retain BOTH. If the second is already stale, unwind the
         // first so we don't leak it, and report the message as missed.
         if p.try_retain(wire.grid_tensor()).is_err() {
@@ -208,13 +217,16 @@ impl TopicMessage for TensorHandle {
 
     #[inline]
     fn from_wire(wire: Tensor, pool: &Option<Arc<TensorPool>>) -> Self {
-        let p = pool.as_ref().cloned().unwrap_or_else(global_pool);
+        let p = pool.as_ref().cloned().unwrap_or_else(fallback_pool);
         TensorHandle::new(wire, p)
     }
 
     #[inline]
     fn try_from_wire(wire: Tensor, pool: &Option<Arc<TensorPool>>) -> Option<Self> {
-        let p = pool.as_ref().cloned().unwrap_or_else(global_pool);
+        let p = match pool.as_ref().cloned() {
+            Some(p) => p,
+            None => global_pool().ok()?,
+        };
         if p.try_retain(&wire).is_err() {
             return None;
         }

--- a/horus_core/src/memory/costmap.rs
+++ b/horus_core/src/memory/costmap.rs
@@ -77,7 +77,7 @@ impl CostMap {
         resolution: f32,
         inflation_radius: f32,
     ) -> HorusResult<Self> {
-        Self::new_on(width, height, resolution, inflation_radius, global_pool())
+        Self::new_on(width, height, resolution, inflation_radius, global_pool()?)
     }
 
     /// Create a cost map backed by a specific pool.

--- a/horus_core/src/memory/depth_image.rs
+++ b/horus_core/src/memory/depth_image.rs
@@ -69,7 +69,7 @@ impl DepthImage {
     /// Prefer `meters()` or `millimeters()` for common formats.
     #[doc(hidden)]
     pub fn new(width: u32, height: u32, dtype: TensorDtype) -> HorusResult<Self> {
-        Self::new_on(width, height, dtype, global_pool())
+        Self::new_on(width, height, dtype, global_pool()?)
     }
 
     /// Create a depth image backed by a specific pool.

--- a/horus_core/src/memory/image.rs
+++ b/horus_core/src/memory/image.rs
@@ -63,7 +63,7 @@ impl Image {
     /// assert_eq!(img.height(), 480);
     /// ```
     pub fn new(width: u32, height: u32, encoding: ImageEncoding) -> HorusResult<Self> {
-        Self::new_on(width, height, encoding, global_pool())
+        Self::new_on(width, height, encoding, global_pool()?)
     }
 
     /// Create a new image backed by a specific pool.

--- a/horus_core/src/memory/occupancy_grid.rs
+++ b/horus_core/src/memory/occupancy_grid.rs
@@ -48,7 +48,7 @@ impl OccupancyGrid {
     ///
     /// Allocates shared memory from a global pool. Cells are initialized to -1 (unknown).
     pub fn new(width: u32, height: u32, resolution: f32) -> HorusResult<Self> {
-        Self::new_on(width, height, resolution, global_pool())
+        Self::new_on(width, height, resolution, global_pool()?)
     }
 
     /// Create an occupancy grid backed by a specific pool.

--- a/horus_core/src/memory/pointcloud.rs
+++ b/horus_core/src/memory/pointcloud.rs
@@ -130,7 +130,7 @@ impl PointCloud {
     /// Prefer `from_xyz()`, `from_xyzi()`, or `from_xyzrgb()` for common formats.
     #[doc(hidden)]
     pub fn new(num_points: u32, fields_per_point: u32, dtype: TensorDtype) -> HorusResult<Self> {
-        Self::new_on(num_points, fields_per_point, dtype, global_pool())
+        Self::new_on(num_points, fields_per_point, dtype, global_pool()?)
     }
 
     /// Create a point cloud backed by a specific pool.

--- a/horus_core/src/memory/tensor_handle.rs
+++ b/horus_core/src/memory/tensor_handle.rs
@@ -133,7 +133,7 @@ impl TensorHandle {
                 "TensorHandle::from_shape: every dimension must be greater than zero".to_string(),
             )));
         }
-        let pool = crate::communication::topic::pool_registry::global_pool();
+        let pool = crate::communication::topic::pool_registry::global_pool()?;
         let device = pool.backend_device();
         Self::alloc(pool, shape, dtype, device)
     }

--- a/horus_core/src/memory/tensor_pool.rs
+++ b/horus_core/src/memory/tensor_pool.rs
@@ -178,6 +178,17 @@ struct PoolHeader {
     _padding: [u8; 16],
 }
 
+/// Byte offset of `PoolHeader::version` inside the mapping.
+///
+/// Exists so a test that ages a pool file by one `POOL_VERSION` does not
+/// hard-code the offset. `8` was correct only for as long as `magic: u64` stays
+/// the single field ahead of `version`; a field added in front of it would have
+/// left that test corrupting some *other* header field and then failing on an
+/// assertion about `open()`'s message, which is a long way from the cause.
+/// Derived from the struct, so a reordering moves it automatically.
+#[cfg(test)]
+pub(crate) const HEADER_VERSION_OFFSET: u64 = std::mem::offset_of!(PoolHeader, version) as u64;
+
 /// Slot metadata stored in shared memory
 ///
 /// Layout (56 bytes, repr(C)):


### PR DESCRIPTION
`pool_registry::get_or_create_pool` tried `TensorPool::open(pid)` and on any
failure fell back to `TensorPool::new(pid, auto_pool_config())
.expect("failed to create tensor pool for topic")`. Both calls fail together
whenever the file on disk disagrees with this process: a POOL_VERSION mismatch
(validate_fields), a geometry mismatch, or a file shorter than this process's
geometry (await_pool_file_size). So the `.expect()` was not a "cannot happen"
guard — it was the ordinary answer to a stale pool file.

The trigger is not hypothetical: `TensorPool::drop` never unlinks, no production
cleanup routine exists, and the filename carries no version, so an in-place
upgrade across any of the four POOL_VERSION bumps leaves a poisoned file behind
(a stale 1 GB `tensor_pool_1` was sitting in the default namespace on the machine
this was written on).

That made a panic out of `Topic::new`, `Image::new`, `PointCloud::new`,
`DepthImage::new`, `CostMap::new`, `OccupancyGrid::new` and
`TensorHandle::from_shape` — all of which return `HorusResult` and so advertise
an error channel the panic bypassed — and it fired on every call, because the
failure happens before `pools.insert` and is never cached. Inside a scheduler
tick `NodeRunner::run_tick`'s `catch_unwind` swallowed it (a pool-backed node
enters ticks and completes none while the process still exits 0); outside one
— `Topic::new` in `main()`, a CLI tool, an embedding — it killed the process.

`get_or_create_pool` and `global_pool` now return `HorusResult<Arc<TensorPool>>`
and every caller uses the channel it already has:

  - the constructors above and `Topic::new`/`new_with_kind`/`with_capacity`
    add a `?`;
  - `read_spilled_once`/`read_spilled_retained` return `None` — the same counted
    miss they already return for a superseded slot;
  - `get_or_create_spill_pool` returns `Option`, so `spill_to_pool` falls into
    the `None => ring.send_serde(inline)` arm the fanout send already has;
  - `Topic::<Tensor>::pool()` (`#[doc(hidden)]`) becomes fallible, so
    `alloc_tensor` propagates and `recv_handle` reads it as "nothing to receive".

One `.expect()` remains, isolated in `pool_registry::fallback_pool()` and
documented there: `TopicMessage::from_wire` returns `Self` and has no error
channel, and giving it one would change a trait every message type implements.
It is unreachable by construction — `Topic::<T>::new` builds the pool for every
`T::needs_pool()` type before the handle exists and `Clone` copies it, so
`from_wire` and `keepalive_pool` are only ever reached with `Some(pool)`.

## Ablation

```
Reverted ONLY the production change (restored `.expect("failed to create tensor pool for topic")` in `get_or_create_pool`, keeping its `HorusResult` signature so the rest of the tree still compiles, and keeping the test unchanged). `cargo test -p horus_core --lib pool_registry`:

running 4 tests
test communication::topic::pool_registry::tests::test_pool_id_deterministic ... ok
test communication::topic::pool_registry::tests::test_pool_id_different_names ... ok
test communication::topic::pool_registry::tests::test_pool_id_nonzero ... ok

thread 'communication::topic::pool_registry::tests::a_pool_file_this_build_disagrees_with_errors_instead_of_panicking' (1994478) panicked at horus_core/src/communication/topic/pool_registry.rs:86:14:
failed to create tensor pool for topic: Config(Other("Tensor pool 2124885088 exists but is only 65856 bytes, smaller than the 1073799232 bytes this process's configuration requires — the pool was created with a different geometry (or its creator has not finished initializing it)"))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test communication::topic::pool_registry::tests::a_pool_file_this_build_disagrees_with_errors_instead_of_panicking ... FAILED

failures:
    communication::topic::pool_registry::tests::a_pool_file_this_build_disagrees_with_errors_instead_of_panicking

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 2498 filtered out; finished in 0.11s

error: test failed, to rerun pass `-p horus_core --lib`

The production change was then restored and the test re-run: 4 passed; 0 failed; finished in 0.13s. (The panic message is the geometry rejection because the second `TensorPool::new` call carries `auto_pool_config()`'s 1 GiB geometry; the first call, `TensorPool::open`, is the one that rejected the flipped header version. Both halves failing is exactly the claim.)
```

## Tests

```
Targeted (new test): `cargo test -p horus_core --lib pool_registry` → 4 passed, 0 failed, 2498 filtered out, 0.13s.

Full lib suite: `cargo test -p horus_core --lib` → 2497 passed, 1 failed, 4 ignored, 57.50s. The single failure was `scheduling::event_executor::tests::wake_comes_from_the_publisher_not_from_the_backstop`, a wall-clock assertion ("the median of 9 serial notify->tick round trips was 10.830349ms", budget 5ms). Re-run alone it passes (1 passed, 0.47s). The box was running ~20 concurrent sibling cargo builds and /dev/shm grew 16G→20G during the run (the known HORUS test SHM leak). That test touches futex wake latency, not tensor pools; nothing in this diff runs on that path.

Integration binaries most exposed to the changed code paths — `cargo test -p horus_core --test cross_process_fanout_spill --test tensorpool_matrix --test cross_process_image --test topic_lifecycle --test memory_coverage` → 2 + 3 + 33 + 4 + 6 = 48 passed, 0 failed.

Downstream compile (proves the `Topic::<Tensor>::pool()` signature change breaks nothing): `cargo check -p horus_py -p horus_cpp -p horus_manager -p horus_net` → clean (also builds `horus` and `horus_types`).

`cargo clippy -p horus_core --all-targets` → clean, zero warnings. `cargo fmt --all --check` → clean.
```

## Notes from the implementer

CONFIRMED the finding independently before fixing. The code at pool_registry.rs:64-68 was verbatim as claimed; `TensorPool::open` validates magic (tensor_pool.rs:564) and version (583) inline, and `TensorPool::new`'s AlreadyExists branch goes through `await_pool_file_size` and `validate_or_reclaim`, which deliberately refuses to reclaim a version/geometry mismatch ("must stay an error rather than be overwritten", tensor_pool.rs:806-810). So both halves fail on the same stale file and the `.expect()` was the ordinary outcome, not a guard.

What I could NOT verify, and honest caveats:

1. One `.expect()` survives, in `pool_registry::fallback_pool()`. `TopicMessage::from_wire` returns `Self` and has no error channel; giving it one changes a trait every message type implements (a real public API break), which the brief says not to guess at. I argued unreachability by reading every construction site — `Topic::<T>::new`/`new_with_kind`/`with_capacity` set `pool: Some(..)` exactly when `T::needs_pool()`, `Clone` copies it, and the only `from_wire`/`keepalive_pool` callers are `impl Topic<Image|PointCloud|DepthImage>` — but I did not write a test for it, because reaching it requires poisoning the process-wide `__horus_global__` pool, which would break every other test in the binary. If a reviewer wants zero panics, the follow-up is `from_wire(...) -> Option<Self>` (or dropping `from_wire` in favour of `try_from_wire`), and that is a design decision for a human.

2. `Topic::<Tensor>::pool()` is `#[doc(hidden)] pub` and its return type changed to `HorusResult<Arc<TensorPool>>`. Technically a public API break. I grepped the whole workspace: no caller outside the two methods beside it (horus_py's `.pool()` calls are on `Image`/`PointCloud`/`DepthImage`, not on the topic), and `horus`, `horus_py`, `horus_cpp`, `horus_manager`, `horus_net` all compile unchanged. `alloc_tensor`, `send_handle` and `recv_handle` — what horus_py actually calls — keep their signatures. Flagging it bec

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and full-suite tested in a clean worktree before this PR.
