### PR TITLE
ci: run the three cross-thread topic tests every job was skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,11 +200,28 @@ jobs:
           # Cross-process and long-running scenario binaries are covered by the
           # dedicated integration workflows. Keep this gate to deterministic
           # crate unit tests so one shared namespace cannot leak between bins.
+          #
+          # The three topic_cross_thread_* tests were skipped here too, and in
+          # coverage.yml, safety.yml, multi-platform.yml and
+          # integration-tests.yml -- every invocation in this repo that builds
+          # horus_core's lib target -- so no job on any platform ran them. The
+          # justification that travelled with the skip list was a throughput
+          # floor ("expected at least 50 messages, got 44") that measures the
+          # machine rather than the code; it expired when the floors were
+          # deleted from all three tests. What they assert now holds however the
+          # threads are scheduled: every value received was sent and decodes to
+          # a producer and an index that exist, and at least one message
+          # arrives. This job runs them; the others keep their own skips.
+          #
+          # MEASURED before un-skipping them, on the binary this job builds and
+          # with --test-threads=1: 20/20 green pinned to two cores, which is a
+          # GitHub runner's core count -- 10 runs on an otherwise quiet box and
+          # 10 with those two cores 3x oversubscribed by spinners. 10.1 s best,
+          # 40.2 s worst, against this job's 30-minute budget.
+          #
+          # ci_coverage_contract asserts they keep a runner.
           cargo test --workspace --exclude horus_py --lib --no-fail-fast -- \
             --test-threads=1 \
-            --skip topic_cross_thread_1p_multi_c_spmc \
-            --skip topic_cross_thread_mpmc_pre_initialized_99_percent \
-            --skip topic_cross_thread_multi_p_multi_c_mpmc \
             --skip test_robotics_autonomous_car_perception
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -152,11 +152,18 @@ jobs:
       - name: Test (horus_sys + horus_core)
         run: |
           cargo test --no-default-features -p horus_sys --lib -- --test-threads=1
-          # Apply the same exclusion set ci.yml/coverage.yml/safety.yml use. This
-          # job was the only one running these cross-thread topic tests, and it
-          # does so on the slowest runner: topic_cross_thread_* assert throughput
-          # thresholds ("expected at least 50 messages, got 44") that are a
-          # property of the runner, not of the code.
+          # topic_cross_thread_*: the throughput floor this used to cite
+          # ("expected at least 50 messages, got 44") no longer exists. All
+          # three tests deleted theirs -- the comments at their asserts in
+          # communication/topic/tests.rs record it -- and ci.yml runs them again
+          # on Linux rather than every job repeating a reason that expired.
+          #
+          # They stay skipped HERE because they have never run on Windows since
+          # the floors went, and this job already carries two open, undiagnosed
+          # Windows defects in the same fan-out subsystem (both below). Three
+          # more lossy fan-out tests going red would most likely re-report those
+          # rather than say anything new. Worth a branch: un-skip them together
+          # with mp_send_no_overshoot_corruption.
           #
           # multithread_nonpod_subscribers_each_get_full_stream is skipped for a
           # DIFFERENT and more serious reason: its subscribers never observe the

--- a/horus_manager/tests/ci_coverage_contract.rs
+++ b/horus_manager/tests/ci_coverage_contract.rs
@@ -61,6 +61,27 @@ const CARGO_FLAGS_TAKING_A_VALUE: [&str; 15] = [
     "-j",
 ];
 
+/// The same thing for libtest, applied only after `--`. Disjoint from the list
+/// above on purpose: `--test` is a cargo flag naming a target and takes a
+/// value, while libtest has no `--test` at all, and `--test-threads` is the
+/// reverse. `--skip` is deliberately absent — it is matched earlier so its
+/// value is captured rather than discarded.
+///
+/// Every `--test-threads` in these workflows is written `--test-threads=1`
+/// today, which needs no entry here because the value rides along in the token.
+/// The space-separated spelling is equally valid and is what this guards: left
+/// unhandled, `-- --test-threads 1` files `1` as a positional filter, and a
+/// filter of `1` selects `topic_cross_thread_1p_multi_c_spmc` while excluding
+/// `topic_cross_thread_mpmc_pre_initialized_99_percent`, which contains no `1`.
+const LIBTEST_FLAGS_TAKING_A_VALUE: [&str; 6] = [
+    "--test-threads",
+    "--logfile",
+    "--format",
+    "--color",
+    "--shuffle-seed",
+    "-Z",
+];
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -159,7 +180,17 @@ fn harness_args(cmd: &str) -> HarnessArgs {
             break;
         }
         args.next();
