### PR TITLE
docs(changelog): the Python suite figures are the ones this tag ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,7 +276,7 @@ section is.
 
 ### Testing
 
-- The Python suite runs in CI for the first time: 413 test functions, 442 cases.
+- The Python suite runs in CI for the first time: 421 test functions, 450 cases.
   Nothing had ever invoked pytest, and `--exclude horus_py` appears in every
   other Rust gate, so the binding layer had no coverage at all.
 - 55 `horus_core` tests that were compiled but never executed now run — the


### PR DESCRIPTION
`[0.4.1]` says the Python suite is **413 test functions, 442 cases**. The tree it describes has **421**, and pytest collects **450**.

```
$ grep -rhE '^[[:space:]]*def test_' horus_py/tests/*.py | wc -l
421
$ cd horus_py && python3 -m pytest tests/ --collect-only -q
========================= 450 tests collected =========================
```

413/442 was exact when #129 wrote it — measured on its own branch, where pytest collected 442. The extra eight arrived from two other branches that had no reason to touch a changelog: five from `test_readme_claims_match_code.py` (came with #146) and three from #154's Imu orientation tests. Each branch was internally consistent; only the merged tree is wrong.

The `ci.yml` comment that also says 413/442 is left alone — it describes what "sat in the tree looking like coverage while gating nothing" at the moment the gap was found, which was true then.

Found by a sweep for defects that exist only in the merge; it was the single confirmed finding out of five dimensions searched.