### PR TITLE
docs(readme): ask for issues and PRs, not a hardware survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,18 +641,11 @@ benchmarks/     Performance suite — latency, throughput, jitter, comparisons
 
 ---
 
-## Running HORUS on Real Hardware?
+## Contributing
 
-We'd love to hear from you. HORUS is validated in simulation — if you're running it on a real robot, your experience helps us improve.
-
-Tell us (via [GitHub Issues](https://github.com/softmata/horus/issues), [Discord](https://discord.gg/hEZC3ev2Nf), or [email](mailto:contact@softmata.dev)):
-- **What robot** — platform, actuators, sensors
-- **What control rate** you're achieving on real hardware
-- **What worked** out of the box
-- **What needed tuning** — PID gains, sensor dropout thresholds, timing budgets
-- **What broke** — anything that works in sim but fails on hardware
-
-We'll add validated hardware to the docs and credit contributors.
+- **Found a bug?** [Open an issue](https://github.com/softmata/horus/issues/new) — what you ran, what happened, what you expected. A reproducer is worth more than a description.
+- **Want a feature?** [Open an issue](https://github.com/softmata/horus/issues/new) and say what you are trying to build; the use case shapes the API more than the request does.
+- **Fixed something?** [Open a pull request](https://github.com/softmata/horus/compare). See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
Replaces **"Running HORUS on Real Hardware?"** with a short Contributing section.

## Why

The section asked readers to write in with their platform, achieved control rate, what needed tuning and what broke — routed to GitHub Issues, **Discord, or email**.

Two problems with that:

- **Two of the three destinations are dead ends.** An answer in Discord or email is not searchable, not linkable from a fix, and not what the next person with the same problem finds. A bug report only compounds if it lands somewhere durable.
- **It promises something the repo does not do.** "We'll add validated hardware to the docs and credit contributors" — there is no validated-hardware list to add to.

## What replaces it

The three things a reader can actually do, each pointing at the tracker:

- **Found a bug?** Open an issue — what you ran, what happened, what you expected. *A reproducer is worth more than a description.*
- **Want a feature?** Open an issue and say what you are trying to build; the use case shapes the API more than the request does.
- **Fixed something?** Open a pull request.

The reproducer line is not filler. The faults that have cost the most here recently — the topic-attach SIGBUS in #144, the pool-id collisions — were all cases where reproducing was the entire difficulty and the description was nearly useless.

## Scope

Only `README.md` carried this section. I checked all five translated READMEs (`de`, `es`, `ja`, `pt-BR`, `zh-CN`) — none of them have it, so nothing goes out of sync.