-        if head == "test" || head == "llvm-cov" {
+        if head == "test" {
+            break;
+        }
+        if head == "llvm-cov" {
+            // `cargo llvm-cov` with no subcommand implies `test`, so the
+            // subcommand is optional and can only be consumed conditionally.
+            // Left in place it parses as a positional filter: `cargo llvm-cov
+            // test --lib` would run only tests whose path contains `test`.
+            if matches!(args.peek(), Some(&"test") | Some(&"nextest")) {
+                args.next();
+            }
             break;
         }
     }
@@ -172,7 +203,12 @@ fn harness_args(cmd: &str) -> HarnessArgs {
         } else if arg == "--skip" {
             skips.extend(args.next().map(str::to_string));
         } else if arg.starts_with('-') {
-            if !after_dashdash && CARGO_FLAGS_TAKING_A_VALUE.contains(&arg) {
+            let takes_a_separate_value = if after_dashdash {
+                LIBTEST_FLAGS_TAKING_A_VALUE.contains(&arg)
+            } else {
+                CARGO_FLAGS_TAKING_A_VALUE.contains(&arg)
+            };
+            if takes_a_separate_value {
                 args.next();
             }
         } else {
@@ -261,4 +297,132 @@ fn the_pr_gate_is_one_of_those_runners() {
              takes them back to zero runners.\n  {cmd}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Unit coverage for the two matchers above.
+//
+// Both assertions in this file reduce to "some parsed command runs this test
+// path", so every way the parsers can misread a command surfaces there as a
+// bare pass or fail with no indication of which. One direction of that is
+// silent: a `harness_args` that stopped recognising `--skip` yields an empty
+// `skips`, `runs()` then answers true for everything, and the contract passes
+// while nothing executes. The `cmds.len() >= 6` guard does not catch it — that
+// checks only that commands were *found*, not that they were read correctly.
+//
+// So pin the readings directly, including the spellings CI does not use today
+// but is free to adopt tomorrow.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shell_commands_joins_continuations_and_drops_prose() {
+    const BLOCK: &str = r#"
+      - name: Run Tests
+        run: |
+          # cargo test --workspace --lib, named here only in prose
+          cargo test --workspace --exclude horus_py --lib --no-fail-fast -- \
+            --test-threads=1 \
+            --skip test_robotics_autonomous_car_perception
+      - name: The one-line form
+        run: cargo test -p horus_core --lib -- --skip something
+"#;
+
+    let cmds = shell_commands(BLOCK);
+
+    // Every `--skip` in these workflows sits on a continuation line. Read as
+    // physical lines, the `cargo test` and its exclusions are unrelated
+    // strings and the contract cannot see either.
+    assert!(
+        cmds.iter().any(|c| c.as_str()
+            == "cargo test --workspace --exclude horus_py --lib --no-fail-fast \
+                -- --test-threads=1 --skip test_robotics_autonomous_car_perception"),
+        "continuation lines were not joined into one command: {cmds:#?}"
+    );
+
+    assert!(
+        cmds.iter()
+            .any(|c| c.as_str() == "cargo test -p horus_core --lib -- --skip something"),
+        "the one-line `run:` form was not unwrapped: {cmds:#?}"
+    );
+
+    // docs-contract.yml discusses `cargo test --workspace --lib` in a comment.
+    // Counting that as a job makes this file pass while nothing runs.
+    assert!(
+        !cmds.iter().any(|c| c.contains("named here only in prose")),
+        "a `#` comment was collected as a command: {cmds:#?}"
+    );
+}
+
+#[test]
+fn harness_args_reads_the_spellings_ci_can_use() {
+    let spmc = MUST_RUN_SOMEWHERE[0];
+    let mpmc = MUST_RUN_SOMEWHERE[1];
+    let pre_init = MUST_RUN_SOMEWHERE[2];
+
+    // ci.yml's gate, as it stands after this change.
+    let gate = harness_args(
+        "cargo test --workspace --exclude horus_py --lib --no-fail-fast -- \
+         --test-threads=1 --skip test_robotics_autonomous_car_perception",
+    );
+    assert!(
+        gate.filters.is_empty(),
+        "`horus_py` (the value of --exclude) leaked in as a filter: {:?}",
+        gate.filters
+    );
+    assert_eq!(gate.skips, ["test_robotics_autonomous_car_perception"]);
+    assert!(gate.runs(spmc) && gate.runs(mpmc) && gate.runs(pre_init));
+
+    // `--skip` in both spellings, and a pattern that matches by substring.
+    let skipped = harness_args(
+        "cargo test --no-default-features -p horus_core --lib -- \
+         --skip topic_cross_thread_1p_multi_c_spmc --skip=topic_cross_thread_multi_p_multi_c_mpmc",
+    );
+    assert!(
+        !skipped.runs(spmc),
+        "the space-separated --skip was dropped"
+    );
+    assert!(!skipped.runs(mpmc), "the --skip= form was dropped");
+    assert!(skipped.runs(pre_init));
+
+    // The space-separated `--test-threads`. libtest accepts it, and without the
+    // value being swallowed `1` becomes a positional filter — which selects
+    // `..._1p_multi_c_spmc` and silently drops `..._pre_initialized_99_percent`.
+    let spaced = harness_args("cargo test -p horus_core --lib -- --test-threads 1");
+    assert!(
+        spaced.filters.is_empty(),
+        "`1`, the value of --test-threads, was filed as a test-name filter: {:?}",
+        spaced.filters
+    );
+    assert!(spaced.runs(spmc) && spaced.runs(mpmc) && spaced.runs(pre_init));
+
+    // `cargo llvm-cov test` — the explicit spelling of coverage.yml's bare
+    // `cargo llvm-cov`. `test` is a subcommand, not a filter.
+    let cov = harness_args("cargo llvm-cov test --workspace --lib -- --test-threads=1");
+    assert!(
+        cov.filters.is_empty(),
+        "the `test` subcommand was parsed as a test-name filter: {:?}",
+        cov.filters
+    );
+    assert!(cov.runs(spmc) && cov.runs(mpmc) && cov.runs(pre_init));
+
+    // The bare form still parses, and `+toolchain` / `miri` are not filters.
+    let bare = harness_args("cargo llvm-cov --workspace --lib -- --skip topic_cross_thread");
+    assert!(bare.filters.is_empty() && !bare.runs(spmc));
+    let miri = harness_args("cargo +nightly miri test -p horus_core --lib");
+    assert!(miri.filters.is_empty() && miri.runs(spmc));
+
+    // A real positional filter must still be read as one — that is the whole
+    // reason cargo's value-taking flags are enumerated.
+    let named = harness_args("cargo test -p horus_manager --lib source_resolver -- --ignored");
+    assert_eq!(named.filters, ["source_resolver"]);
+    assert!(!named.runs(spmc));
+
+    // `--exact` turns substring matching into equality, for filters and skips.
+    let exact = harness_args("cargo test -p horus_core --lib -- --exact topic_cross_thread");
+    assert!(
+        !exact.runs(spmc),
+        "--exact was ignored: a bare stem matched a full path"
+    );
+    let exact_hit = harness_args(&format!("cargo test -p horus_core --lib -- --exact {spmc}"));
+    assert!(exact_hit.runs(spmc) && !exact_hit.runs(mpmc));
 }

--- a/horus_manager/tests/ci_coverage_contract.rs
+++ b/horus_manager/tests/ci_coverage_contract.rs
@@ -1,0 +1,264 @@
+//! A test that every job skips is a test that does not exist.
+//!
+//! `topic_cross_thread_1p_multi_c_spmc`, `topic_cross_thread_multi_p_multi_c_mpmc`
+//! and `topic_cross_thread_mpmc_pre_initialized_99_percent` are plain `#[test]`
+//! functions in `horus_core`'s lib target — no `#[ignore]`, nothing conditional.
+//! Six of the CI invocations that build that target passed `--skip` for all
+//! three (`ci.yml`, `coverage.yml`, `safety.yml` twice, `multi-platform.yml`
+//! twice, `integration-tests.yml`) and the remaining two filter by name for
+//! something else. The `--test '*'` jobs build integration targets only, so
+//! they never reached them either. Net runners: zero, on every platform.
+//!
+//! The rationale that travelled with the skip list said the three "assert
+//! throughput thresholds ("expected at least 50 messages, got 44") that are a
+//! property of the runner, not of the code". That was true when it was written
+//! and false by the time it was last copied: all three floors had been deleted,
+//! and the comments at those asserts in `communication/topic/tests.rs` record
+//! the removal in the past tense. The skips outlived their reason and nothing
+//! noticed, because nothing was looking.
+//!
+//! This file looks. It is deliberately about these three names and not about
+//! `--skip` in general: most of the other entries in those lists are
+//! load-bearing (sanitizer false positives on the deliberately-lossy `send()`
+//! path, tick counts that llvm-cov instrumentation cannot hold), and a job is
+//! allowed to exclude a test it genuinely cannot run. What is not allowed is
+//! for the last job that could run one to drop it silently.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Full libtest paths, not bare function names, because that is what both
+/// `--skip` patterns and positional filters are matched against.
+///
+/// Named rather than globbed as `topic_cross_thread_*`: a new test in that
+/// family is not automatically owed a gate, and a glob would make this file
+/// pass or fail for reasons nobody chose.
+const MUST_RUN_SOMEWHERE: [&str; 3] = [
+    "communication::topic::tests::topic_cross_thread_1p_multi_c_spmc",
+    "communication::topic::tests::topic_cross_thread_multi_p_multi_c_mpmc",
+    "communication::topic::tests::topic_cross_thread_mpmc_pre_initialized_99_percent",
+];
+
+/// Cargo flags whose value is a separate token. Needed only to tell a value
+/// (`horus_core` in `-p horus_core`) from a bare test-name filter
+/// (`source_resolver` in `cargo test -p horus_manager --lib source_resolver`),
+/// which changes what a command runs.
+const CARGO_FLAGS_TAKING_A_VALUE: [&str; 15] = [
+    "-p",
+    "--package",
+    "--exclude",
+    "--target",
+    "--features",
+    "-F",
+    "--test",
+    "--bench",
+    "--example",
+    "--bin",
+    "--manifest-path",
+    "--target-dir",
+    "--profile",
+    "--jobs",
+    "-j",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("horus_manager has a parent")
+        .to_path_buf()
+}
+
+fn workflows() -> Vec<(String, String)> {
+    let dir = repo_root().join(".github/workflows");
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir).expect(".github/workflows must exist") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) == Some("yml") {
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            out.push((name, fs::read_to_string(&path).expect("workflow readable")));
+        }
+    }
+    out.sort();
+    assert!(!out.is_empty(), "no workflows found — this test is vacuous");
+    out
+}
+
+/// Collapse `\`-continued shell lines into one logical command each, drop
+/// whole-line `#` comments, and unwrap the one-line `run:` form.
+///
+/// All three matter. Every `--skip` in these workflows sits on a continuation
+/// line, so reading physical lines sees the `cargo test` and its exclusions as
+/// unrelated strings. `docs-contract.yml` discusses `cargo test --workspace
+/// --lib` inside a prose comment — counting that as a job would make this file
+/// pass while nothing actually ran. And a step written `run: cargo test ...`
+/// instead of `run: |` is the same invocation.
+fn shell_commands(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut acc = String::new();
+    for line in body.lines() {
+        let mut t = line.trim();
+        if t.starts_with('#') {
+            continue;
+        }
+        if acc.is_empty() {
+            t = t.strip_prefix("run: ").unwrap_or(t);
+        }
+        if let Some(head) = t.strip_suffix('\\') {
+            acc.push_str(head.trim_end());
+            acc.push(' ');
+        } else {
+            acc.push_str(t);
+            out.push(std::mem::take(&mut acc));
+        }
+    }
+    if !acc.is_empty() {
+        out.push(acc);
+    }
+    out
+}
+
+/// The name filters and `--skip` patterns a command hands to libtest.
+///
+/// Filters may appear on either side of `--` — cargo forwards its own
+/// positional to the harness — so both halves are parsed. `--skip` only ever
+/// appears after it.
+struct HarnessArgs {
+    filters: Vec<String>,
+    skips: Vec<String>,
+    exact: bool,
+}
+
+impl HarnessArgs {
+    /// libtest matches both filters and `--skip` patterns as substrings of the
+    /// full test path — `--exact` narrows that to equality — and running with
+    /// no filter runs everything.
+    fn runs(&self, test_path: &str) -> bool {
+        let matches = |p: &String| {
+            if self.exact {
+                p == test_path
+            } else {
+                test_path.contains(p.as_str())
+            }
+        };
+        let selected = self.filters.is_empty() || self.filters.iter().any(&matches);
+        selected && !self.skips.iter().any(&matches)
+    }
+}
+
+fn harness_args(cmd: &str) -> HarnessArgs {
+    let mut filters = Vec::new();
+    let mut skips = Vec::new();
+    let exact = cmd.split_whitespace().any(|a| a == "--exact");
+    let mut args = cmd.split_whitespace().peekable();
+    let mut after_dashdash = false;
+
+    // `cargo`, an optional `+toolchain`, then the subcommand(s): `test`,
+    // `llvm-cov`, `miri test`. None of these is a filter.
+    while let Some(&head) = args.peek() {
+        if head.starts_with('-') {
+            break;
+        }
+        args.next();
+        if head == "test" || head == "llvm-cov" {
+            break;
+        }
+    }
+
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            after_dashdash = true;
+        } else if let Some(pattern) = arg.strip_prefix("--skip=") {
+            skips.push(pattern.to_string());
+        } else if arg == "--skip" {
+            skips.extend(args.next().map(str::to_string));
+        } else if arg.starts_with('-') {
+            if !after_dashdash && CARGO_FLAGS_TAKING_A_VALUE.contains(&arg) {
+                args.next();
+            }
+        } else {
+            filters.push(arg.trim_matches('\'').to_string());
+        }
+    }
+
+    HarnessArgs {
+        filters,
+        skips,
+        exact,
+    }
+}
+
+/// Every invocation that builds `horus_core`'s lib test target, as
+/// `(workflow, command)`.
+///
+/// `cargo llvm-cov --workspace` in `coverage.yml` also runs that target but
+/// carries no `--lib`, so it is not counted. Under-counting is the safe
+/// direction: it can only make the assertion below stricter.
+fn horus_core_lib_test_commands() -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for (name, body) in workflows() {
+        for cmd in shell_commands(&body) {
+            let is_cargo_test =
+                cmd.starts_with("cargo ") && (cmd.contains(" test ") || cmd.contains(" llvm-cov "));
+            let builds_horus_core = cmd.contains("-p horus_core") || cmd.contains("--workspace");
+            if is_cargo_test
+                && builds_horus_core
+                && cmd.contains("--lib")
+                && !cmd.contains("--exclude horus_core")
+            {
+                out.push((name.clone(), cmd));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn every_cross_thread_topic_test_still_has_a_ci_runner() {
+    let cmds = horus_core_lib_test_commands();
+
+    // The failure guarded against is "nothing runs it", which a matcher that
+    // has stopped matching reports as success. Eight invocations parse today;
+    // if this trips, fix the matcher rather than deleting the file.
+    assert!(
+        cmds.len() >= 6,
+        "only {} invocation(s) of horus_core's lib test target found across \
+         .github/workflows — the matcher has drifted and this test is vacuous",
+        cmds.len()
+    );
+
+    for path in MUST_RUN_SOMEWHERE {
+        assert!(
+            cmds.iter().any(|(_, cmd)| harness_args(cmd).runs(path)),
+            "no CI job runs {path}: all {} invocations that build horus_core's \
+             lib target either --skip it or filter it out by name. A test \
+             nothing executes is not coverage — give it a runner, or delete it, \
+             but do not leave it looking like a gate.",
+            cmds.len()
+        );
+    }
+}
+
+#[test]
+fn the_pr_gate_is_one_of_those_runners() {
+    // The test above is satisfied by any job, the Windows one included, which
+    // skips these three for reasons of its own (an open fan-out gap and an open
+    // multi-producer data-loss defect, both recorded in multi-platform.yml).
+    // Linux is where the ring protocol is actually exercised, so pin the gate
+    // every pull request has to pass.
+    let ci = fs::read_to_string(repo_root().join(".github/workflows/ci.yml"))
+        .expect("ci.yml must exist");
+    let cmd = shell_commands(&ci)
+        .into_iter()
+        .find(|c| c.starts_with("cargo test --workspace") && c.contains("--lib"))
+        .expect("ci.yml's test job must run `cargo test --workspace ... --lib`");
+    let args = harness_args(&cmd);
+
+    for path in MUST_RUN_SOMEWHERE {
+        assert!(
+            args.runs(path),
+            "ci.yml's workspace lib step does not run {path}. It is the only \
+             job that runs the cross-thread topic tests; excluding it here \
+             takes them back to zero runners.\n  {cmd}"
+        );
+    }
+}


### PR DESCRIPTION
topic_cross_thread_1p_multi_c_spmc, topic_cross_thread_multi_p_multi_c_mpmc
and topic_cross_thread_mpmc_pre_initialized_99_percent are plain #[test]
functions in horus_core's lib target. Six of the eight CI invocations that
build that target --skip'd all three (ci.yml, coverage.yml, safety.yml twice,
multi-platform.yml twice, integration-tests.yml) and the other two filter by
name for something else. The --test '*' jobs build integration targets only.
Net runners: zero, on every platform.

The justification that travelled with the skip list, written out in full at
multi-platform.yml, said the three "assert throughput thresholds ('expected at
least 50 messages, got 44') that are a property of the runner, not of the
code". That stopped being true. All three floors were deleted, and the
comments at those asserts in communication/topic/tests.rs record the removal
in the past tense ("This used to assert `>= 50` unique messages and failed at
30 under load"). What survives asserts only what holds however the threads are
scheduled: every value received was sent and decodes to a producer and an
index that exist, and at least one message arrives.

So ci.yml runs them again. MEASURED first, on the binary that job builds and
with --test-threads=1: 20/20 green pinned to two cores (a GitHub runner's core
count) -- 10 runs on a quiet box and 10 with those cores 3x oversubscribed by
spinners -- 10.1 s best, 40.2 s worst, against a 30-minute budget. And the
whole communication::topic::tests module single-threaded in one process, which
is how this job reaches them: 368 passed, 0 failed, 71 s.

multi-platform.yml's rationale is rewritten to stop citing an assertion that
no longer exists. The Windows skip stays: these three have never run there
since the floors went, and that job already carries two open, undiagnosed
Windows defects in the same fan-out subsystem. The sanitizer, coverage,
MSRV and integration-tests skips stay too -- they were never the reason
coverage was zero, and each needs its own look.

horus_manager/tests/ci_coverage_contract.rs is the guard, alongside the other
workflow contract tests in that directory. It parses every workflow's cargo
test/llvm-cov invocations -- joining `\` continuations, dropping comment lines
so docs-contract.yml's prose does not count as a job, and reading positional
name filters as well as --skip patterns, both matched as substrings the way
libtest matches them -- and fails if any of the three has no job left that
runs it.

## Ablation

```
Reverted ONLY the production change (`git checkout -- .github/workflows/ci.yml .github/workflows/multi-platform.yml`, restoring the three `--skip topic_cross_thread_*` lines and the stale comment), kept horus_manager/tests/ci_coverage_contract.rs, and re-ran `cargo test -p horus_manager --test ci_coverage_contract`. EXACT output:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running tests/ci_coverage_contract.rs (/home/neos/.cache/horus-wf23-target/debug/deps/ci_coverage_contract-7707e8f84801f16b)

running 2 tests
test the_pr_gate_is_one_of_those_runners ... FAILED
test every_cross_thread_topic_test_still_has_a_ci_runner ... FAILED

failures:

---- the_pr_gate_is_one_of_those_runners stdout ----

thread 'the_pr_gate_is_one_of_those_runners' (2192263) panicked at horus_manager/tests/ci_coverage_contract.rs:257:9:
ci.yml's workspace lib step does not run communication::topic::tests::topic_cross_thread_1p_multi_c_spmc. It is the only job that runs the cross-thread topic tests; excluding it here takes them back to zero runners.
  cargo test --workspace --exclude horus_py --lib --no-fail-fast -- --test-threads=1 --skip topic_cross_thread_1p_multi_c_spmc --skip topic_cross_thread_mpmc_pre_initialized_99_percent --skip topic_cross_thread_multi_p_multi_c_mpmc --skip test_robotics_autonomous_car_perception
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- every_cross_thread_topic_test_still_has_a_ci_runner stdout ----

thread 'every_cross_thread_topic_test_still_has_a_ci_runner' (2192262) panicked at horus_manager/tests/ci_coverage_contract.rs:230:9:
no CI job runs communication::topic::tests::topic_cross_thread_1p_multi_c_spmc: all 8 invocations that build horus_core's lib target either --skip it or filter it out by name. A test nothing executes is not coverage — give it a runner, or delete it, but do not leave it looking like a gate.


failures:
    every_cross_thread_topic_test_still_has_a_ci_runner
    the_pr_gate_is_one_of_those_runners

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

error: test failed, to rerun pass `-p horus_manager --test ci_coverage_contract`
```

Then `git apply` of the saved production patch restored the change and both tests went green again (2 passed; 0 failed).

An earlier draft of the general test WAS vacuous and I caught it: the first matcher counted `cargo miri test -p horus_core --lib -- memory::simd ...` and `cargo test -p horus_core --release --lib -- scheduling::scheduler::tests::...` as "runners" because
```

## Tests

```
All in a depth-1 clone of horus `main` @ 71e6a4a, `CARGO_TARGET_DIR` outside every repo. 12-core box, heavily loaded by sibling sessions.

- `cargo test -p horus_manager --test ci_coverage_contract` — 2 passed, 0 failed (with fix); 0 passed, 2 failed (ablated).
- `cargo test -p horus_manager --test container_contract --test install_contract --test ci_coverage_contract -- --test-threads=1` — the other two workflow-reading contract tests still pass against the edited YAML: ci_coverage_contract 2 passed, container_contract 7 passed, install_contract 32 passed; 0 failed.
- `cargo test -p horus_manager --lib -- --test-threads=1` — 3472 passed, 0 failed, 7 ignored, 103.16 s.
- The three un-skipped tests standalone, `--test-threads=1`, pinned to two cores with `taskset -c 10,11`: 10/10 green idle (10.12 s – 40.16 s) and 10/10 green with those two cores 3x oversubscribed by spinners (25.15 s – 40.23 s). 20/20 total, no failures.
- Whole `communication::topic::tests` module single-threaded in one process (what ci.yml's change actually causes for this module): 368 passed, 0 failed, 2 ignored, 71.03 s — all six `topic_cross_thread_*` including the three un-skipped ones.
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p horus_manager --all-targets -- -D warnings` clean.
- `python3 -c "yaml.safe_load(...)"` on both edited workflows, plus rendering the resulting `run:` block, to confirm the YAML and the shell command are intact.

FIRST run of `cargo test -p horus_manager --lib` died
```

## Notes from the implementer

CONFIRMED the finding independently before fixing. All three functions are plain `#[test]` at tests.rs:576/762/2094 with no `#[ignore]`. I enumerated every `cargo test`/`cargo llvm-cov` line in `.github/workflows/` rather than grepping for names: eight invocations build horus_core's lib target, six `--skip` all three, and the other two (`cargo miri test ... -- memory::*` and `cargo test -p horus_core --release --lib -- scheduling::scheduler::tests::...`) filter by name for something else. `integration-tests.yml`'s `--test '*'` builds integration targets only. Zero runners is correct. And multi-platform.yml:157-159 does assert in the present tense that the three "assert throughput thresholds ('expected at least 50 messages, got 44')" while tests.rs:626-644, 837-847 and 2168-2177 record the removal of exactly those floors in the past tense. The stated justification is false.

WHERE I WORKED, AND WHY IT MATTERS TO WHOEVER LANDS THIS. The worktree I was given is `/home/neos/softmata/horus-docs/.claude/worktrees/wf_b365913e-0a9-23` — the docs site, not the Rust workspace. Every finding in findings.json is against `/home/neos/softmata/horus`, and the harness refuses git operations that target that shared checkout, so I could not branch there. I worked in a depth-1 clone of horus `main` (71e6a4a, "test: run the 404 tests this repo already has but never executed (#126)") at `/tmp/claude-1000/-home-neos-softmata/822523d0-05fe-4676-a353-d31ab6bdc2b3/scratchpad/horus`. The diff above is a real `git diff` from that clone and applies cleanly to horus main; the patch is also saved at `/tmp/claude-1000/-home-neos-softmata/822523d0-05fe-4676-a353-d31ab6bdc2b3/scratchpad/final.diff`. There is no branch to check out — the branch name is a suggestion. Nothing was committed, pushed, or written into any repo.

WHAT I COULD NOT VERIFY. (1) CI itself. I have no GitHub runner, so "the ci.yml job stays green and inside 30 minutes" rests on local measurement (20/20 pinned to two cores, worst

---
Found by a 10-dimension adversarial audit. Implemented in an isolated worktree with an ablation required, then re-applied to current `main`, compiled, and tested in a clean worktree before this PR.
