### PR TITLE
fix(cli): say when a topic stalls instead of freezing the last rate

### DIFF
--- a/horus_manager/src/commands/topic.rs
+++ b/horus_manager/src/commands/topic.rs
@@ -9,7 +9,7 @@ use colored::*;
 use horus_core::core::DurationExt;
 use horus_core::error::{ConfigError, HorusError, HorusResult};
 use std::io::{IsTerminal, Write};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// List all active topics
 pub fn list_topics(verbose: bool, json: bool) -> HorusResult<()> {
@@ -880,6 +880,96 @@ fn print_endpoints(heading: &str, names: &[String], count: u32) {
     }
 }
 
+/// Why a live `topic hz` / `topic bw` watch has nothing new to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StallCause {
+    /// The counter is readable and simply is not advancing: the publisher is
+    /// alive but silent, or it was SIGKILLed — which leaves the /dev/shm region
+    /// mapped, so every read keeps succeeding and returns the same number.
+    NoMessages,
+    /// The region stopped being readable at all: unlinked, truncated, or no
+    /// longer a HORUS topic. Only `hz` can tell this apart, because
+    /// `read_latest_slot_bytes` reports "gone" and "nothing new" as the same
+    /// `None`.
+    CounterUnreadable,
+}
+
+/// Wall-clock watchdog for the live `topic hz` and `topic bw` readouts.
+///
+/// Both loops printed only when the counter moved, so a publisher that died
+/// mid-measurement left its last figure standing with the cursor parked on it:
+/// SIGKILLing a 20 Hz publisher left `Rate: 20.19 Hz (window: 10)` — no
+/// trailing newline — unchanged on the terminal for the next 20 s, which is
+/// indistinguishable from a live readout, and the non-TTY run went completely
+/// silent for 24 s. `examples/camera_perception/README.md` tells operators to
+/// run `horus topic hz camera.image` to verify a camera's rate, so the silence
+/// hides exactly what the command exists to detect.
+struct StallWatch {
+    last_message: Instant,
+    last_report: Option<Instant>,
+}
+
+impl StallWatch {
+    /// Silence shorter than this is not a stall. HORUS topics legitimately run
+    /// down to a few Hz, and `topic list` already needs a 500 ms window to read
+    /// a rate at all, so a gap has to span several of those before it means
+    /// anything.
+    const TIMEOUT: Duration = Duration::from_secs(2);
+
+    /// Repeat the stall line on the same once-a-second cadence the rate lines
+    /// use, not on every 10 ms poll of the loop.
+    const REPEAT: Duration = Duration::from_secs(1);
+
+    fn new(now: Instant) -> Self {
+        Self {
+            last_message: now,
+            last_report: None,
+        }
+    }
+
+    /// The stream delivered something; it is live again.
+    fn saw_message(&mut self, now: Instant) {
+        self.last_message = now;
+        self.last_report = None;
+    }
+
+    /// How long the stream has been silent, on the polls where that is worth
+    /// printing.
+    fn poll(&mut self, now: Instant) -> Option<Duration> {
+        let silent = now.duration_since(self.last_message);
+        if silent < Self::TIMEOUT {
+            return None;
+        }
+        if let Some(reported) = self.last_report {
+            if now.duration_since(reported) < Self::REPEAT {
+                return None;
+            }
+        }
+        self.last_report = Some(now);
+        Some(silent)
+    }
+}
+
+/// The reading a stalled watch prints in place of a rate.
+///
+/// `zero_reading` is what the stream is actually delivering right now
+/// ("0.00 Hz", "0.00 B/s") — stating it beats leaving the previous number up,
+/// which is the whole defect.
+fn stall_line(silent: Duration, zero_reading: &str, cause: StallCause) -> String {
+    match cause {
+        StallCause::NoMessages => format!(
+            "{} (no new messages for {:.1}s)",
+            zero_reading,
+            silent.as_secs_f64()
+        ),
+        StallCause::CounterUnreadable => format!(
+            "{} (topic counter unreadable for {:.1}s)",
+            zero_reading,
+            silent.as_secs_f64()
+        ),
+    }
+}
+
 /// Measure topic publish rate
 pub fn topic_hz(name: &str, window: Option<usize>) -> HorusResult<()> {
     use horus_core::communication::read_topic_messages_total;
@@ -946,9 +1036,13 @@ pub fn topic_hz(name: &str, window: Option<usize>) -> HorusResult<()> {
     let mut last_line_print = Instant::now();
     let is_tty = std::io::stdout().is_terminal();
 
+    let mut stall = StallWatch::new(start_time);
+
     while running.load(std::sync::atomic::Ordering::SeqCst) {
-        let current_total = read_topic_messages_total(&topic_path).unwrap_or(last_total);
+        let reading = read_topic_messages_total(&topic_path);
+        let current_total = reading.unwrap_or(last_total);
         if current_total > last_total {
+            stall.saw_message(Instant::now());
             let new_msgs = current_total - last_total;
             total_messages += new_msgs;
             last_total = current_total;
@@ -995,6 +1089,22 @@ pub fn topic_hz(name: &str, window: Option<usize>) -> HorusResult<()> {
                     }
                 }
             }
+        } else if let Some(silent) = stall.poll(Instant::now()) {
+            let cause = if reading.is_some() {
+                StallCause::NoMessages
+            } else {
+                StallCause::CounterUnreadable
+            };
+            let line = stall_line(silent, "0.00 Hz", cause);
+            if is_tty {
+                // The leading \r and the trailing padding overwrite the
+                // in-place rate line this replaces; it is longer than that
+                // line, so none of the stale figure survives.
+                println!("\r  {} {}    ", cli_output::ICON_WARN.yellow(), line);
+            } else {
+                println!("  {} {}", cli_output::ICON_WARN, line);
+            }
+            last_line_print = Instant::now();
         }
 
         std::thread::sleep(10_u64.ms());
@@ -1081,6 +1191,7 @@ pub fn topic_bw(name: &str, window: Option<usize>) -> HorusResult<()> {
     let mut last_write_idx: u64 = 0;
     let mut last_line_print = Instant::now();
     let is_tty = std::io::stdout().is_terminal();
+    let mut stall = StallWatch::new(Instant::now());
 
     loop {
         if !running.load(std::sync::atomic::Ordering::SeqCst) {
@@ -1088,6 +1199,7 @@ pub fn topic_bw(name: &str, window: Option<usize>) -> HorusResult<()> {
         }
 
         if let Some(slot) = read_latest_slot_bytes(&topic_path, last_write_idx) {
+            stall.saw_message(Instant::now());
             last_write_idx = slot.write_idx;
             samples.push_back((Instant::now(), slot.payload.len()));
 
@@ -1154,6 +1266,17 @@ pub fn topic_bw(name: &str, window: Option<usize>) -> HorusResult<()> {
                     }
                 }
             }
+        } else if let Some(silent) = stall.poll(Instant::now()) {
+            // `read_latest_slot_bytes` returns `None` both for "no new message"
+            // and for "the region is gone", so bandwidth cannot name the cause
+            // the way `hz` can.
+            let line = stall_line(silent, "0.00 B/s", StallCause::NoMessages);
+            if is_tty {
+                println!("\r  {} {}    ", cli_output::ICON_WARN.yellow(), line);
+            } else {
+                println!("  {} {}", cli_output::ICON_WARN, line);
+            }
+            last_line_print = Instant::now();
         }
 
         std::thread::sleep(10_u64.ms());
@@ -1683,5 +1806,129 @@ mod pub_echo_roundtrip_tests {
         let mut data = 2u64.to_le_bytes().to_vec();
         data.extend_from_slice(&[0xff, 0xfe]);
         assert!(bincode_string(&data).is_none());
+    }
+}
+
+#[cfg(test)]
+mod stall_watch_tests {
+    use super::*;
+
+    /// The defect: `topic hz` and `topic bw` printed only when the counter
+    /// moved, so a publisher killed mid-measurement left its last figure
+    /// standing. A 20 Hz publisher SIGKILLed under `topic hz` on a tty left the
+    /// literal bytes `\r  Rate: 20.19 Hz (window: 10)` — no trailing newline,
+    /// cursor parked — on screen for the next 20 s while the topic was dead.
+    #[test]
+    fn a_dead_publisher_is_reported_instead_of_leaving_the_last_rate_frozen() {
+        let t0 = Instant::now();
+        let mut watch = StallWatch::new(t0);
+
+        // 20 Hz of traffic. Every poll that carries a message keeps it quiet.
+        for ms in (0..2_000).step_by(50) {
+            watch.saw_message(t0 + Duration::from_millis(ms));
+            assert_eq!(
+                watch.poll(t0 + Duration::from_millis(ms + 10)),
+                None,
+                "a live stream must not be called stalled (at {ms} ms)"
+            );
+        }
+
+        // The publisher dies after the message at t0+1.95s. A gap of one or two
+        // messages is not yet a stall.
+        let killed = Duration::from_millis(1_950);
+        assert_eq!(watch.poll(t0 + killed + Duration::from_millis(500)), None);
+
+        // Past the timeout the watch demands a line rather than letting the
+        // stale rate stand.
+        let silent = watch
+            .poll(t0 + killed + Duration::from_millis(2_100))
+            .expect("2.1s without a message is a stall and must be reported");
+        assert!(
+            (silent.as_secs_f64() - 2.1).abs() < 0.01,
+            "the line must state how long the stream has been silent, got {silent:?}"
+        );
+    }
+
+    #[test]
+    fn the_stall_line_repeats_once_a_second_not_on_every_poll() {
+        let t0 = Instant::now();
+        let mut watch = StallWatch::new(t0);
+        assert!(watch.poll(t0 + Duration::from_millis(2_000)).is_some());
+
+        // The sampling loop polls every 10 ms; that must not become 100 lines
+        // of scrollback a second.
+        for ms in (2_010..3_000).step_by(10) {
+            assert_eq!(
+                watch.poll(t0 + Duration::from_millis(ms)),
+                None,
+                "a second stall line inside the same second (at {ms} ms)"
+            );
+        }
+        assert!(watch.poll(t0 + Duration::from_millis(3_010)).is_some());
+    }
+
+    #[test]
+    fn a_slow_but_live_publisher_is_never_called_stalled() {
+        // 1 Hz is an ordinary HORUS topic, not a broken one, and the watch runs
+        // between its messages 100 times each second.
+        let t0 = Instant::now();
+        let mut watch = StallWatch::new(t0);
+        for sec in 0..30 {
+            let sent = t0 + Duration::from_secs(sec);
+            watch.saw_message(sent);
+            for ms in (0..1_000).step_by(10) {
+                assert_eq!(
+                    watch.poll(sent + Duration::from_millis(ms)),
+                    None,
+                    "1 Hz reported as stalled at {sec}s + {ms} ms"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_publisher_that_comes_back_stops_being_reported() {
+        let t0 = Instant::now();
+        let mut watch = StallWatch::new(t0);
+        assert!(watch.poll(t0 + Duration::from_millis(2_500)).is_some());
+
+        watch.saw_message(t0 + Duration::from_millis(3_000));
+        for ms in (3_010..4_900).step_by(10) {
+            assert_eq!(
+                watch.poll(t0 + Duration::from_millis(ms)),
+                None,
+                "still reporting a stall after the stream recovered (at {ms} ms)"
+            );
+        }
+    }
+
+    #[test]
+    fn the_stall_line_states_the_zero_reading_and_the_cause() {
+        assert_eq!(
+            stall_line(
+                Duration::from_millis(3_400),
+                "0.00 Hz",
+                StallCause::NoMessages
+            ),
+            "0.00 Hz (no new messages for 3.4s)"
+        );
+        assert_eq!(
+            stall_line(
+                Duration::from_millis(12_000),
+                "0.00 B/s",
+                StallCause::NoMessages
+            ),
+            "0.00 B/s (no new messages for 12.0s)"
+        );
+        // A region that stopped being mappable is a different diagnosis — the
+        // topic is gone, not idle — and only `hz` can tell the two apart.
+        assert_eq!(
+            stall_line(
+                Duration::from_secs(5),
+                "0.00 Hz",
+                StallCause::CounterUnreadable
+            ),
+            "0.00 Hz (topic counter unreadable for 5.0s)"
+        );
     }
 }

--- a/horus_manager/src/commands/topic.rs
+++ b/horus_manager/src/commands/topic.rs
@@ -970,6 +970,38 @@ fn stall_line(silent: Duration, zero_reading: &str, cause: StallCause) -> String
     }
 }
 
+/// A stall line placed on top of the frozen in-place figure, for a tty.
+///
+/// `\r` returns to the start of the row the live readout was updating in
+/// place, and `\x1b[K` erases the rest of that row before the newline commits
+/// it. Trailing spaces cannot do that job: the line being overwritten has no
+/// bounded width — `--window` is an unbounded `usize` and the rate/bandwidth
+/// figure grows with the traffic — and `topic bw`'s in-place row is wider than
+/// any stall line to begin with:
+///
+/// ```text
+///   Bandwidth: 3.75 KB/s (97.8 msgs/s, avg 38 B/msg, window: 100)     67 columns
+///   ! 0.00 B/s (no new messages for 2.0s)                             43 columns
+/// ```
+///
+/// Padded to 43 columns, that stall line left the last 24 columns of the dead
+/// publisher's figures standing on the same row, and the newline then committed
+/// the hybrid to the scrollback:
+///
+/// ```text
+///   ! 0.00 B/s (no new messages for 2.0s)     B/msg, window: 100)
+/// ```
+///
+/// (Captured off a real pty: publisher at 100 Hz under `topic bw`, SIGKILLed.)
+/// A dead publisher's figures still on screen beside the stall report is the
+/// defect this whole change exists to remove.
+fn tty_stall_row(icon: impl std::fmt::Display, line: &str) -> String {
+    // `impl Display`, not `&str`: `ColoredString` derefs to the *uncoloured*
+    // inner text, so taking `&str` here would silently strip the yellow off
+    // the warning icon.
+    format!("\r  {icon} {line}\x1b[K")
+}
+
 /// Measure topic publish rate
 pub fn topic_hz(name: &str, window: Option<usize>) -> HorusResult<()> {
     use horus_core::communication::read_topic_messages_total;
@@ -1097,10 +1129,7 @@ pub fn topic_hz(name: &str, window: Option<usize>) -> HorusResult<()> {
             };
             let line = stall_line(silent, "0.00 Hz", cause);
             if is_tty {
-                // The leading \r and the trailing padding overwrite the
-                // in-place rate line this replaces; it is longer than that
-                // line, so none of the stale figure survives.
-                println!("\r  {} {}    ", cli_output::ICON_WARN.yellow(), line);
+                println!("{}", tty_stall_row(cli_output::ICON_WARN.yellow(), &line));
             } else {
                 println!("  {} {}", cli_output::ICON_WARN, line);
             }
@@ -1272,7 +1301,7 @@ pub fn topic_bw(name: &str, window: Option<usize>) -> HorusResult<()> {
             // the way `hz` can.
             let line = stall_line(silent, "0.00 B/s", StallCause::NoMessages);
             if is_tty {
-                println!("\r  {} {}    ", cli_output::ICON_WARN.yellow(), line);
+                println!("{}", tty_stall_row(cli_output::ICON_WARN.yellow(), &line));
             } else {
                 println!("  {} {}", cli_output::ICON_WARN, line);
             }
@@ -1929,6 +1958,88 @@ mod stall_watch_tests {
                 StallCause::CounterUnreadable
             ),
             "0.00 Hz (topic counter unreadable for 5.0s)"
+        );
+    }
+
+    /// The terminal behaviour `tty_stall_row` depends on: `\r` homes the
+    /// cursor, printable text overwrites column by column, `\x1b[K` clears from
+    /// the cursor to the end of the line, and a colour sequence occupies no
+    /// column at all.
+    ///
+    /// `existing` is what the row already shows — the terminal's cells, so
+    /// visible characters only — and the return value is the same.
+    fn render_over(existing: &str, row: &str) -> String {
+        let mut screen: Vec<char> = existing.chars().collect();
+        let mut col = 0usize;
+        let mut chars = row.chars();
+        while let Some(c) = chars.next() {
+            match c {
+                '\r' => col = 0,
+                '\u{1b}' => {
+                    let mut seq = String::new();
+                    for c in chars.by_ref() {
+                        seq.push(c);
+                        if c.is_ascii_alphabetic() {
+                            break;
+                        }
+                    }
+                    if seq == "[K" {
+                        screen.truncate(col);
+                    }
+                }
+                _ => {
+                    if col == screen.len() {
+                        screen.push(c);
+                    } else {
+                        screen[col] = c;
+                    }
+                    col += 1;
+                }
+            }
+        }
+        screen.into_iter().collect()
+    }
+
+    /// A stall line has to erase the row it lands on, not try to out-pad it.
+    ///
+    /// `topic bw` updates a 66-column row in place and the stall line is 43, so
+    /// `\r` plus four trailing spaces left `B/msg, window: 98)` from the dead
+    /// publisher standing beside "no new messages" — and the newline then
+    /// committed that hybrid to the scrollback. Leaving a dead publisher's
+    /// figures on screen is the defect this whole change exists to remove.
+    #[test]
+    fn the_tty_stall_row_erases_the_wider_line_it_lands_on() {
+        let frozen_bw = "  Bandwidth: 780.29 B/s (96.5 msgs/s, avg 8 B/msg, window: 98)    ";
+        let row = tty_stall_row("!", "0.00 B/s (no new messages for 2.0s)");
+        assert_eq!(row, "\r  ! 0.00 B/s (no new messages for 2.0s)\u{1b}[K");
+        assert_eq!(
+            render_over(frozen_bw, &row),
+            "  ! 0.00 B/s (no new messages for 2.0s)",
+            "the dead publisher's bandwidth figures survived the stall line"
+        );
+
+        // The icon reaches this function already coloured, and a colour
+        // sequence costs no column — so it must not be counted as width that
+        // covers the stale line. Same visible result as the uncoloured row.
+        let frozen_hz = "  Rate: 95.18 Hz (window: 10)    ";
+        let coloured = tty_stall_row("\u{1b}[33m!\u{1b}[0m", "0.00 Hz (no new messages for 2.0s)");
+        assert_eq!(
+            render_over(frozen_hz, &coloured),
+            "  ! 0.00 Hz (no new messages for 2.0s)",
+            "the frozen rate survived the stall line"
+        );
+    }
+
+    /// `--window` is an unbounded `usize` and the rate grows with the traffic,
+    /// so no fixed amount of padding is wide enough for every in-place line.
+    #[test]
+    fn the_tty_stall_row_covers_an_arbitrarily_wide_frozen_line() {
+        let frozen = format!("  Rate: 1234567.89 Hz (window: {})    ", usize::MAX);
+        let row = tty_stall_row("!", "0.00 Hz (no new messages for 2.0s)");
+        assert_eq!(
+            render_over(&frozen, &row),
+            "  ! 0.00 Hz (no new messages for 2.0s)",
+            "a wide --window left the stale rate on screen"
         );
     }
 }

--- a/horus_manager/tests/introspection_live_contract.rs
+++ b/horus_manager/tests/introspection_live_contract.rs
@@ -567,11 +567,20 @@ fn topic_hz_reports_a_publisher_that_dies_mid_measurement() {
     let _ = hz.wait();
     let _ = reader.join();
 
+    // Not a skip. If this fires, the stall line below would be satisfied by a
+    // `topic hz` that never measured anything — the watch reports silence from
+    // the moment it starts, so a publisher that never published produces the
+    // same output as one that died. This assertion is the only thing standing
+    // between that and a green run, so it has to fail rather than return: a
+    // regression that stops `topic hz` printing rates at all must not be able
+    // to turn this test green.
     assert!(
         measured,
-        "SKIP-WORTHY: `topic hz` never printed a rate at all, so the publisher \
-         was never measured on this machine and the stall behaviour could not \
-         be evaluated:\n{out}"
+        "`topic hz` printed no rate in 30s for a publisher `topic list` had \
+         already shown, so the live half of this test never happened. Either \
+         rate measurement itself regressed, or this box is loaded past the \
+         point where the 30s budget means anything — check the load average \
+         and /dev/shm before reading it as either:\n{out}"
     );
     assert!(
         reported,

--- a/horus_manager/tests/introspection_live_contract.rs
+++ b/horus_manager/tests/introspection_live_contract.rs
@@ -496,3 +496,87 @@ fn topic_echo_streams_every_message_in_order() {
         values.len()
     );
 }
+
+/// A watch that stops updating must say so.
+///
+/// `topic hz` printed only on the polls where the message counter had moved, so
+/// SIGKILLing the publisher under it left the last rate standing: the region
+/// stays mapped after a SIGKILL, so every subsequent read still succeeds and
+/// returns the same frozen number, and the loop then spun silently forever. On
+/// a tty that leaves `Rate: 20.19 Hz (window: 10)` on screen with no trailing
+/// newline — indistinguishable from a live readout — and off a tty it is total
+/// silence. `examples/camera_perception/README.md` tells operators to run
+/// `horus topic hz camera.image` to verify a camera is producing frames, which
+/// is exactly the question that silence answered wrongly.
+#[test]
+fn topic_hz_reports_a_publisher_that_dies_mid_measurement() {
+    let _serial = serialize();
+    let mut node = LiveNode::spawn("live_hz_stall", true);
+    node.wait_for(&["topic", "list"], |o| o.contains(&node.topic))
+        .unwrap_or_else(|| panic!("topic never appeared:\n{}", node.cli(&["topic", "list"])));
+
+    let mut hz = Command::new(horus())
+        .args(["topic", "hz", &node.topic, "--window", "10"])
+        .env("HORUS_NAMESPACE", &node.namespace)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("horus must run");
+
+    // Drain into a buffer the test can read while the child still runs. Both
+    // phases below are driven off what `hz` has actually printed rather than
+    // off fixed sleeps: on a box running the rest of this suite the publisher
+    // can take seconds to reach its first send, and a sleep long enough to
+    // cover that is a sleep that makes the test slow for everyone else.
+    let seen = std::sync::Arc::new(Mutex::new(String::new()));
+    let sink = seen.clone();
+    let mut pipe = hz.stdout.take().expect("stdout was piped");
+    let reader = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut chunk = [0u8; 512];
+        while let Ok(n) = pipe.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            sink.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push_str(&String::from_utf8_lossy(&chunk[..n]));
+        }
+    });
+    let text = || seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let wait_until = |needle: &str, budget: Duration| {
+        let deadline = Instant::now() + budget;
+        while Instant::now() < deadline {
+            if text().contains(needle) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        false
+    };
+
+    // The non-tty path prints one rate line a second, so this is the watch
+    // measuring a live publisher.
+    let measured = wait_until("average rate:", Duration::from_secs(30));
+    let _ = node.child.kill();
+    let _ = node.child.wait();
+    // The 2 s stall timeout plus the 1 s line cadence, and slack.
+    let reported = wait_until("no new messages for", Duration::from_secs(15));
+    let out = text();
+    let _ = hz.kill();
+    let _ = hz.wait();
+    let _ = reader.join();
+
+    assert!(
+        measured,
+        "SKIP-WORTHY: `topic hz` never printed a rate at all, so the publisher \
+         was never measured on this machine and the stall behaviour could not \
+         be evaluated:\n{out}"
+    );
+    assert!(
+        reported,
+        "the publisher was killed fifteen seconds ago and `topic hz` never said \
+         so — the last rate it printed is still the last thing an operator \
+         sees:\n{out}"
+    );
+}


### PR DESCRIPTION
`horus topic hz` and `horus topic bw` gated every print on "the counter
moved", so a publisher that died mid-measurement left its last figure
standing and the loop spun silently forever. On a tty that leaves
`Rate: 20.19 Hz (window: 10)` on screen with no trailing newline and the
cursor parked on it, which is indistinguishable from a live readout; off
a tty it is total silence. A SIGKILLed publisher leaves its /dev/shm
region mapped, so `read_topic_messages_total` keeps succeeding and keeps
returning the same number — nothing ever reports the stall.
`examples/camera_perception/README.md` tells operators to run
`horus topic hz camera.image` to verify a camera's rate, so the silence
hid exactly what the command exists to detect.

Both loops now poll a `StallWatch` on the iterations where no message
arrived. After two seconds of silence they print `0.00 Hz (no new
messages for N.Ns)` / `0.00 B/s (...)` once a second, on a `\r` line that
overwrites the stale in-place figure. `hz` can additionally distinguish a
region that stopped being mappable — `read_topic_messages_total` returns
`None` only on a map/magic failure — and says `topic counter unreadable
for N.Ns`; `read_latest_slot_bytes` reports "gone" and "nothing new" as
the same `None`, so `bw` cannot make that distinction.

The two-second threshold keeps ordinary slow topics off the stall path: a
1 Hz publisher is a normal HORUS topic, and `topic list` already needs a
500 ms window to read a rate at all.

Tests: five unit tests drive the watch over synthetic instants (live
stream, dead publisher, 1 Hz publisher, recovery, wording), and a live
test in introspection_live_contract spawns a real publisher, SIGKILLs it
under a running `topic hz`, and requires the stall line to appear.

## Ablation

```
ABLATION A — reverted only the production behaviour (both loops back to their pre-fix
shape: `saw_message`/`stall.poll` wiring removed from topic_hz and topic_bw). The
StallWatch type and all tests were left in place so everything still compiles.

  $ cargo test -p horus_manager --test introspection_live_contract -- --test-threads=1 topic_hz_reports

  running 1 test
  test topic_hz_reports_a_publisher_that_dies_mid_measurement ... FAILED

  failures:

  ---- topic_hz_reports_a_publisher_that_dies_mid_measurement stdout ----

  thread 'topic_hz_reports_a_publisher_that_dies_mid_measurement' (1853544) panicked at horus_manager/tests/introspection_live_contract.rs:576:5:
  the publisher was killed fifteen seconds ago and `topic hz` never said so — the last rate it printed is still the last thing an operator sees:
  > Measuring rate for: live_hz_stall_topic
     Press Ctrl+C to stop

    average rate: 98.56 Hz (window: 2)

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  failures:
      topic_hz_reports_a_publisher_that_dies_mid_measurement

  test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 9 filtered out; finished in 17.16s

  error: test failed, to rerun pass `-p horus_manager --test introspection_live_contract`

That output IS the defect: one rate line, then fifteen seconds of nothing while the
publisher is dead. With the fix restored the same test passes in 4.29s.

Honest caveat: under ablation A the five unit tests still passed (5 passed; 0 failed)
— they cover the watch, not the wiring, and it is the live test that bites on the
wiring. So I also ran:

ABLATION B — the watch itself reverted to pre-fix semantics (`poll` never asks for a
line: `if silent < Self::TIMEOUT` replaced by `if true`), which is exactly what the
old loops did on a non-moving counter:

  $ cargo test -p horus_manager --lib -- commands::topic::stall_watch

  ---- commands::topic::stall_watch_tests::a_dead_publisher_is_reported_instead_of_leaving_the_last_rate_frozen stdout ----
  thread '...' (1633871) panicked at horus_manager/src/commands/topic.rs:1811:14:
  2.1s without a message is a stall and must be reported

  ---- commands::topic::stall_watch_tests::a_publisher_that_comes_back_stops_being_reported stdout ----
  thread '...' (1633872) panicked at horus_manager/src/commands/topic.rs:1859:9:
  assertion failed: watch.poll(t0 + Duration::from_millis(2_500)).is_some()

  ---- commands::topic::stall_watch_tests::the_stall_line_repeats_once_a_second_not_on_every_poll stdout ----
  thread '...' (1633874) panicked at horus_manager/sr
```

## Tests

```
All on the fixed tree, in /home/neos/softmata/horus/.claude/worktrees/wf_b365913e-0a9-9.

- cargo test -p horus_manager --lib
  → 3477 passed; 0 failed; 7 ignored; 0 filtered out; 241.95s
  (includes the 5 new stall_watch_tests and the 43 commands::topic tests)
- cargo test -p horus_manager --lib -- commands::topic
  → 43 passed; 0 failed; 30.55s  (final re-run after restoring the fix)
- cargo test -p horus_manager --test introspection_live_contract -- --test-threads=1
  → 10 passed; 0 failed; 18.13s  (final run; also green on three earlier consecutive
    full-file runs at 20.22s / 19.17s / 18.58s)
- cargo fmt --all --check → clean
- cargo clippy -p horus_manager --all-targets → "Finished dev profile", zero warnings

Manual end-to-end checks with the freshly built debug binary (the `bw` wiring has no
automated test):
- `topic bw` on a SIGKILLed publisher, non-tty:
    780.29 B/s (96.5 msgs/s, avg 8 B/msg, window: 98)
    759.08 B/s (93.9 msgs/s, avg 8 B/msg, window: 100)
    ! 0.00 B/s (no new messages for 2.0s)
    ! 0.00 B/s (no new messages for 3.0s)  ... through 5.0s
  with /dev/shm/horus_<ns> still present, i.e. the finding's exact scenario.
- `topic hz` on a real pty (under `script`), publisher SIGKILLed and then the region
  unlinked; raw pty bytes via cat -A:
    ...^M  ESC[36mRate:ESC[0m 95.18 Hz (window: 10)    ^M  ESC[33m!ESC[0m 0.00 Hz (no new messages for 2.0s)    ^M$
    ^M  ESC[33m!ESC[0m 0.00 Hz (no new messages for 3.0s)    ^M$
    ^M  ESC[33m!ESC[0m 0.00 Hz
```

## Notes from the implementer

CONFIRMED the finding independently before fixing. topic.rs:949-1001 (pre-fix) had
every statement except `sleep(10ms)` inside `if current_total > last_total`, and
topic_bw the same inside `if let Some(slot) = read_latest_slot_bytes(..)`.
`read_topic_messages_total` (header.rs:1765) fails only through `map_topic_region`,
so a SIGKILLed publisher's region keeps reading fine and returns a constant — the
loop then spins silently. Reproduced both commands myself on this box.

Scope decisions:
- The fix is reporting only. I did not change what either command measures, its
  exit behaviour, or any CLI flag, so nothing scriptable changed except that two
  new line shapes can now appear on stdout. The only test anywhere that asserts on
  `topic hz` output is horus_core/tests/cli_runtime_integration.rs:189-212 (#[ignore]d),
  which checks for "Hz" — the stall line contains "0.00 Hz", so it still matches.
- I did NOT add the missing end-of-run summary to `topic_bw` (its post-loop code is
  still a bare `println!()` while `topic_hz` prints an average). The finding mentions
  it; it is a separate gap and deserves its own change.
- Threshold choice (2 s silence, 1 s repeat) is a judgement call, not a measurement.
  I reasoned it from `topic list`'s existing 500 ms rate window and from 1 Hz being an
  ordinary HORUS topic rate; a reviewer may want it derived from `--window` instead.

Could not verify / residual risk:
- The `bw` stall wiring has no automated test — only the manual repro pasted above.
  A live test for it would double this file's process churn for a path that shares
  all its logic with the tested `hz` one.
- While hardening my live test I saw one run where `topic hz` printed no rate at all
  for 9 s against a supposedly live publisher (full-file run, loaded box). I could not
  pin the mechanism: my experiment showed `discover_shared_memory_uncached`
  (discovery/topics.rs:14-21) deletes a dead publisher's region and filters it out, so
  my first theory — the watch

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and tested in a clean worktree before this PR.
