### PR TITLE
fix(pypi): the sdist declared a LICENSE it did not carry at that path

### DIFF
--- a/horus_py/pyproject.toml
+++ b/horus_py/pyproject.toml
@@ -8,7 +8,8 @@ version = "0.4.1"
 description = "Simple & intuitive Python API for HORUS robotics framework - ultra-low latency IPC and real-time scheduling"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     {name = "HORUS Contributors"}
 ]


### PR DESCRIPTION
`v0.4.1` published **all five wheels** and then PyPI refused the sdist:

```
400 License-File LICENSE does not exist in distribution file
horus_robotics-0.4.1.tar.gz at horus_robotics-0.4.1/LICENSE
```

## What is actually wrong

maturin roots a workspace member's sdist at the **workspace**, so `horus_py/LICENSE` is packed at `<root>/horus_py/LICENSE`. The metadata that `license = {text = "Apache-2.0"}` produces declares `License-File: LICENSE`, which PyPI resolves against the **sdist root**. The file was in the archive the whole time; the metadata pointed somewhere it wasn't.

Declaring `license-files` explicitly (PEP 639) makes maturin place the file where the metadata says it is.

## Verified against the maturin CI actually ran

The failing run used **maturin 1.15.0** (`gh run view 33849553498 --log | grep -i maturin`), so this was reproduced and fixed against that version, not a convenient local one.

| | sdist contents | PKG-INFO |
|---|---|---|
| before | `horus_py/LICENSE` only | `License-File: LICENSE` · `License: Apache-2.0` |
| after | `LICENSE` **at root** + `horus_py/LICENSE` | `License-File: LICENSE` · `License-Expression: Apache-2.0` |

`twine check` — which runs PyPI's own metadata validation — goes from the 400 above to `PASSED`.

## What this does not do

It does **not** backfill 0.4.1's sdist. The publish step deliberately omits `--skip-existing`, on the reasoning that a version already on PyPI means the tag did not bump `pyproject.toml` and should be a red run rather than a quiet pass. Re-running the tag would therefore fail on the five wheels already uploaded. The sdist ships with the next release.

## Not a regression from the auth work

Worth separating, because the previous failure looked similar and was not: v0.4.0 died at `403 Invalid or non-existent authentication information`. **Trusted publishing worked this time** — the run minted an OIDC token, signed with sigstore and got Rekor entries, and all five wheels are live on PyPI. This 400 is a packaging defect, not a credentials one.