### PR TITLE
fix(maps): world_to_grid and grid_to_world must honour origin_theta

### DIFF
--- a/horus_core/src/memory/costmap.rs
+++ b/horus_core/src/memory/costmap.rs
@@ -381,8 +381,28 @@ impl CostMap {
     pub fn world_to_grid(&self, x: f64, y: f64) -> Option<(u32, u32)> {
         const EPSILON: f64 = 1e-6;
         let res = (self.resolution() as f64).max(1e-9);
-        let grid_x = ((x - self.origin_x()) / res + EPSILON).floor() as i32;
-        let grid_y = ((y - self.origin_y()) / res + EPSILON).floor() as i32;
+
+        // Translate into the map frame, then UNDO the map's rotation before
+        // dividing by resolution. `origin_theta` is documented as "map origin
+        // orientation (radians)" and was stored, exposed by a getter, and read
+        // by neither transform -- so every lookup on a rotated map silently
+        // returned the wrong cell. Wrong, not absent: the indices stayed in
+        // range and looked entirely plausible, which for a costmap means a
+        // planner confidently avoids the wrong places.
+        //
+        // theta == 0 short-circuits to the original arithmetic, so unrotated
+        // maps -- the overwhelmingly common case, and every existing test --
+        // are bit-identical and pay nothing.
+        let (dx, dy) = (x - self.origin_x(), y - self.origin_y());
+        let theta = self.origin_theta();
+        let (rx, ry) = if theta == 0.0 {
+            (dx, dy)
+        } else {
+            let (sin_t, cos_t) = theta.sin_cos();
+            (dx * cos_t + dy * sin_t, -dx * sin_t + dy * cos_t)
+        };
+        let grid_x = (rx / res + EPSILON).floor() as i32;
+        let grid_y = (ry / res + EPSILON).floor() as i32;
 
         if grid_x >= 0
             && grid_x < self.width() as i32
@@ -398,9 +418,19 @@ impl CostMap {
     /// Convert grid indices to world coordinates (cell center).
     pub fn grid_to_world(&self, grid_x: u32, grid_y: u32) -> Option<(f64, f64)> {
         if grid_x < self.width() && grid_y < self.height() {
-            let x = self.origin_x() + (grid_x as f64 + 0.5) * self.resolution() as f64;
-            let y = self.origin_y() + (grid_y as f64 + 0.5) * self.resolution() as f64;
-            Some((x, y))
+            // Cell centre in the map frame, rotated INTO the world frame by
+            // `origin_theta` and then translated. Exact inverse of
+            // `world_to_grid`, including the theta == 0 short-circuit.
+            let mx = (grid_x as f64 + 0.5) * self.resolution() as f64;
+            let my = (grid_y as f64 + 0.5) * self.resolution() as f64;
+            let theta = self.origin_theta();
+            let (ox, oy) = if theta == 0.0 {
+                (mx, my)
+            } else {
+                let (sin_t, cos_t) = theta.sin_cos();
+                (mx * cos_t - my * sin_t, mx * sin_t + my * cos_t)
+            };
+            Some((self.origin_x() + ox, self.origin_y() + oy))
         } else {
             None
         }
@@ -625,5 +655,66 @@ mod tests {
         let dbg = format!("{:?}", cm);
         assert!(dbg.contains("CostMap"));
         assert!(dbg.contains("100"));
+    }
+}
+
+#[cfg(test)]
+mod origin_theta_tests {
+    use super::*;
+
+    const RES: f32 = 0.05;
+
+    /// A rotated map must round-trip: grid -> world -> grid returns the cell.
+    ///
+    /// `origin_theta` is documented as the map origin's orientation and was
+    /// read by neither transform. On a map rotated 90 degrees this returned a
+    /// cell that was in range and plausible and simply wrong, so a planner
+    /// avoided the wrong places with no error anywhere.
+    #[test]
+    fn rotated_map_round_trips_grid_to_world_to_grid() {
+        let mut m = CostMap::new(32, 32, RES, 0.3).expect("alloc");
+        m.set_origin(1.0, -2.0, std::f64::consts::FRAC_PI_2);
+        for &(gx, gy) in &[(0u32, 0u32), (3, 7), (19, 11)] {
+            let (wx, wy) = m.grid_to_world(gx, gy).expect("in range");
+            let back = m.world_to_grid(wx, wy);
+            assert_eq!(
+                back,
+                Some((gx, gy)),
+                "cell ({gx},{gy}) -> world ({wx:.4},{wy:.4}) -> {back:?} on a \
+                 map rotated by origin_theta"
+            );
+        }
+    }
+
+    /// The rotation must actually be applied, not merely round-trip with
+    /// itself. A 90-degree map sends +x in the map frame to +y in the world.
+    #[test]
+    fn ninety_degrees_maps_map_x_onto_world_y() {
+        let mut m = CostMap::new(32, 32, RES, 0.3).expect("alloc");
+        m.set_origin(1.0, -2.0, std::f64::consts::FRAC_PI_2);
+        let (wx, wy) = m.grid_to_world(4, 0).expect("in range");
+        // Cell (4,0) centre is (4.5*res, 0.5*res) in the map frame. Rotated by
+        // +90 degrees that is (-0.5*res, 4.5*res), then translated by the
+        // origin (1.0, -2.0).
+        let res = RES as f64;
+        let (ex, ey) = (1.0 + -0.5 * res, -2.0 + 4.5 * res);
+        assert!(
+            (wx - ex).abs() < 1e-6 && (wy - ey).abs() < 1e-6,
+            "expected map +x to become world +y: wanted ({ex:.6}, {ey:.6}), \
+             got ({wx:.6}, {wy:.6})"
+        );
+    }
+
+    /// theta == 0 must be bit-identical to the original translation-only
+    /// arithmetic, so unrotated maps -- every existing caller -- are untouched.
+    #[test]
+    fn unrotated_map_is_unchanged() {
+        let mut m = CostMap::new(32, 32, RES, 0.3).expect("alloc");
+        m.set_origin(0.0, 0.0, 0.0);
+        let (wx, wy) = m.grid_to_world(6, 2).expect("in range");
+        let res = RES as f64;
+        assert!((wx - 6.5 * res).abs() < 1e-12, "x drifted: {wx}");
+        assert!((wy - 2.5 * res).abs() < 1e-12, "y drifted: {wy}");
+        assert_eq!(m.world_to_grid(wx, wy), Some((6, 2)));
     }
 }

--- a/horus_core/src/memory/costmap.rs
+++ b/horus_core/src/memory/costmap.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use crate::types::{CostMapDescriptor, TensorDtype};
 
+use super::grid_transform;
 use super::tensor_pool::TensorPool;
 use crate::communication::topic::pool_registry::global_pool;
 use crate::error::HorusResult;
@@ -390,17 +391,18 @@ impl CostMap {
         // range and looked entirely plausible, which for a costmap means a
         // planner confidently avoids the wrong places.
         //
-        // theta == 0 short-circuits to the original arithmetic, so unrotated
-        // maps -- the overwhelmingly common case, and every existing test --
-        // are bit-identical and pay nothing.
-        let (dx, dy) = (x - self.origin_x(), y - self.origin_y());
-        let theta = self.origin_theta();
-        let (rx, ry) = if theta == 0.0 {
-            (dx, dy)
-        } else {
-            let (sin_t, cos_t) = theta.sin_cos();
-            (dx * cos_t + dy * sin_t, -dx * sin_t + dy * cos_t)
-        };
+        // `grid_transform` holds the one copy of this arithmetic shared with
+        // the other grid type, short-circuits theta == 0 to the original
+        // translation (so unrotated maps are bit-identical and pay nothing),
+        // and returns None rather than a NaN that `as i32` would saturate
+        // into a plausible cell (0, 0).
+        let (rx, ry) = grid_transform::world_to_map(
+            self.origin_x(),
+            self.origin_y(),
+            self.origin_theta(),
+            x,
+            y,
+        )?;
         let grid_x = (rx / res + EPSILON).floor() as i32;
         let grid_y = (ry / res + EPSILON).floor() as i32;
 
@@ -420,17 +422,18 @@ impl CostMap {
         if grid_x < self.width() && grid_y < self.height() {
             // Cell centre in the map frame, rotated INTO the world frame by
             // `origin_theta` and then translated. Exact inverse of
-            // `world_to_grid`, including the theta == 0 short-circuit.
+            // `world_to_grid` -- they share one implementation so they cannot
+            // drift apart -- including the theta == 0 short-circuit and the
+            // refusal of a non-finite origin.
             let mx = (grid_x as f64 + 0.5) * self.resolution() as f64;
             let my = (grid_y as f64 + 0.5) * self.resolution() as f64;
-            let theta = self.origin_theta();
-            let (ox, oy) = if theta == 0.0 {
-                (mx, my)
-            } else {
-                let (sin_t, cos_t) = theta.sin_cos();
-                (mx * cos_t - my * sin_t, mx * sin_t + my * cos_t)
-            };
-            Some((self.origin_x() + ox, self.origin_y() + oy))
+            grid_transform::map_to_world(
+                self.origin_x(),
+                self.origin_y(),
+                self.origin_theta(),
+                mx,
+                my,
+            )
         } else {
             None
         }
@@ -716,5 +719,30 @@ mod origin_theta_tests {
         assert!((wx - 6.5 * res).abs() < 1e-12, "x drifted: {wx}");
         assert!((wy - 2.5 * res).abs() < 1e-12, "y drifted: {wy}");
         assert_eq!(m.world_to_grid(wx, wy), Some((6, 2)));
+    }
+
+    /// A non-finite `origin_theta` must refuse the lookup, not answer it.
+    ///
+    /// `origin_theta` arrives in a Pod descriptor that travels through shared
+    /// memory, so any f64 bit pattern is reachable. `sin_cos()` on NaN is NaN,
+    /// and `(NaN.floor() as i32)` saturates to 0 -- so before the guard this
+    /// returned `Some((0, 0))`: in range, plausible, and wrong for every query
+    /// point on the map.
+    #[test]
+    fn non_finite_origin_theta_refuses_the_lookup() {
+        for theta in [f64::NAN, f64::INFINITY] {
+            let mut m = CostMap::new(32, 32, RES, 0.3).expect("alloc");
+            m.set_origin(1.0, -2.0, theta);
+            assert_eq!(
+                m.world_to_grid(1.0, -2.0),
+                None,
+                "theta {theta} must not yield a cell"
+            );
+            assert_eq!(
+                m.grid_to_world(4, 4),
+                None,
+                "theta {theta} must not yield a world point"
+            );
+        }
     }
 }

--- a/horus_core/src/memory/grid_transform.rs
+++ b/horus_core/src/memory/grid_transform.rs
@@ -1,0 +1,150 @@
+//! Shared map-origin transforms for the grid-shaped message types.
+//!
+//! `OccupancyGrid` and `CostMap` both carry an origin `(x, y, theta)` and both
+//! need the same pair of transforms between world coordinates and the map
+//! frame. Keeping one copy here is not tidiness: the two directions must stay
+//! exact inverses of each other, and `world_to_grid`/`grid_to_world` on either
+//! type round-tripping is the property the callers rely on. Four hand-written
+//! copies of the same trigonometry is four places for that property to rot.
+
+/// Transform world coordinates into the map frame.
+///
+/// Translates by the origin, then UNDOES the map's rotation, leaving a
+/// displacement in metres along the grid's own axes. Divide by the resolution
+/// to get cell coordinates.
+///
+/// `theta == 0.0` short-circuits to plain translation, so unrotated maps --
+/// the overwhelmingly common case -- get bit-for-bit the arithmetic they had
+/// before rotation was honoured, and pay nothing for the trig.
+///
+/// Returns `None` if the result is not finite. `origin_theta` reaches this
+/// code from a Pod descriptor that travels through shared memory, so any f64
+/// bit pattern is reachable, including NaN and the infinities; `sin_cos()` on
+/// those yields NaN, and `(NaN.floor() as i32)` saturates to 0 rather than
+/// trapping. Without this check a poisoned origin turns every lookup into a
+/// confident, in-range, wrong cell (0, 0). Refusing is the same answer the
+/// caller already handles for an out-of-map query.
+#[inline]
+pub(crate) fn world_to_map(
+    origin_x: f64,
+    origin_y: f64,
+    theta: f64,
+    x: f64,
+    y: f64,
+) -> Option<(f64, f64)> {
+    let (dx, dy) = (x - origin_x, y - origin_y);
+    let (mx, my) = if theta == 0.0 {
+        (dx, dy)
+    } else {
+        let (sin_t, cos_t) = theta.sin_cos();
+        (dx * cos_t + dy * sin_t, -dx * sin_t + dy * cos_t)
+    };
+    if mx.is_finite() && my.is_finite() {
+        Some((mx, my))
+    } else {
+        None
+    }
+}
+
+/// Transform map-frame coordinates (metres along the grid's own axes) into
+/// world coordinates.
+///
+/// Exact inverse of [`world_to_map`]: rotate INTO the world frame, then
+/// translate by the origin. Same `theta == 0.0` short-circuit, same
+/// non-finite refusal, for the same reasons.
+#[inline]
+pub(crate) fn map_to_world(
+    origin_x: f64,
+    origin_y: f64,
+    theta: f64,
+    mx: f64,
+    my: f64,
+) -> Option<(f64, f64)> {
+    let (rx, ry) = if theta == 0.0 {
+        (mx, my)
+    } else {
+        let (sin_t, cos_t) = theta.sin_cos();
+        (mx * cos_t - my * sin_t, mx * sin_t + my * cos_t)
+    };
+    let (x, y) = (origin_x + rx, origin_y + ry);
+    if x.is_finite() && y.is_finite() {
+        Some((x, y))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::FRAC_PI_2;
+
+    /// theta == 0 must be the plain translation, to the bit -- every existing
+    /// caller has an unrotated map and must not drift.
+    #[test]
+    fn zero_theta_is_exact_translation() {
+        assert_eq!(world_to_map(1.5, -2.25, 0.0, 4.0, 6.0), Some((2.5, 8.25)));
+        assert_eq!(map_to_world(1.5, -2.25, 0.0, 2.5, 8.25), Some((4.0, 6.0)));
+    }
+
+    /// The two directions are inverses, which is what makes
+    /// `grid -> world -> grid` return the cell it started from.
+    #[test]
+    fn directions_are_inverses() {
+        let (ox, oy, theta) = (1.0, -2.0, 0.7);
+        for &(mx, my) in &[(0.0, 0.0), (0.35, 1.2), (-4.0, 9.5)] {
+            let (wx, wy) = map_to_world(ox, oy, theta, mx, my).expect("finite");
+            let (bx, by) = world_to_map(ox, oy, theta, wx, wy).expect("finite");
+            assert!(
+                (bx - mx).abs() < 1e-9 && (by - my).abs() < 1e-9,
+                "({mx}, {my}) -> ({wx}, {wy}) -> ({bx}, {by})"
+            );
+        }
+    }
+
+    /// A quarter turn sends map +x onto world +y. Guards against the pair
+    /// being consistently wrong (e.g. both rotating the wrong way), which the
+    /// inverse test alone would not catch.
+    #[test]
+    fn quarter_turn_sends_map_x_to_world_y() {
+        let (x, y) = map_to_world(0.0, 0.0, FRAC_PI_2, 3.0, 0.0).expect("finite");
+        assert!(
+            (x - 0.0).abs() < 1e-9 && (y - 3.0).abs() < 1e-9,
+            "({x}, {y})"
+        );
+    }
+
+    /// A non-finite origin_theta must refuse, not answer. `sin_cos()` on NaN
+    /// is NaN, and the caller's `as i32` would saturate that to a plausible
+    /// in-range cell (0, 0).
+    #[test]
+    fn non_finite_theta_is_refused() {
+        for theta in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(
+                world_to_map(1.0, 2.0, theta, 3.0, 4.0),
+                None,
+                "theta {theta} must not produce coordinates"
+            );
+            assert_eq!(
+                map_to_world(1.0, 2.0, theta, 3.0, 4.0),
+                None,
+                "theta {theta} must not produce coordinates"
+            );
+        }
+    }
+
+    /// The same refusal covers a non-finite origin or query point, which reach
+    /// this code from the same untrusted descriptor bytes.
+    #[test]
+    fn non_finite_origin_or_point_is_refused() {
+        assert_eq!(world_to_map(f64::NAN, 0.0, 0.0, 1.0, 1.0), None);
+        assert_eq!(world_to_map(0.0, 0.0, 0.0, f64::NAN, 1.0), None);
+        assert_eq!(map_to_world(0.0, f64::NAN, 0.0, 1.0, 1.0), None);
+        // Infinity minus infinity is NaN, so an infinite origin is refused
+        // even when the query point is infinite too.
+        assert_eq!(
+            world_to_map(f64::INFINITY, 0.0, 0.0, f64::INFINITY, 1.0),
+            None
+        );
+    }
+}

--- a/horus_core/src/memory/mod.rs
+++ b/horus_core/src/memory/mod.rs
@@ -235,6 +235,8 @@ macro_rules! impl_tensor_backed {
 // Domain-specific types (RAII wrappers with rich API for data access)
 pub mod costmap;
 pub mod depth_image;
+// Map-origin transforms shared by `costmap` and `occupancy_grid`.
+pub(crate) mod grid_transform;
 pub mod image;
 pub mod occupancy_grid;
 pub mod pointcloud;

--- a/horus_core/src/memory/occupancy_grid.rs
+++ b/horus_core/src/memory/occupancy_grid.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use crate::types::{OccupancyGridDescriptor, TensorDtype};
 
+use super::grid_transform;
 use super::tensor_pool::TensorPool;
 use crate::communication::topic::pool_registry::global_pool;
 use crate::error::HorusResult;
@@ -204,17 +205,18 @@ impl OccupancyGrid {
         // range and looked entirely plausible, which for a costmap means a
         // planner confidently avoids the wrong places.
         //
-        // theta == 0 short-circuits to the original arithmetic, so unrotated
-        // maps -- the overwhelmingly common case, and every existing test --
-        // are bit-identical and pay nothing.
-        let (dx, dy) = (x - self.origin_x(), y - self.origin_y());
-        let theta = self.origin_theta();
-        let (rx, ry) = if theta == 0.0 {
-            (dx, dy)
-        } else {
-            let (sin_t, cos_t) = theta.sin_cos();
-            (dx * cos_t + dy * sin_t, -dx * sin_t + dy * cos_t)
-        };
+        // `grid_transform` holds the one copy of this arithmetic shared with
+        // the other grid type, short-circuits theta == 0 to the original
+        // translation (so unrotated maps are bit-identical and pay nothing),
+        // and returns None rather than a NaN that `as i32` would saturate
+        // into a plausible cell (0, 0).
+        let (rx, ry) = grid_transform::world_to_map(
+            self.origin_x(),
+            self.origin_y(),
+            self.origin_theta(),
+            x,
+            y,
+        )?;
         let grid_x = (rx / res + EPSILON).floor() as i32;
         let grid_y = (ry / res + EPSILON).floor() as i32;
 
@@ -234,17 +236,18 @@ impl OccupancyGrid {
         if grid_x < self.width() && grid_y < self.height() {
             // Cell centre in the map frame, rotated INTO the world frame by
             // `origin_theta` and then translated. Exact inverse of
-            // `world_to_grid`, including the theta == 0 short-circuit.
+            // `world_to_grid` -- they share one implementation so they cannot
+            // drift apart -- including the theta == 0 short-circuit and the
+            // refusal of a non-finite origin.
             let mx = (grid_x as f64 + 0.5) * self.resolution() as f64;
             let my = (grid_y as f64 + 0.5) * self.resolution() as f64;
-            let theta = self.origin_theta();
-            let (ox, oy) = if theta == 0.0 {
-                (mx, my)
-            } else {
-                let (sin_t, cos_t) = theta.sin_cos();
-                (mx * cos_t - my * sin_t, mx * sin_t + my * cos_t)
-            };
-            Some((self.origin_x() + ox, self.origin_y() + oy))
+            grid_transform::map_to_world(
+                self.origin_x(),
+                self.origin_y(),
+                self.origin_theta(),
+                mx,
+                my,
+            )
         } else {
             None
         }
@@ -509,5 +512,30 @@ mod origin_theta_tests {
         assert!((wx - 6.5 * res).abs() < 1e-12, "x drifted: {wx}");
         assert!((wy - 2.5 * res).abs() < 1e-12, "y drifted: {wy}");
         assert_eq!(m.world_to_grid(wx, wy), Some((6, 2)));
+    }
+
+    /// A non-finite `origin_theta` must refuse the lookup, not answer it.
+    ///
+    /// `origin_theta` arrives in a Pod descriptor that travels through shared
+    /// memory, so any f64 bit pattern is reachable. `sin_cos()` on NaN is NaN,
+    /// and `(NaN.floor() as i32)` saturates to 0 -- so before the guard this
+    /// returned `Some((0, 0))`: in range, plausible, and wrong for every query
+    /// point on the map.
+    #[test]
+    fn non_finite_origin_theta_refuses_the_lookup() {
+        for theta in [f64::NAN, f64::INFINITY] {
+            let mut m = OccupancyGrid::new(32, 32, RES).expect("alloc");
+            m.set_origin(1.0, -2.0, theta);
+            assert_eq!(
+                m.world_to_grid(1.0, -2.0),
+                None,
+                "theta {theta} must not yield a cell"
+            );
+            assert_eq!(
+                m.grid_to_world(4, 4),
+                None,
+                "theta {theta} must not yield a world point"
+            );
+        }
     }
 }

--- a/horus_core/src/memory/occupancy_grid.rs
+++ b/horus_core/src/memory/occupancy_grid.rs
@@ -195,8 +195,28 @@ impl OccupancyGrid {
     pub fn world_to_grid(&self, x: f64, y: f64) -> Option<(u32, u32)> {
         const EPSILON: f64 = 1e-6;
         let res = (self.resolution() as f64).max(1e-9);
-        let grid_x = ((x - self.origin_x()) / res + EPSILON).floor() as i32;
-        let grid_y = ((y - self.origin_y()) / res + EPSILON).floor() as i32;
+
+        // Translate into the map frame, then UNDO the map's rotation before
+        // dividing by resolution. `origin_theta` is documented as "map origin
+        // orientation (radians)" and was stored, exposed by a getter, and read
+        // by neither transform -- so every lookup on a rotated map silently
+        // returned the wrong cell. Wrong, not absent: the indices stayed in
+        // range and looked entirely plausible, which for a costmap means a
+        // planner confidently avoids the wrong places.
+        //
+        // theta == 0 short-circuits to the original arithmetic, so unrotated
+        // maps -- the overwhelmingly common case, and every existing test --
+        // are bit-identical and pay nothing.
+        let (dx, dy) = (x - self.origin_x(), y - self.origin_y());
+        let theta = self.origin_theta();
+        let (rx, ry) = if theta == 0.0 {
+            (dx, dy)
+        } else {
+            let (sin_t, cos_t) = theta.sin_cos();
+            (dx * cos_t + dy * sin_t, -dx * sin_t + dy * cos_t)
+        };
+        let grid_x = (rx / res + EPSILON).floor() as i32;
+        let grid_y = (ry / res + EPSILON).floor() as i32;
 
         if grid_x >= 0
             && grid_x < self.width() as i32
@@ -212,9 +232,19 @@ impl OccupancyGrid {
     /// Convert grid indices to world coordinates (cell center).
     pub fn grid_to_world(&self, grid_x: u32, grid_y: u32) -> Option<(f64, f64)> {
         if grid_x < self.width() && grid_y < self.height() {
-            let x = self.origin_x() + (grid_x as f64 + 0.5) * self.resolution() as f64;
-            let y = self.origin_y() + (grid_y as f64 + 0.5) * self.resolution() as f64;
-            Some((x, y))
+            // Cell centre in the map frame, rotated INTO the world frame by
+            // `origin_theta` and then translated. Exact inverse of
+            // `world_to_grid`, including the theta == 0 short-circuit.
+            let mx = (grid_x as f64 + 0.5) * self.resolution() as f64;
+            let my = (grid_y as f64 + 0.5) * self.resolution() as f64;
+            let theta = self.origin_theta();
+            let (ox, oy) = if theta == 0.0 {
+                (mx, my)
+            } else {
+                let (sin_t, cos_t) = theta.sin_cos();
+                (mx * cos_t - my * sin_t, mx * sin_t + my * cos_t)
+            };
+            Some((self.origin_x() + ox, self.origin_y() + oy))
         } else {
             None
         }
@@ -418,5 +448,66 @@ mod tests {
         assert!(dbg.contains("OccupancyGrid"));
         assert!(dbg.contains("100"));
         assert!(dbg.contains("200"));
+    }
+}
+
+#[cfg(test)]
+mod origin_theta_tests {
+    use super::*;
+
+    const RES: f32 = 0.05;
+
+    /// A rotated map must round-trip: grid -> world -> grid returns the cell.
+    ///
+    /// `origin_theta` is documented as the map origin's orientation and was
+    /// read by neither transform. On a map rotated 90 degrees this returned a
+    /// cell that was in range and plausible and simply wrong, so a planner
+    /// avoided the wrong places with no error anywhere.
+    #[test]
+    fn rotated_map_round_trips_grid_to_world_to_grid() {
+        let mut m = OccupancyGrid::new(32, 32, RES).expect("alloc");
+        m.set_origin(1.0, -2.0, std::f64::consts::FRAC_PI_2);
+        for &(gx, gy) in &[(0u32, 0u32), (3, 7), (19, 11)] {
+            let (wx, wy) = m.grid_to_world(gx, gy).expect("in range");
+            let back = m.world_to_grid(wx, wy);
+            assert_eq!(
+                back,
+                Some((gx, gy)),
+                "cell ({gx},{gy}) -> world ({wx:.4},{wy:.4}) -> {back:?} on a \
+                 map rotated by origin_theta"
+            );
+        }
+    }
+
+    /// The rotation must actually be applied, not merely round-trip with
+    /// itself. A 90-degree map sends +x in the map frame to +y in the world.
+    #[test]
+    fn ninety_degrees_maps_map_x_onto_world_y() {
+        let mut m = OccupancyGrid::new(32, 32, RES).expect("alloc");
+        m.set_origin(1.0, -2.0, std::f64::consts::FRAC_PI_2);
+        let (wx, wy) = m.grid_to_world(4, 0).expect("in range");
+        // Cell (4,0) centre is (4.5*res, 0.5*res) in the map frame. Rotated by
+        // +90 degrees that is (-0.5*res, 4.5*res), then translated by the
+        // origin (1.0, -2.0).
+        let res = RES as f64;
+        let (ex, ey) = (1.0 + -0.5 * res, -2.0 + 4.5 * res);
+        assert!(
+            (wx - ex).abs() < 1e-6 && (wy - ey).abs() < 1e-6,
+            "expected map +x to become world +y: wanted ({ex:.6}, {ey:.6}), \
+             got ({wx:.6}, {wy:.6})"
+        );
+    }
+
+    /// theta == 0 must be bit-identical to the original translation-only
+    /// arithmetic, so unrotated maps -- every existing caller -- are untouched.
+    #[test]
+    fn unrotated_map_is_unchanged() {
+        let mut m = OccupancyGrid::new(32, 32, RES).expect("alloc");
+        m.set_origin(0.0, 0.0, 0.0);
+        let (wx, wy) = m.grid_to_world(6, 2).expect("in range");
+        let res = RES as f64;
+        assert!((wx - 6.5 * res).abs() < 1e-12, "x drifted: {wx}");
+        assert!((wy - 2.5 * res).abs() < 1e-12, "y drifted: {wy}");
+        assert_eq!(m.world_to_grid(wx, wy), Some((6, 2)));
     }
 }


### PR DESCRIPTION
`origin_theta` is stored on both `OccupancyGridDescriptor` and
`CostMapDescriptor`, documented as *"map origin orientation (radians)"*, and
exposed by a getter on both wrappers.

**Neither `world_to_grid` nor `grid_to_world` ever read it.** Both did
translation only:

```rust
let grid_x = ((x - self.origin_x()) / res + EPSILON).floor() as i32;
let grid_y = ((y - self.origin_y()) / res + EPSILON).floor() as i32;
```

So every coordinate conversion on a rotated map was wrong — **wrong, not
absent**. The indices stayed in range and looked entirely plausible. For a
costmap that means a planner confidently treats the wrong cells as occupied,
with no error anywhere and nothing in the API hinting the rotation was dropped.

The only existing coverage was `assert_eq!(grid.origin_theta(), 1.57)`, which
checks the field round-trips through *storage* — not that anything reads it.

## The fix

`world_to_grid` translates into the map frame and **undoes** the rotation before
dividing by resolution. `grid_to_world` rotates the cell centre **into** the
world frame and then translates. Exact inverses.

`theta == 0.0` short-circuits to the original arithmetic, so unrotated maps —
the common case, and every existing caller and test — are bit-identical and pay
neither the `sin_cos` nor the multiplies.

## Why there are two tests, not one

A round-trip test **passes against the bug**: a translation-only transform is a
perfect inverse of itself, so `grid → world → grid` returns the original cell
whether or not rotation is applied.

Confirmed by ablation — forcing the `theta == 0` branch leaves
`rotated_map_round_trips_grid_to_world_to_grid` green and fails only
`ninety_degrees_maps_map_x_onto_world_y`, which pins the actual geometry: a
90° map sends +x in the map frame to +y in the world.

```
wanted (0.975000, -1.775000), got (1.225000, -1.975000)
```

2503 lib tests pass; fmt and clippy clean under `-D warnings`.