### PR TITLE
perf(rt): no lock and no name hashing on the RT tick path

### DIFF
--- a/horus_core/src/core/tick_context.rs
+++ b/horus_core/src/core/tick_context.rs
@@ -84,7 +84,48 @@ pub fn set_tick_context(
     tick_start: ClockInstant,
     budget: Option<Duration>,
 ) {
-    let seed = deterministic_seed(tick_number, node_name);
+    set_tick_context_with_hash(
+        node_name,
+        hash_node_name(node_name),
+        tick_number,
+        clock,
+        dt,
+        sim_time,
+        tick_start,
+        budget,
+    )
+}
+
+/// `set_tick_context` for a caller that already knows the node's name hash.
+///
+/// The RNG seed is `f(tick_number, hash(node_name))`, and this runs once per
+/// node per tick — so the by-name form above re-derives a per-node CONSTANT on
+/// every period. At 1 kHz that is one SipHash per node per millisecond, ~25 ns
+/// each, to obtain a value that cannot have changed.
+///
+/// It is deliberately a parameter rather than a memo on the context. A memo
+/// would have to be keyed on the name and revalidated, and it only ever hits
+/// when the SAME node is entered twice in a row — which for a multi-node chain
+/// is never, since the executor walks A, B, C, A, B, C and the name differs on
+/// every call. Measured, that memo cost 5 ns per tick more than it saved on any
+/// chain longer than one node. An executor that resolved the hash once at
+/// thread start pays nothing here at all.
+///
+/// `name_hash` MUST be `hash_node_name(node_name)`; passing anything else
+/// silently changes `horus::rng()`'s stream for that node.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub fn set_tick_context_with_hash(
+    node_name: &str,
+    name_hash: u64,
+    tick_number: u64,
+    clock: &dyn Clock,
+    dt: Duration,
+    sim_time: Duration,
+    tick_start: ClockInstant,
+    budget: Option<Duration>,
+) {
+    let seed = seed_from_parts(tick_number, name_hash);
     let rng = SmallRng::seed_from_u64(seed);
     // Erase the trait object's lifetime so the pointer can live in a `'static`
     // thread-local.
@@ -246,13 +287,24 @@ pub fn ctx_with_rng<R>(f: impl FnOnce(&mut SmallRng) -> R) -> R {
 
 /// Deterministic seed from tick number + node name.
 /// Same tick + same name → same seed → same RNG sequence.
-fn deterministic_seed(tick_number: u64, node_name: &str) -> u64 {
+pub(crate) fn hash_node_name(node_name: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     node_name.hash(&mut hasher);
-    let name_hash = hasher.finish();
+    hasher.finish()
+}
+
+fn seed_from_parts(tick_number: u64, name_hash: u64) -> u64 {
     tick_number
         .wrapping_mul(0x517cc1b727220a95)
         .wrapping_add(name_hash)
+}
+
+/// Unchanged in behaviour — `seed_from_parts(tick, hash_node_name(name))` is
+/// the same expression the single function used to evaluate inline. Kept so the
+/// property test below can assert the memoized path agrees with it.
+#[cfg(test)]
+pub(crate) fn deterministic_seed(tick_number: u64, node_name: &str) -> u64 {
+    seed_from_parts(tick_number, hash_node_name(node_name))
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -262,7 +314,188 @@ mod tests {
     use super::*;
     use crate::core::clock::SimClock;
     use crate::core::duration_ext::DurationExt;
+    use rand::RngCore;
 
+    /// What resolving the node-name hash once removes from each tick.
+    ///
+    /// Also records the road not taken. Memoizing the hash on the thread-local
+    /// context — comparing the name and reusing the hash when it matches — is
+    /// the obvious cheaper-looking fix, and it is worse: it only HITS when the
+    /// same node is entered twice in a row, which for a multi-node chain never
+    /// happens, because the executor walks A, B, C, A, B, C and the name
+    /// differs on every call. On a miss it pays the comparison AND the hash.
+    /// The numbers below are why this file takes the hash as a parameter
+    /// instead.
+    ///
+    /// `#[ignore]`d: a stopwatch, not an assertion. Run with:
+    ///
+    /// ```text
+    /// cargo test -p horus_core --release name_hash_cost -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "stopwatch, not an assertion — run manually with --ignored"]
+    fn name_hash_cost() {
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        const N: usize = 2_000_000;
+        let name = "perception_stage_3";
+        let other = "perception_stage_4";
+
+        // What the old path paid every tick, and what passing the hash removes.
+        let t = Instant::now();
+        let mut acc = 0u64;
+        for _ in 0..N {
+            acc ^= hash_node_name(black_box(name));
+        }
+        black_box(acc);
+        let hashing = t.elapsed().as_nanos() as f64 / N as f64;
+
+        // A thread-local memo, had it hit: the guard comparison alone.
+        let t = Instant::now();
+        let mut hits = 0u64;
+        for _ in 0..N {
+            hits += (black_box(name) == black_box(name)) as u64;
+        }
+        black_box(hits);
+        let memo_hit = t.elapsed().as_nanos() as f64 / N as f64;
+
+        // The same memo on a miss, which is what a multi-node chain always gets.
+        let t = Instant::now();
+        let mut acc = 0u64;
+        for _ in 0..N {
+            if black_box(name) != black_box(other) {
+                acc ^= hash_node_name(black_box(other));
+            }
+        }
+        black_box(acc);
+        let memo_miss = t.elapsed().as_nanos() as f64 / N as f64;
+
+        println!("\n  node-name hash, per node per tick:");
+        println!("    recompute every tick (what this replaces): {hashing:6.2} ns");
+        println!("    resolved once at thread start (now)      :   0.00 ns");
+        println!("    -- the memo alternative, for the record --");
+        println!("    memo hit  (single-node chain only)       : {memo_hit:6.2} ns");
+        println!("    memo miss (any chain of 2+ nodes)        : {memo_miss:6.2} ns");
+        println!(
+            "    => a memo LOSES {:.2} ns/tick on a multi-node chain\n",
+            memo_miss - hashing
+        );
+    }
+
+    /// The precomputed-hash path must produce a bit-identical seed to the
+    /// by-name path, for every node and every tick.
+    ///
+    /// This is the whole correctness burden of letting the RT executor resolve
+    /// `hash_node_name` once at thread start and pass it in. `horus::rng()` is
+    /// documented as deterministic in (tick, node) — replay, simulation
+    /// reproducibility and every seeded-fixture test rest on it. If the two
+    /// paths disagreed, nothing would fail loudly: RT nodes would simply draw a
+    /// different random stream than the same node drew on the main loop, and
+    /// two runs of the same scenario would quietly diverge.
+    #[test]
+    fn the_precomputed_hash_path_seeds_identically_to_the_by_name_path() {
+        let clock = SimClock::new();
+
+        // A first draw from a freshly seeded RNG identifies the seed: SmallRng
+        // is a pure function of it.
+        fn draw(hashed: bool, name: &str, tick: u64, clock: &SimClock) -> u64 {
+            if hashed {
+                set_tick_context_with_hash(
+                    name,
+                    hash_node_name(name),
+                    tick,
+                    clock,
+                    Duration::from_millis(1),
+                    Duration::ZERO,
+                    ClockInstant::from_nanos(0),
+                    None,
+                );
+            } else {
+                set_tick_context(
+                    name,
+                    tick,
+                    clock,
+                    Duration::from_millis(1),
+                    Duration::ZERO,
+                    ClockInstant::from_nanos(0),
+                    None,
+                );
+            }
+            let drawn = ctx_with_rng(|r| r.next_u64());
+            clear_tick_context();
+            drawn
+        }
+
+        for name in ["perception", "control", "", "a", "perception_stage_11"] {
+            for tick in 0..8u64 {
+                let by_name = draw(false, name, tick, &clock);
+                let precomputed = draw(true, name, tick, &clock);
+                assert_eq!(
+                    by_name, precomputed,
+                    "precomputed hash changed the RNG stream for {name:?} at tick {tick}"
+                );
+                // ...and both must equal the seed the documented formula gives.
+                assert_eq!(
+                    by_name,
+                    SmallRng::seed_from_u64(deterministic_seed(tick, name)).next_u64(),
+                    "the seed for {name:?} at tick {tick} is no longer f(tick, hash(name))"
+                );
+            }
+        }
+
+        // Distinct nodes on the same tick must still differ — the property the
+        // per-node hash exists to provide.
+        assert_ne!(
+            draw(true, "perception", 3, &clock),
+            draw(true, "control", 3, &clock)
+        );
+    }
+
+    /// Interleaving nodes on one thread must not let one node's seed leak into
+    /// another's.
+    ///
+    /// An executor thread walks its whole chain every period — A, B, C, A, B,
+    /// C — reusing one thread-local context, and a mixed-rate chain also
+    /// produces runs like A, A, ..., A, B, A, A where a node repeats. Any
+    /// per-thread caching of the name or its hash has to survive both shapes.
+    #[test]
+    fn interleaved_nodes_on_one_thread_keep_their_own_seeds() {
+        let clock = SimClock::new();
+
+        let draw = |name: &str, tick: u64| {
+            set_tick_context_with_hash(
+                name,
+                hash_node_name(name),
+                tick,
+                &clock,
+                Duration::from_millis(1),
+                Duration::ZERO,
+                ClockInstant::from_nanos(0),
+                None,
+            );
+            let d = ctx_with_rng(|r| r.next_u64());
+            clear_tick_context();
+            d
+        };
+        let expect = |name: &str, tick: u64| {
+            SmallRng::seed_from_u64(deterministic_seed(tick, name)).next_u64()
+        };
+
+        // Round-robin, the multi-node chain shape.
+        for tick in 0..4u64 {
+            for name in ["a_node", "b_node", "c_node"] {
+                assert_eq!(draw(name, tick), expect(name, tick), "{name} at {tick}");
+            }
+        }
+
+        // A node repeating right after a different one ran, the mixed-rate shape.
+        for tick in 0..4u64 {
+            let _ = draw("slow_planner", tick);
+            assert_eq!(draw("fast_servo", tick), expect("fast_servo", tick));
+            assert_eq!(draw("fast_servo", tick + 1), expect("fast_servo", tick + 1));
+        }
+    }
     #[test]
     fn ctx_now_fallback_outside_tick() {
         clear_tick_context();

--- a/horus_core/src/scheduling/async_executor.rs
+++ b/horus_core/src/scheduling/async_executor.rs
@@ -211,6 +211,7 @@ impl AsyncExecutor {
                             node_ref,
                             &*clock,
                             ctx_tick_period,
+                            None,
                         );
                         let tr = NodeRunner::run_tick(&mut node_ref.node);
                         super::primitives::clear_node_tick_context();

--- a/horus_core/src/scheduling/compute_executor.rs
+++ b/horus_core/src/scheduling/compute_executor.rs
@@ -167,7 +167,7 @@ impl TickContextGuard {
         clock: &dyn crate::core::clock::Clock,
         tick_period: Duration,
     ) -> Self {
-        super::primitives::set_node_tick_context(node, clock, tick_period);
+        super::primitives::set_node_tick_context(node, clock, tick_period, None);
         Self
     }
 }

--- a/horus_core/src/scheduling/event_executor.rs
+++ b/horus_core/src/scheduling/event_executor.rs
@@ -408,6 +408,7 @@ impl EventExecutor {
                     &node,
                     &*monitors.clock,
                     monitors.tick_period,
+                    None,
                 );
                 let tr = NodeRunner::run_tick(&mut node.node);
                 super::primitives::clear_node_tick_context();

--- a/horus_core/src/scheduling/primitives.rs
+++ b/horus_core/src/scheduling/primitives.rs
@@ -77,10 +77,42 @@ pub(crate) fn honor_safe_state_request(
     node: &mut RegisteredNode,
     monitors: &super::types::SharedMonitors,
 ) {
-    if !monitors
+    let requested = monitors
         .node_controls
-        .take_safe_state_request(node.name.as_ref())
-    {
+        .take_safe_state_request(node.name.as_ref());
+    honor_safe_state_request_with(node, requested, monitors);
+}
+
+/// `honor_safe_state_request` for a caller that already holds the node's
+/// control block.
+///
+/// The by-name form above takes an `RwLock` read guard and hashes the node
+/// name to find a pair of atomics. An RT tick loop calling it once per node
+/// per tick pays that on every period for a flag that changes at most once in
+/// the life of a fault — and pays it holding a lock with no priority
+/// inheritance. A caller that resolved `NodeControlMap::handle` at startup
+/// passes the block straight in and the check costs one atomic swap.
+///
+/// `None` means the node was never registered, which the by-name form reports
+/// as "no request pending"; this keeps that exactly.
+pub(crate) fn honor_safe_state_request_via(
+    node: &mut RegisteredNode,
+    control: Option<&super::types::NodeControl>,
+    monitors: &super::types::SharedMonitors,
+) {
+    let requested = control.is_some_and(|c| {
+        c.safe_state_requested
+            .swap(false, std::sync::atomic::Ordering::AcqRel)
+    });
+    honor_safe_state_request_with(node, requested, monitors);
+}
+
+fn honor_safe_state_request_with(
+    node: &mut RegisteredNode,
+    requested: bool,
+    monitors: &super::types::SharedMonitors,
+) {
+    if !requested {
         return;
     }
 
@@ -275,6 +307,7 @@ pub(crate) fn set_node_tick_context(
     node: &RegisteredNode,
     clock: &dyn crate::core::clock::Clock,
     tick_period: Duration,
+    name_hash: Option<u64>,
 ) {
     // Read the tick number the same way run_node_tick does: after start_tick()
     // (already called by the executor) and before record_tick().
@@ -311,8 +344,14 @@ pub(crate) fn set_node_tick_context(
     // process start, which needs 584 years of uptime to exceed `u64::MAX` ns.
     let sim_time = clock.elapsed();
     let tick_start_ci = crate::core::clock::ClockInstant::from_nanos(sim_time.as_nanos() as u64);
-    crate::core::tick_context::set_tick_context(
+    // `name_hash` is the node-name hash the caller resolved once, if it did.
+    // The RT executor does; the other executors and the main loop pass `None`
+    // and pay the hash here, exactly as before.
+    let name_hash =
+        name_hash.unwrap_or_else(|| crate::core::tick_context::hash_node_name(&node.name));
+    crate::core::tick_context::set_tick_context_with_hash(
         &node.name,
+        name_hash,
         tick_number,
         clock,
         node_dt,

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -1221,6 +1221,8 @@ impl RtExecutor {
         running: &Arc<AtomicBool>,
         is_first_tick: bool,
         release_late_ns: u64,
+        registry_slot: Option<usize>,
+        name_hash: u64,
     ) {
         // Failure-policy backoff (Restart) / cooldown (Skip): skip this tick
         // while the node is suppressed.
@@ -1275,7 +1277,12 @@ impl RtExecutor {
         // run_node_tick. Set BEFORE entering the alloc-free guard — the first
         // set_tick_context allocates its RNG + node-name string, which must not
         // trip `.no_alloc()`.
-        super::primitives::set_node_tick_context(node, &*monitors.clock, monitors.tick_period);
+        super::primitives::set_node_tick_context(
+            node,
+            &*monitors.clock,
+            monitors.tick_period,
+            Some(name_hash),
+        );
 
         if enforce_no_alloc {
             crate::memory::rt_allocator::enter_rt_context(&node.name);
@@ -1658,7 +1665,7 @@ impl RtExecutor {
         }
 
         // Update live SHM registry AFTER record_tick() so tick_count is current
-        monitors.update_registry(node, tr.duration.as_nanos() as u64);
+        monitors.update_registry_slot_of(node, registry_slot, tr.duration.as_nanos() as u64);
     }
 
     /// Main function for the RT thread.
@@ -1903,6 +1910,36 @@ impl RtExecutor {
         // first recv/send) may allocate; steady-state ticks are then enforced.
         let mut warmed = vec![false; nodes.len()];
 
+        // Per-node control blocks, resolved ONCE, aligned with `nodes`.
+        //
+        // The three flag checks below (safe-state, stopped, paused) used to be
+        // `monitors.node_controls.<x>(node.name)` — each an `RwLock` read guard
+        // plus a SipHash of the name plus a `HashMap` probe, three times per
+        // node per tick. Resolving the `Arc` here turns the steady state into
+        // three relaxed atomic loads and, more importantly, takes a lock with
+        // no priority inheritance out of the tick path entirely.
+        //
+        // `None` for a node that was never registered; every check below then
+        // reads the same "not set" the by-name accessors returned for a miss.
+        let controls: Vec<Option<Arc<super::types::NodeControl>>> = nodes
+            .iter()
+            .map(|n| monitors.node_controls.handle(n.name.as_ref()))
+            .collect();
+
+        // Registry slots, likewise resolved once. Together with `controls` this
+        // leaves the steady-state tick path with no hash of a node name in it.
+        let registry_slots: Vec<Option<usize>> = nodes
+            .iter()
+            .map(|n| monitors.registry_slots.get(n.name.as_ref()).copied())
+            .collect();
+
+        // And the node-name hash the per-tick RNG reseed needs, which is a
+        // per-node constant that used to be recomputed every period.
+        let name_hashes: Vec<u64> = nodes
+            .iter()
+            .map(|n| crate::core::tick_context::hash_node_name(n.name.as_ref()))
+            .collect();
+
         // Cyclic cadence on an absolute phase grid. Constructed here, after all
         // the one-time setup above, so the phase anchor is not polluted by
         // affinity/governor/IRQ work that only happens once.
@@ -1922,18 +1959,24 @@ impl RtExecutor {
                     continue;
                 }
 
+                let control = controls[idx].as_deref();
+
                 // Safing requested by the main thread's watchdog ladder. Runs
                 // before the pause/stop gates: an Isolated node must reach its
                 // safe state even if it is also about to be stopped.
-                super::primitives::honor_safe_state_request(node, &monitors);
+                super::primitives::honor_safe_state_request_via(node, control, &monitors);
 
-                // Check shared control flags (set by CLI: horus node pause/kill)
-                if monitors.node_controls.is_stopped(node.name.as_ref()) {
-                    node.is_stopped = true;
-                    continue;
-                }
-                if monitors.node_controls.is_paused(node.name.as_ref()) {
-                    continue; // Skip tick but don't auto-unpause
+                // Check shared control flags (set by CLI: horus node pause/kill).
+                // Unregistered node (`None`) reads as neither stopped nor
+                // paused, matching what the by-name accessors returned on a miss.
+                if let Some(c) = control {
+                    if c.stopped.load(Ordering::Relaxed) {
+                        node.is_stopped = true;
+                        continue;
+                    }
+                    if c.paused.load(Ordering::Relaxed) {
+                        continue; // Skip tick but don't auto-unpause
+                    }
                 }
 
                 // Auto-unpause (Miss::Skip skips one tick)
@@ -1976,7 +2019,15 @@ impl RtExecutor {
                 // continues ticking remaining nodes.
                 let is_first_tick = !warmed[idx];
                 let infra_result = catch_unwind(AssertUnwindSafe(|| {
-                    Self::tick_node(node, &monitors, &running, is_first_tick, release_late_ns)
+                    Self::tick_node(
+                        node,
+                        &monitors,
+                        &running,
+                        is_first_tick,
+                        release_late_ns,
+                        registry_slots[idx],
+                        name_hashes[idx],
+                    )
                 }));
                 warmed[idx] = true;
 
@@ -2164,7 +2215,7 @@ mod tests {
 
         // The RT loop wraps `tick_node` exactly like this.
         let outcome = catch_unwind(AssertUnwindSafe(|| {
-            RtExecutor::tick_node(&mut node, &monitors, &running, true, 0)
+            RtExecutor::tick_node(&mut node, &monitors, &running, true, 0, None, 0)
         }));
 
         assert!(
@@ -2337,6 +2388,8 @@ mod tests {
             &Arc::new(AtomicBool::new(true)),
             true,
             0,
+            None,
+            0,
         );
 
         assert_eq!(
@@ -2399,6 +2452,93 @@ mod tests {
             use_sched_deadline: false,
             no_alloc: false,
         }
+    }
+
+    /// `horus node pause` / `kill` must still reach a node the RT executor is
+    /// already running.
+    ///
+    /// The tick loop resolves each node's control block ONCE, at thread start,
+    /// instead of looking it up by name every tick. That is only correct
+    /// because `Scheduler::run` registers every node in the control map before
+    /// it calls `start_pool` — an ordering the two sites do not state and
+    /// nothing else enforces. If a later change registers after the pool
+    /// starts, every handle resolves to `None` and the operator's pause and
+    /// kill commands go nowhere: the flags would still be set, and read by
+    /// nobody. Nothing would panic, and no test of the control map itself would
+    /// notice, because the map would be perfectly correct — just unobserved.
+    ///
+    /// So assert the end-to-end behaviour rather than the ordering: set the
+    /// flag from outside on a pool that is already ticking, and require the
+    /// ticks to stop.
+    #[test]
+    fn cli_pause_reaches_a_running_rt_node_through_its_cached_handle() {
+        use std::sync::atomic::{AtomicU64, Ordering as AOrd};
+
+        let count = Arc::new(AtomicU64::new(0));
+        let node = make_rt_registered("pause_target", count.clone());
+
+        let mut monitors = test_monitors();
+        monitors.verbose = false;
+        monitors.node_controls.register("pause_target");
+
+        let running = Arc::new(AtomicBool::new(true));
+        let exec = start_pool_for_test(
+            vec![vec![node]],
+            running.clone(),
+            Duration::from_millis(1),
+            monitors.clone(),
+            vec![],
+        )
+        .expect("pool should start");
+
+        // It must actually be ticking before pausing proves anything.
+        let mut waited = Duration::ZERO;
+        while count.load(AOrd::Relaxed) == 0 && waited < Duration::from_secs(5) {
+            std::thread::sleep(Duration::from_millis(5));
+            waited += Duration::from_millis(5);
+        }
+        assert!(
+            count.load(AOrd::Relaxed) > 0,
+            "node never ticked, so this test cannot say anything about pausing"
+        );
+
+        monitors.node_controls.set_paused("pause_target", true);
+
+        // Let any tick already in flight finish before sampling.
+        std::thread::sleep(Duration::from_millis(50));
+        let after_pause = count.load(AOrd::Relaxed);
+        std::thread::sleep(Duration::from_millis(150));
+        let settled = count.load(AOrd::Relaxed);
+
+        // Resuming must bring it back, so the test cannot pass by the node
+        // having simply died.
+        monitors.node_controls.set_paused("pause_target", false);
+        std::thread::sleep(Duration::from_millis(150));
+        let resumed = count.load(AOrd::Relaxed);
+
+        // Stop the pool BEFORE asserting, and do it unconditionally.
+        //
+        // `RtExecutor::drop` joins its threads, and those threads only leave
+        // the tick loop when `running` goes false. An assertion that fires
+        // before this line therefore unwinds into a `join` that never returns:
+        // the test HANGS instead of failing. That is not hypothetical — it is
+        // what the first version of this test did when the regression it
+        // guards was deliberately introduced, and a hang costs a CI job its
+        // whole timeout while reporting nothing about the cause.
+        running.store(false, AOrd::Relaxed);
+        drop(exec);
+
+        assert_eq!(
+            settled,
+            after_pause,
+            "the node kept ticking {} times after `pause` — the executor is not \
+             observing the control flag it cached at startup",
+            settled - after_pause
+        );
+        assert!(
+            resumed > settled,
+            "the node never resumed after `pause` was cleared"
+        );
     }
 
     #[test]
@@ -4120,6 +4260,87 @@ mod tests {
             *self.observed_dt.lock().unwrap() = Some(dt);
             *self.observed_budget.lock().unwrap() = Some(budget);
             self.ticked.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// An RT node's `horus::rng()` must draw the same stream it would draw
+    /// anywhere else.
+    ///
+    /// The executor resolves each node's name hash ONCE at thread start and
+    /// passes it to `set_tick_context_with_hash`, rather than re-hashing the
+    /// name every tick. Nothing about that is visible in a tick's timing or its
+    /// result, so if the executor ever resolved the hash from the wrong thing —
+    /// a chain label, a stale index, the previous node — RT nodes would simply
+    /// draw a DIFFERENT random stream than the same node draws on the main
+    /// loop, and no existing test would notice. `dt` and `budget` are checked
+    /// above; the seed was not.
+    ///
+    /// `horus::rng()` is documented as deterministic in (tick, node), so pin it
+    /// to that formula from inside a real executor tick.
+    #[test]
+    fn an_rt_node_draws_the_documented_rng_stream_for_its_name_and_tick() {
+        use rand::{RngCore, SeedableRng};
+
+        struct RngProbe {
+            name: String,
+            seen: Arc<Mutex<Vec<(u64, u64)>>>,
+        }
+        impl Node for RngProbe {
+            fn name(&self) -> &str {
+                &self.name
+            }
+            fn tick(&mut self) {
+                let tick = crate::core::tick_context::ctx_tick();
+                let drawn = crate::core::tick_context::ctx_with_rng(|r| r.next_u64());
+                self.seen.lock().unwrap().push((tick, drawn));
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mut reg =
+            make_rt_registered("rng_probe", Arc::new(std::sync::atomic::AtomicU64::new(0)));
+        reg.node = super::super::types::NodeKind::new(Box::new(RngProbe {
+            name: "rng_probe".to_string(),
+            seen: seen.clone(),
+        }));
+
+        let running = Arc::new(AtomicBool::new(true));
+        let mut monitors = test_monitors();
+        monitors.verbose = false;
+        let executor = start_pool_for_test(
+            vec![vec![reg]],
+            running.clone(),
+            1_u64.ms(),
+            monitors,
+            Vec::new(),
+        )
+        .unwrap();
+
+        for _ in 0..100 {
+            if seen.lock().unwrap().len() >= 3 {
+                break;
+            }
+            std::thread::sleep(5_u64.ms());
+        }
+        running.store(false, Ordering::SeqCst);
+        let _ = executor.stop();
+
+        let seen = seen.lock().unwrap();
+        assert!(
+            seen.len() >= 3,
+            "probe must have ticked at least 3 times, got {}",
+            seen.len()
+        );
+        for &(tick, drawn) in seen.iter() {
+            let expected = rand::rngs::SmallRng::seed_from_u64(
+                crate::core::tick_context::deterministic_seed(tick, "rng_probe"),
+            )
+            .next_u64();
+            assert_eq!(
+                drawn, expected,
+                "RT node 'rng_probe' drew the wrong stream at tick {tick} — the \
+                 executor is passing a name hash that is not hash(\"rng_probe\")"
+            );
         }
     }
 

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -1224,6 +1224,7 @@ impl RtExecutor {
         registry_slot: Option<usize>,
         name_hash: u64,
         timing: Option<&super::safety_monitor::NodeTimingState>,
+        watchdog: Option<&super::safety_monitor::Watchdog>,
     ) {
         // Failure-policy backoff (Restart) / cooldown (Skip): skip this tick
         // while the node is suppressed.
@@ -1574,8 +1575,15 @@ impl RtExecutor {
                 // still trips expiry. Feeding the wrong (non-critical) node is a
                 // harmless no-op (no watchdog registered for it).
                 if node.is_rt_node || node.node_watchdog.is_some() {
-                    if let Some(ref feeder) = monitors.watchdog {
-                        feeder.feed(&node.name);
+                    match watchdog {
+                        // Resolved at thread start: two atomic stores, no map,
+                        // no lock, no hash of the node name.
+                        Some(w) => w.feed(),
+                        None => {
+                            if let Some(ref feeder) = monitors.watchdog {
+                                feeder.feed(&node.name);
+                            }
+                        }
                     }
                 }
 
@@ -1969,6 +1977,18 @@ impl RtExecutor {
         // Per-node budget/deadline accounting, resolved once. This one took a
         // process-wide `Mutex<BudgetEnforcer>` shared by every RT chain, so its
         // cost grew with the number of chains rather than staying flat.
+        // Watchdogs, resolved once. The feed itself is two atomic stores; it
+        // was reached through an `RwLock<HashMap<String, _>>` every tick.
+        let watchdogs: Vec<Option<Arc<super::safety_monitor::Watchdog>>> = nodes
+            .iter()
+            .map(|n| {
+                monitors
+                    .watchdog
+                    .as_ref()
+                    .and_then(|f| f.handle(n.name.as_ref()))
+            })
+            .collect();
+
         let timings: Vec<Option<Arc<super::safety_monitor::NodeTimingState>>> = nodes
             .iter()
             .map(|n| {
@@ -2067,6 +2087,7 @@ impl RtExecutor {
                         registry_slots[idx],
                         name_hashes[idx],
                         timings[idx].as_deref(),
+                        watchdogs[idx].as_deref(),
                     )
                 }));
                 warmed[idx] = true;
@@ -2255,7 +2276,7 @@ mod tests {
 
         // The RT loop wraps `tick_node` exactly like this.
         let outcome = catch_unwind(AssertUnwindSafe(|| {
-            RtExecutor::tick_node(&mut node, &monitors, &running, true, 0, None, 0, None)
+            RtExecutor::tick_node(&mut node, &monitors, &running, true, 0, None, 0, None, None)
         }));
 
         assert!(
@@ -2430,6 +2451,7 @@ mod tests {
             0,
             None,
             0,
+            None,
             None,
         );
 

--- a/horus_core/src/scheduling/rt_executor.rs
+++ b/horus_core/src/scheduling/rt_executor.rs
@@ -1223,6 +1223,7 @@ impl RtExecutor {
         release_late_ns: u64,
         registry_slot: Option<usize>,
         name_hash: u64,
+        timing: Option<&super::safety_monitor::NodeTimingState>,
     ) {
         // Failure-policy backoff (Restart) / cooldown (Skip): skip this tick
         // while the node is suppressed.
@@ -1322,7 +1323,14 @@ impl RtExecutor {
             // deadline path below: this node is not in `Scheduler::nodes`, so
             // the main loop's budget accounting never sees it.
             if let Some(ref monitor) = monitors.safety {
-                let _ = monitor.check_tick_budget(&node.name, tr.duration);
+                match timing {
+                    Some(state) => {
+                        let _ = monitor.check_tick_budget_of(&node.name, state, tr.duration);
+                    }
+                    None => {
+                        let _ = monitor.check_tick_budget(&node.name, tr.duration);
+                    }
+                }
             }
             if let Some(budget_result) =
                 TimingEnforcer::check_tick_budget(&node.name, tr.duration, tick_budget)
@@ -1456,8 +1464,26 @@ impl RtExecutor {
                 // the ceiling only ever worked in deterministic/replay mode,
                 // where the partition does not happen.
                 if let Some(ref monitor) = monitors.safety {
-                    monitor.record_deadline_miss(&node.name);
-                    let consecutive = monitor.consecutive_misses(&node.name);
+                    // Through the resolved handle when we have one: the by-name
+                    // pair below is two more map lookups, taken at the exact
+                    // moment the node is already late.
+                    //
+                    // Both arms only RECORD; the monitor-level bookkeeping (the
+                    // process-wide counter and the `max_deadline_misses` e-stop
+                    // check) happens exactly once below, so routing through the
+                    // handle cannot skip an escalation.
+                    let consecutive = match timing {
+                        Some(state) => {
+                            state.record_miss(0);
+                            state.consecutive_misses()
+                        }
+                        None => {
+                            let state = monitor.tick_budget_handle(&node.name);
+                            state.record_miss(0);
+                            state.consecutive_misses()
+                        }
+                    };
+                    monitor.note_deadline_miss_recorded(&node.name, consecutive);
                     let action =
                         monitor.evaluate_degradation(&node.name, consecutive, node.rate_hz);
                     if !matches!(action, super::safety_monitor::DegradationAction::None) {
@@ -1940,6 +1966,19 @@ impl RtExecutor {
             .map(|n| crate::core::tick_context::hash_node_name(n.name.as_ref()))
             .collect();
 
+        // Per-node budget/deadline accounting, resolved once. This one took a
+        // process-wide `Mutex<BudgetEnforcer>` shared by every RT chain, so its
+        // cost grew with the number of chains rather than staying flat.
+        let timings: Vec<Option<Arc<super::safety_monitor::NodeTimingState>>> = nodes
+            .iter()
+            .map(|n| {
+                monitors
+                    .safety
+                    .as_ref()
+                    .map(|m| m.tick_budget_handle(n.name.as_ref()))
+            })
+            .collect();
+
         // Cyclic cadence on an absolute phase grid. Constructed here, after all
         // the one-time setup above, so the phase anchor is not polluted by
         // affinity/governor/IRQ work that only happens once.
@@ -2027,6 +2066,7 @@ impl RtExecutor {
                         release_late_ns,
                         registry_slots[idx],
                         name_hashes[idx],
+                        timings[idx].as_deref(),
                     )
                 }));
                 warmed[idx] = true;
@@ -2215,7 +2255,7 @@ mod tests {
 
         // The RT loop wraps `tick_node` exactly like this.
         let outcome = catch_unwind(AssertUnwindSafe(|| {
-            RtExecutor::tick_node(&mut node, &monitors, &running, true, 0, None, 0)
+            RtExecutor::tick_node(&mut node, &monitors, &running, true, 0, None, 0, None)
         }));
 
         assert!(
@@ -2390,6 +2430,7 @@ mod tests {
             0,
             None,
             0,
+            None,
         );
 
         assert_eq!(

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -2,7 +2,7 @@
 use crate::core::rt_node::BudgetViolation;
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -288,8 +288,14 @@ pub(crate) enum WatchdogSeverity {
 /// no lock acquisition delay during which a heartbeat could slip in.
 #[derive(Debug)]
 pub(crate) struct Watchdog {
-    /// Timeout duration
-    timeout: Duration,
+    /// Timeout in nanoseconds.
+    ///
+    /// Atomic, and `set_scale` is `&self`, so a `Watchdog` can live behind an
+    /// `Arc` and be fed without going back through the map. The RT tick loop
+    /// fed its node by NAME every tick — an `RwLock` read guard plus a SipHash
+    /// plus a probe, per node per period — and the feed is a two-atomic-store
+    /// operation on the other side of all that.
+    timeout_ns: AtomicU64,
     /// The timeout as configured, before any rate-change scaling. `set_scale`
     /// is always applied to this, so scaling never compounds.
     base_timeout: Duration,
@@ -303,7 +309,7 @@ pub(crate) struct Watchdog {
 impl Watchdog {
     pub(crate) fn new(timeout: Duration) -> Self {
         Self {
-            timeout,
+            timeout_ns: AtomicU64::new(timeout.as_nanos() as u64),
             base_timeout: timeout,
             last_heartbeat_ns: AtomicU64::new(now_ns()),
             expired: AtomicBool::new(false),
@@ -315,9 +321,18 @@ impl Watchdog {
     ///
     /// Always relative to the configured value, never compounding, so
     /// repeated calls are idempotent and `scale = 1.0` restores exactly.
-    pub(crate) fn set_scale(&mut self, scale: f64) {
+    pub(crate) fn set_scale(&self, scale: f64) {
         let scaled = self.base_timeout.as_secs_f64() * scale.max(1.0);
-        self.timeout = Duration::from_secs_f64(scaled);
+        self.timeout_ns.store(
+            Duration::from_secs_f64(scaled).as_nanos() as u64,
+            Ordering::Relaxed,
+        );
+    }
+
+    /// The current (possibly scaled) timeout.
+    #[cfg(test)]
+    pub(crate) fn timeout(&self) -> Duration {
+        Duration::from_nanos(self.timeout_ns.load(Ordering::Relaxed))
     }
 
     /// Feed the watchdog (reset timer)
@@ -331,7 +346,7 @@ impl Watchdog {
     pub(crate) fn check(&self) -> bool {
         let last_ns = self.last_heartbeat_ns.load(Ordering::Acquire);
         let elapsed_ns = now_ns().saturating_sub(last_ns);
-        let expired = elapsed_ns >= self.timeout.as_nanos() as u64;
+        let expired = elapsed_ns >= self.timeout_ns.load(Ordering::Relaxed);
         if expired {
             self.expired.store(true, Ordering::SeqCst);
         }
@@ -361,7 +376,7 @@ impl Watchdog {
     pub(crate) fn check_graduated_at(&self, now_ns: u64) -> WatchdogSeverity {
         let last_ns = self.last_heartbeat_ns.load(Ordering::Acquire);
         let elapsed_ns = now_ns.saturating_sub(last_ns);
-        let timeout_ns = self.timeout.as_nanos() as u64;
+        let timeout_ns = self.timeout_ns.load(Ordering::Relaxed);
 
         if elapsed_ns <= timeout_ns {
             WatchdogSeverity::Ok
@@ -865,7 +880,7 @@ pub(crate) struct SafetyMonitor {
     /// only READ the map (individual watchdog state is in `AtomicU64`/`AtomicBool`),
     /// so multiple scheduler ticks can iterate concurrently.  Only
     /// `add_critical_node()` needs a write lock (infrequent setup-time call).
-    watchdogs: Arc<RwLock<HashMap<String, Watchdog>>>,
+    watchdogs: Arc<RwLock<HashMap<String, Arc<Watchdog>>>>,
     /// budget enforcer
     budget_enforcer: Arc<BudgetEnforcer>,
     /// Critical nodes that must never fail — protected by RwLock for interior mutability.
@@ -881,6 +896,22 @@ pub(crate) struct SafetyMonitor {
     degradation_policy: DegradationPolicy,
     /// Per-node degradation state
     degradation_states: Mutex<HashMap<String, NodeDegradationState>>,
+    /// How many nodes are currently in a non-`Normal` degradation stage.
+    ///
+    /// Exists so `record_successful_tick` — which runs on the RT thread after
+    /// EVERY successful tick — does not have to take `degradation_states` to
+    /// discover that there is nothing to do. That mutex is process-global and
+    /// blocking, and on a healthy robot the answer is always "nothing to do":
+    /// with no node degraded, the function provably returns
+    /// `DegradationAction::None` for every node, so skipping it is exact rather
+    /// than approximate.
+    ///
+    /// Maintained under the `degradation_states` lock by `refresh_degraded_count`,
+    /// which recomputes it from the map after any stage change. Recomputing is
+    /// O(nodes) but only happens when a stage actually moves, which is rare;
+    /// incrementing and decrementing at each transition would be cheaper and
+    /// far easier to get wrong.
+    degraded_nodes: AtomicUsize,
     /// A NEW external safe-state request the tick loop has not acted on yet.
     ///
     /// Separate from `state`, which latches `SafetyState::SafeState` as an
@@ -905,7 +936,7 @@ pub(crate) struct SafetyMonitor {
 /// fleet-halting emergency stop (FIX #2).
 #[derive(Clone, Debug)]
 pub(crate) struct WatchdogFeeder {
-    watchdogs: Arc<RwLock<HashMap<String, Watchdog>>>,
+    watchdogs: Arc<RwLock<HashMap<String, Arc<Watchdog>>>>,
 }
 
 impl WatchdogFeeder {
@@ -915,6 +946,14 @@ impl WatchdogFeeder {
         if let Some(watchdog) = self.watchdogs.read().get(node_name) {
             watchdog.feed();
         }
+    }
+
+    /// Resolve a node's watchdog ONCE, so a tick loop never looks it up again.
+    ///
+    /// `None` for a node with no registered watchdog, which `feed` treats as a
+    /// no-op — so a caller holding `None` simply never feeds, exactly as before.
+    pub(crate) fn handle(&self, node_name: &str) -> Option<Arc<Watchdog>> {
+        self.watchdogs.read().get(node_name).cloned()
     }
 }
 
@@ -960,6 +999,7 @@ impl SafetyMonitor {
             degrade_activations: AtomicU64::new(0),
             degradation_policy: DegradationPolicy::default(),
             degradation_states: Mutex::new(HashMap::new()),
+            degraded_nodes: AtomicUsize::new(0),
             external_safe_state_pending: AtomicBool::new(false),
         }
     }
@@ -989,7 +1029,7 @@ impl SafetyMonitor {
         self.critical_nodes.write().push(node_name.clone());
         self.watchdogs
             .write()
-            .insert(node_name, Watchdog::new(watchdog_timeout));
+            .insert(node_name, Arc::new(Watchdog::new(watchdog_timeout)));
     }
 
     /// Returns true if `node_name` was registered as a critical node.
@@ -1019,7 +1059,7 @@ impl SafetyMonitor {
     /// The current watchdog timeout for a node, after any rate scaling.
     #[cfg(test)]
     pub(crate) fn watchdog_timeout(&self, node_name: &str) -> Option<Duration> {
-        self.watchdogs.read().get(node_name).map(|w| w.timeout)
+        self.watchdogs.read().get(node_name).map(|w| w.timeout())
     }
 
     /// Scale a node's watchdog timeout to match a deliberate change in its
@@ -1037,7 +1077,7 @@ impl SafetyMonitor {
     /// values below 1.0 are clamped away — this may only ever widen the window,
     /// never tighten it below what the operator asked for.
     pub(crate) fn scale_watchdog(&self, node_name: &str, scale: f64) {
-        if let Some(watchdog) = self.watchdogs.write().get_mut(node_name) {
+        if let Some(watchdog) = self.watchdogs.read().get(node_name) {
             watchdog.set_scale(scale);
             watchdog.feed();
         }
@@ -1325,6 +1365,16 @@ impl SafetyMonitor {
     ///
     /// Returns a `DegradationAction` that the scheduler should execute.
     /// Call this after recording a deadline miss or budget violation.
+    /// Recompute [`SafetyMonitor::degraded_nodes`] from the map. Call while
+    /// holding the `degradation_states` lock, after any stage change.
+    fn refresh_degraded_count(&self, states: &HashMap<String, NodeDegradationState>) {
+        let n = states
+            .values()
+            .filter(|s| s.stage != DegradationStage::Normal)
+            .count();
+        self.degraded_nodes.store(n, Ordering::Release);
+    }
+
     pub(crate) fn evaluate_degradation(
         &self,
         node_name: &str,
@@ -1342,7 +1392,9 @@ impl SafetyMonitor {
             .get_mut(node_name)
             .expect("inserted immediately above");
 
-        if consecutive_misses >= policy.kill_after && state.stage != DegradationStage::Killed {
+        let action = if consecutive_misses >= policy.kill_after
+            && state.stage != DegradationStage::Killed
+        {
             state.stage = DegradationStage::Killed;
             state.recovery_counter = 0;
             DegradationAction::Kill(node_name.to_string())
@@ -1374,7 +1426,13 @@ impl SafetyMonitor {
             DegradationAction::Warn(node_name.to_string())
         } else {
             DegradationAction::None
-        }
+        };
+
+        // Single exit, so a stage change cannot escape without updating the
+        // lock-free counter `record_successful_tick` reads. This is the only
+        // function that moves a node OUT of `Normal`.
+        self.refresh_degraded_count(&states);
+        action
     }
 
     /// Record a successful tick for recovery tracking.
@@ -1383,6 +1441,14 @@ impl SafetyMonitor {
     /// consecutive times, it returns `RestoreRate` to signal the scheduler should
     /// restore the original rate.
     pub(crate) fn record_successful_tick(&self, node_name: &str) -> DegradationAction {
+        // Nothing degraded anywhere: every branch below would return
+        // `DegradationAction::None`, so do not take a process-global blocking
+        // mutex on the RT thread to find that out. This is the steady state of
+        // a healthy robot — i.e. essentially every tick.
+        if self.degraded_nodes.load(Ordering::Acquire) == 0 {
+            return DegradationAction::None;
+        }
+
         let recovery_ticks = self.degradation_policy.recovery_ticks;
 
         let mut states = self.degradation_states.lock();
@@ -1390,7 +1456,7 @@ impl SafetyMonitor {
             return DegradationAction::None;
         };
 
-        match state.stage {
+        let action = match state.stage {
             DegradationStage::RateReduced => {
                 state.recovery_counter += 1;
                 if state.recovery_counter >= recovery_ticks {
@@ -1399,17 +1465,21 @@ impl SafetyMonitor {
                     state.recovery_counter = 0;
                     state.original_rate_hz = None;
                     if let Some(rate) = original {
-                        return DegradationAction::RestoreRate {
+                        // An early `return` here would leave `degraded_nodes`
+                        // stale-high on the very transition that clears the last
+                        // degraded node, so this arm yields a value like the rest.
+                        DegradationAction::RestoreRate {
                             node: node_name.to_string(),
                             original_rate_hz: rate,
-                        };
+                        }
+                    } else {
+                        // No original rate saved — rate cannot be restored
+                        log::warn!(
+                            "Node '{}': recovered from RateReduced but original_rate_hz was None — rate not restored",
+                            node_name
+                        );
+                        DegradationAction::None
                     }
-                    // No original rate saved — rate cannot be restored
-                    log::warn!(
-                        "Node '{}': recovered from RateReduced but original_rate_hz was None — rate not restored",
-                        node_name
-                    );
-                    DegradationAction::None
                 } else {
                     DegradationAction::None
                 }
@@ -1437,7 +1507,13 @@ impl SafetyMonitor {
                 }
             }
             _ => DegradationAction::None,
-        }
+        };
+
+        // Single exit, as in `evaluate_degradation`: this is the only function
+        // that moves a node back INTO `Normal`, so it must refresh the counter
+        // or a recovered robot would keep paying for the mutex forever.
+        self.refresh_degraded_count(&states);
+        action
     }
 
     /// Get the current degradation stage for a node.
@@ -2127,10 +2203,10 @@ mod tests {
 
         let monitor = SafetyMonitor::new(100);
         // Register a watchdog but NOT as critical
-        monitor
-            .watchdogs
-            .write()
-            .insert("noncritical".to_string(), Watchdog::new(10_u64.ms()));
+        monitor.watchdogs.write().insert(
+            "noncritical".to_string(),
+            Arc::new(Watchdog::new(10_u64.ms())),
+        );
 
         thread::sleep(35_u64.ms());
 
@@ -3711,15 +3787,15 @@ mod tests {
         monitor
             .watchdogs
             .write()
-            .insert("short_a".to_string(), Watchdog::new(1_u64.ms()));
+            .insert("short_a".to_string(), Arc::new(Watchdog::new(1_u64.ms())));
         monitor
             .watchdogs
             .write()
-            .insert("short_b".to_string(), Watchdog::new(1_u64.ms()));
+            .insert("short_b".to_string(), Arc::new(Watchdog::new(1_u64.ms())));
         monitor
             .watchdogs
             .write()
-            .insert("long_c".to_string(), Watchdog::new(1_u64.secs()));
+            .insert("long_c".to_string(), Arc::new(Watchdog::new(1_u64.secs())));
 
         // Let the short ones expire
         thread::sleep(5_u64.ms());
@@ -3935,6 +4011,171 @@ mod estop_trigger_tests {
 /// this moved into atomics are the ones `trigger_emergency_stop` and the
 /// degradation ladder read, so a lost or mis-ordered update here is a robot
 /// that either stops for no reason or fails to stop when it should.
+/// Guards for the two lock-free fast paths added to the RT tick loop:
+/// the degraded-node counter and the resolved watchdog handle.
+#[cfg(test)]
+mod tick_fast_path_correctness {
+    use super::*;
+
+    /// The `degraded_nodes` shortcut must not swallow a real recovery.
+    ///
+    /// `record_successful_tick` returns early without taking
+    /// `degradation_states` when the counter is zero. That is exact only if the
+    /// counter is refreshed on EVERY stage change — so drive a node all the way
+    /// down the ladder and back up, and require the recovery actions to still
+    /// come out. If a refresh were missed on the way down, the counter would
+    /// read zero, the early return would fire, and the node would stay degraded
+    /// for the life of the process with `recovery_ticks` silently dead.
+    #[test]
+    fn a_degraded_node_still_recovers_through_the_lock_free_fast_path() {
+        let mut m = SafetyMonitor::new(u64::MAX);
+        m.set_degradation_policy(DegradationPolicy {
+            warn_after: 1,
+            reduce_after: 2,
+            isolate_after: 100,
+            kill_after: 200,
+            recovery_ticks: 3,
+        });
+
+        // Healthy: nothing degraded, so the fast path is what runs.
+        assert_eq!(m.degraded_nodes.load(Ordering::Acquire), 0);
+        assert_eq!(
+            m.record_successful_tick("servo"),
+            DegradationAction::None,
+            "a healthy node must be a no-op"
+        );
+
+        // Degrade it to RateReduced.
+        let _ = m.evaluate_degradation("servo", 1, Some(1000.0));
+        let action = m.evaluate_degradation("servo", 2, Some(1000.0));
+        assert!(
+            matches!(action, DegradationAction::ReduceRate { .. }),
+            "expected ReduceRate, got {action:?}"
+        );
+        assert_eq!(
+            m.degraded_nodes.load(Ordering::Acquire),
+            1,
+            "the counter must see the node leave Normal, or recovery is unreachable"
+        );
+
+        // Recover: recovery_ticks successes must produce RestoreRate.
+        assert_eq!(m.record_successful_tick("servo"), DegradationAction::None);
+        assert_eq!(m.record_successful_tick("servo"), DegradationAction::None);
+        let restored = m.record_successful_tick("servo");
+        assert!(
+            matches!(
+                restored,
+                DegradationAction::RestoreRate { ref node, original_rate_hz }
+                    if node == "servo" && original_rate_hz == 1000.0
+            ),
+            "expected RestoreRate(1000Hz), got {restored:?}"
+        );
+
+        // ...and the counter must fall back to zero, or a recovered robot pays
+        // for the mutex forever.
+        assert_eq!(
+            m.degraded_nodes.load(Ordering::Acquire),
+            0,
+            "the counter must clear when the last node returns to Normal"
+        );
+    }
+
+    /// One degraded node must not let another node's ticks skip the check.
+    #[test]
+    fn the_counter_is_process_wide_so_a_second_node_is_still_evaluated() {
+        let mut m = SafetyMonitor::new(u64::MAX);
+        m.set_degradation_policy(DegradationPolicy {
+            warn_after: 1,
+            reduce_after: 2,
+            isolate_after: 100,
+            kill_after: 200,
+            recovery_ticks: 2,
+        });
+
+        let _ = m.evaluate_degradation("a", 1, Some(1000.0));
+        let _ = m.evaluate_degradation("a", 2, Some(1000.0));
+        let _ = m.evaluate_degradation("b", 1, Some(500.0));
+        let _ = m.evaluate_degradation("b", 2, Some(500.0));
+        assert_eq!(m.degraded_nodes.load(Ordering::Acquire), 2);
+
+        // Recover only 'a'. 'b' must still be degraded and still recoverable.
+        assert_eq!(m.record_successful_tick("a"), DegradationAction::None);
+        assert!(matches!(
+            m.record_successful_tick("a"),
+            DegradationAction::RestoreRate { .. }
+        ));
+        assert_eq!(
+            m.degraded_nodes.load(Ordering::Acquire),
+            1,
+            "'b' is still degraded"
+        );
+
+        assert_eq!(m.record_successful_tick("b"), DegradationAction::None);
+        assert!(
+            matches!(
+                m.record_successful_tick("b"),
+                DegradationAction::RestoreRate { .. }
+            ),
+            "'b' must still recover after 'a' did"
+        );
+        assert_eq!(m.degraded_nodes.load(Ordering::Acquire), 0);
+    }
+
+    /// A watchdog fed through a resolved handle is the same watchdog the
+    /// main-thread expiry check reads.
+    ///
+    /// The RT loop now feeds `Arc<Watchdog>` resolved at thread start instead of
+    /// calling `WatchdogFeeder::feed(name)`. If the handle ever pointed at a
+    /// different object than the map holds — a clone of the value rather than a
+    /// shared `Arc` — feeding would appear to work and `check_watchdogs` would
+    /// expire the node anyway, e-stopping a perfectly healthy robot.
+    #[test]
+    fn a_watchdog_fed_through_its_handle_is_the_one_the_monitor_checks() {
+        let m = SafetyMonitor::new(u64::MAX);
+        m.add_critical_node("servo".to_string(), Duration::from_millis(50));
+        let feeder = m.watchdog_feeder();
+        let handle = feeder.handle("servo").expect("servo has a watchdog");
+
+        // Let it go stale, confirm the monitor sees that.
+        std::thread::sleep(Duration::from_millis(80));
+        let mut expired = Vec::new();
+        m.check_watchdogs(&mut expired);
+        assert_eq!(expired, vec!["servo".to_string()], "should have expired");
+
+        // Feed through the HANDLE, then re-check: the monitor must agree.
+        handle.feed();
+        let mut expired = Vec::new();
+        m.check_watchdogs(&mut expired);
+        assert!(
+            expired.is_empty(),
+            "feeding through the resolved handle did not reach the watchdog the \
+             monitor checks — got {expired:?}"
+        );
+
+        // An unregistered node has no handle, which is the documented no-op.
+        assert!(feeder.handle("not_registered").is_none());
+    }
+
+    /// `scale_watchdog` must still reach a watchdog held by `Arc`.
+    #[test]
+    fn scaling_still_widens_the_timeout_behind_the_arc() {
+        let m = SafetyMonitor::new(u64::MAX);
+        m.add_critical_node("servo".to_string(), Duration::from_millis(10));
+        assert_eq!(m.watchdog_timeout("servo"), Some(Duration::from_millis(10)));
+
+        m.scale_watchdog("servo", 3.0);
+        assert_eq!(
+            m.watchdog_timeout("servo"),
+            Some(Duration::from_millis(30)),
+            "scaling did not reach the shared watchdog"
+        );
+
+        // Never tightens below the configured value.
+        m.scale_watchdog("servo", 0.5);
+        assert_eq!(m.watchdog_timeout("servo"), Some(Duration::from_millis(10)));
+    }
+}
+
 #[cfg(test)]
 mod budget_atomics_correctness {
     use super::*;
@@ -4164,6 +4405,70 @@ mod budget_hot_path_perf {
             h.join().unwrap();
         }
         (by_name, by_handle)
+    }
+
+    /// The other two per-tick safety calls: the watchdog feed and the
+    /// degradation-recovery check.
+    ///
+    /// Both ran by NAME on every successful tick — the feed through an
+    /// `RwLock<HashMap<String, Watchdog>>`, the recovery check through a
+    /// process-global blocking `Mutex<HashMap<String, _>>` that a healthy robot
+    /// never needed to take at all.
+    #[test]
+    #[ignore = "stopwatch, not an assertion — run manually with --ignored"]
+    fn watchdog_and_recovery_cost() {
+        let names: Vec<String> = (0..NODES)
+            .map(|i| format!("perception_stage_{i}"))
+            .collect();
+        let m = Arc::new(SafetyMonitor::new(u64::MAX));
+        for n in &names {
+            m.add_critical_node(n.clone(), Duration::from_millis(50));
+        }
+        let feeder = m.watchdog_feeder();
+        let handles: Vec<_> = names.iter().map(|n| feeder.handle(n).unwrap()).collect();
+
+        let by_name = {
+            let start = Instant::now();
+            for _ in 0..TICKS {
+                for n in &names {
+                    feeder.feed(black_box(n));
+                }
+            }
+            start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+        };
+        let by_handle = {
+            let start = Instant::now();
+            for _ in 0..TICKS {
+                for h in &handles {
+                    black_box(h).feed();
+                }
+            }
+            start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+        };
+
+        // Recovery check on a HEALTHY robot: nothing degraded, which is the
+        // steady state and the case the counter short-circuits.
+        let recovery = {
+            let start = Instant::now();
+            for _ in 0..TICKS {
+                for n in &names {
+                    black_box(m.record_successful_tick(black_box(n)));
+                }
+            }
+            start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+        };
+
+        println!("\n  remaining per-tick safety calls, per node per tick:");
+        println!("    watchdog feed by name  : {by_name:8.1} ns");
+        println!(
+            "    watchdog feed by handle: {by_handle:8.1} ns  ({:.1}x)",
+            by_name / by_handle
+        );
+        println!("    recovery check (healthy, counter==0): {recovery:8.1} ns");
+        println!(
+            "    => saved per tick for {NODES} nodes: {:8.1} ns on the feed alone\n",
+            (by_name - by_handle) * NODES as f64
+        );
     }
 
     #[test]

--- a/horus_core/src/scheduling/safety_monitor.rs
+++ b/horus_core/src/scheduling/safety_monitor.rs
@@ -388,56 +388,74 @@ impl Watchdog {
 /// min/max/avg/p99 calculations without unbounded memory growth.
 const TIMING_RING_CAPACITY: usize = 1024;
 
+/// Sentinel in `NodeTimingState::budget_ns` for "no budget configured".
+const NO_BUDGET: u64 = u64::MAX;
+
+/// Written by exactly ONE thread per node — the executor that owns it — and
+/// read by reporting threads. That is what lets `record` be `&self` with plain
+/// relaxed stores instead of read-modify-writes: there is no writer-writer
+/// race to lose an update to.
+///
+/// A reader may see a torn snapshot — a `count` that has advanced past a slot
+/// the writer has not filled yet, or a mix of old and new samples across a
+/// wrap. That is deliberate and acceptable: these feed min/avg/p99 of a
+/// 1024-sample window in a shutdown report, where one stale sample changes
+/// nothing anybody acts on. It is NOT acceptable for the counters that drive
+/// escalation, and those are not in here — see `NodeTimingState`.
 #[derive(Debug)]
 pub(crate) struct TickTimingRing {
-    durations: Box<[u64; TIMING_RING_CAPACITY]>,
-    write_pos: usize,
-    count: u64,
+    durations: Box<[AtomicU64; TIMING_RING_CAPACITY]>,
+    /// Total samples ever recorded. `write_pos` is `count % CAPACITY`, so one
+    /// counter serves both and they cannot disagree.
+    count: AtomicU64,
 }
 
 impl TickTimingRing {
     pub(crate) fn new() -> Self {
         Self {
-            durations: Box::new([0u64; TIMING_RING_CAPACITY]),
-            write_pos: 0,
-            count: 0,
+            durations: Box::new(std::array::from_fn(|_| AtomicU64::new(0))),
+            count: AtomicU64::new(0),
         }
     }
 
     /// Record a tick duration in microseconds.
-    pub(crate) fn record(&mut self, duration_us: u64) {
-        self.durations[self.write_pos] = duration_us;
-        self.write_pos = (self.write_pos + 1) % TIMING_RING_CAPACITY;
-        self.count += 1;
+    ///
+    /// `&self`, and on the RT tick path. The whole point of the atomics is that
+    /// this no longer needs the process-wide mutex it used to be called under.
+    pub(crate) fn record(&self, duration_us: u64) {
+        let n = self.count.load(Ordering::Relaxed);
+        self.durations[(n as usize) % TIMING_RING_CAPACITY].store(duration_us, Ordering::Relaxed);
+        // Release so a reader that sees this count also sees the sample.
+        self.count.store(n.wrapping_add(1), Ordering::Release);
     }
 
     /// Number of samples recorded (total, not just in buffer).
     #[cfg(test)]
     pub(crate) fn total_count(&self) -> u64 {
-        self.count
-    }
-
-    /// Number of valid samples in the ring (min of count and capacity).
-    fn valid_count(&self) -> usize {
-        (self.count as usize).min(TIMING_RING_CAPACITY)
+        self.count.load(Ordering::Acquire)
     }
 
     /// Compute timing statistics from the ring buffer.
     pub(crate) fn stats(&self) -> TimingStats {
-        let n = self.valid_count();
+        let count = self.count.load(Ordering::Acquire);
+        let n = (count as usize).min(TIMING_RING_CAPACITY);
         if n == 0 {
             return TimingStats::default();
         }
 
-        let samples = &self.durations[..n];
+        // One pass into a stack copy, so min/max/avg/p99 all describe the SAME
+        // snapshot. Reading the atomics four separate times could otherwise
+        // report a max that is not in the set the average was taken over.
+        let mut scratch = [0u64; TIMING_RING_CAPACITY];
+        for (i, slot) in scratch[..n].iter_mut().enumerate() {
+            *slot = self.durations[i].load(Ordering::Relaxed);
+        }
+        let samples = &scratch[..n];
         let min = samples.iter().copied().min().unwrap_or(0);
         let max = samples.iter().copied().max().unwrap_or(0);
         let sum: u64 = samples.iter().sum();
         let avg = sum / n as u64;
 
-        // P99: sort on stack-allocated copy (no heap allocation)
-        let mut scratch = [0u64; TIMING_RING_CAPACITY];
-        scratch[..n].copy_from_slice(samples);
         scratch[..n].sort_unstable();
         let p99_idx = ((n as f64 * 0.99) as usize).min(n - 1);
         let p99 = scratch[p99_idx];
@@ -447,7 +465,7 @@ impl TickTimingRing {
             max_us: max,
             avg_us: avg,
             p99_us: p99,
-            total_ticks: self.count,
+            total_ticks: count,
         }
     }
 }
@@ -484,49 +502,115 @@ pub(crate) struct NodeTimingReport {
 }
 
 /// Per-node timing and overrun tracking.
+///
+/// Every field is atomic and every method takes `&self`, so an executor can
+/// hold this by `Arc` and update it from its tick loop without a lock. That is
+/// the point: this used to live behind one process-wide `Mutex<BudgetEnforcer>`
+/// that EVERY RT chain took once per node per tick, which serialised chains
+/// against each other — measured at 32.9x per-call cost with 8 chains, so
+/// timing got worse the more cores the robot used. See `budget_check_cost`.
+///
+/// `consecutive_misses` in particular must not be sampled loosely: it drives
+/// `trigger_emergency_stop` and the degradation ladder.
+///
+/// # Single writer per node
+///
+/// Correctness here rests on one invariant: a node is owned by exactly one
+/// executor, so exactly one thread ever WRITES its state. That is what makes
+/// `record_tick`'s `store(0)` on `consecutive_misses` safe against
+/// `record_miss`'s increment — they are the same thread, one tick apart, and
+/// cannot interleave.
+///
+/// The counters use `fetch_add`/`fetch_max` anyway, so a second writer would
+/// not lose a count; what it would break is the reset, which could be clobbered
+/// and leave a stale run in the number the emergency stop reads. If a future
+/// change ever gives two threads the same node, this type needs revisiting —
+/// widening the atomics is not enough.
+///
+/// Readers are unconstrained: any thread may read at any time, and the worst it
+/// sees is a value one tick stale.
 #[derive(Debug)]
 pub(crate) struct NodeTimingState {
     /// Tick duration ring buffer
     pub(crate) ring: TickTimingRing,
-    /// Budget for this node (None = no budget set)
-    pub(crate) budget: Option<Duration>,
+    /// Budget for this node in nanoseconds; `NO_BUDGET` means none is set.
+    ///
+    /// Flattened from `Option<Duration>` so it can be one atomic. The sentinel
+    /// is `u64::MAX`, NOT zero: a zero budget is a real, tested configuration
+    /// meaning "every tick violates" (see `test_budget_enforcer_zero_budget`),
+    /// so zero has to stay distinguishable from absent. `u64::MAX` ns is ~584
+    /// years, which no one is configuring as a tick budget.
+    budget_ns: AtomicU64,
     /// Total overrun count
-    pub(crate) overrun_count: u64,
+    overrun_count: AtomicU64,
     /// Worst overrun (actual - budget), zero if no overruns
-    pub(crate) worst_overrun_us: u64,
+    worst_overrun_us: AtomicU64,
     /// Deadline miss tracking
-    pub(crate) total_deadline_misses: u64,
+    total_deadline_misses: AtomicU64,
     /// Consecutive deadline misses (resets on successful tick)
-    pub(crate) consecutive_misses: u64,
+    consecutive_misses: AtomicU64,
     /// Worst deadline miss severity (how far past deadline)
-    pub(crate) worst_miss_us: u64,
+    worst_miss_us: AtomicU64,
 }
 
 impl NodeTimingState {
     pub(crate) fn new(budget: Option<Duration>) -> Self {
         Self {
             ring: TickTimingRing::new(),
-            budget,
-            overrun_count: 0,
-            worst_overrun_us: 0,
-            total_deadline_misses: 0,
-            consecutive_misses: 0,
-            worst_miss_us: 0,
+            budget_ns: AtomicU64::new(budget.map(|b| b.as_nanos() as u64).unwrap_or(NO_BUDGET)),
+            overrun_count: AtomicU64::new(0),
+            worst_overrun_us: AtomicU64::new(0),
+            total_deadline_misses: AtomicU64::new(0),
+            consecutive_misses: AtomicU64::new(0),
+            worst_miss_us: AtomicU64::new(0),
         }
     }
 
+    pub(crate) fn budget(&self) -> Option<Duration> {
+        match self.budget_ns.load(Ordering::Relaxed) {
+            NO_BUDGET => None,
+            ns => Some(Duration::from_nanos(ns)),
+        }
+    }
+
+    pub(crate) fn set_budget(&self, budget: Duration) {
+        self.budget_ns
+            .store(budget.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    pub(crate) fn overrun_count(&self) -> u64 {
+        self.overrun_count.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn total_deadline_misses(&self) -> u64 {
+        self.total_deadline_misses.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn consecutive_misses(&self) -> u64 {
+        self.consecutive_misses.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn worst_overrun_us(&self) -> u64 {
+        self.worst_overrun_us.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn worst_miss_us(&self) -> u64 {
+        self.worst_miss_us.load(Ordering::Relaxed)
+    }
+
     /// Record a tick and check budget.
-    pub(crate) fn record_tick(&mut self, actual: Duration) -> Option<BudgetViolation> {
+    pub(crate) fn record_tick(&self, actual: Duration) -> Option<BudgetViolation> {
         let actual_us = actual.as_micros() as u64;
         self.ring.record(actual_us);
 
-        if let Some(budget) = self.budget {
+        if let Some(budget) = self.budget() {
             if actual > budget {
-                self.overrun_count += 1;
+                self.overrun_count.fetch_add(1, Ordering::Relaxed);
                 let overrun_us = actual_us.saturating_sub(budget.as_micros() as u64);
-                if overrun_us > self.worst_overrun_us {
-                    self.worst_overrun_us = overrun_us;
-                }
+                self.worst_overrun_us
+                    .fetch_max(overrun_us, Ordering::Relaxed);
                 return Some(BudgetViolation::new(
                     String::new(), // filled by caller
                     budget,
@@ -544,23 +628,24 @@ impl NodeTimingState {
         // 0 here, then `record_miss` increments to 1. Pinned at 1 forever, so
         // `evaluate_degradation`, whose ladder starts at 3 consecutive misses,
         // could never fire for the nodes in the worst trouble.
-        self.consecutive_misses = 0;
+        self.consecutive_misses.store(0, Ordering::Release);
         None
     }
 
     /// Record a deadline miss with severity.
-    pub(crate) fn record_miss(&mut self, severity_us: u64) {
-        self.total_deadline_misses += 1;
-        self.consecutive_misses += 1;
-        if severity_us > self.worst_miss_us {
-            self.worst_miss_us = severity_us;
-        }
+    pub(crate) fn record_miss(&self, severity_us: u64) {
+        self.total_deadline_misses.fetch_add(1, Ordering::Relaxed);
+        // Release, paired with the Acquire in `consecutive_misses()`: this
+        // number is read to decide an emergency stop, so a reader must never
+        // see the increment without the miss that caused it.
+        self.consecutive_misses.fetch_add(1, Ordering::Release);
+        self.worst_miss_us.fetch_max(severity_us, Ordering::Relaxed);
     }
 
     /// Whether this node is chronically missing deadlines (3+ consecutive).
     #[cfg(test)]
     pub(crate) fn is_chronic(&self) -> bool {
-        self.consecutive_misses >= 3
+        self.consecutive_misses() >= 3
     }
 }
 
@@ -652,8 +737,12 @@ pub(crate) enum DegradationAction {
 /// budget (Worst-Case Execution Time) enforcer with real per-node metrics.
 #[derive(Debug)]
 pub(crate) struct BudgetEnforcer {
-    /// Per-node timing state with ring buffers
-    pub(crate) node_timing: HashMap<String, NodeTimingState>,
+    /// Per-node timing state with ring buffers.
+    ///
+    /// `Arc` so a caller can resolve one node's state ONCE and keep it; the
+    /// `RwLock` is then only taken to register a node or to walk every node for
+    /// a report, never on the tick path.
+    pub(crate) node_timing: RwLock<HashMap<String, Arc<NodeTimingState>>>,
     /// Global overrun counter (atomic for cross-thread access)
     pub(crate) overruns: AtomicU64,
     /// Critical overruns (that triggered emergency stop)
@@ -663,7 +752,7 @@ pub(crate) struct BudgetEnforcer {
 impl Default for BudgetEnforcer {
     fn default() -> Self {
         Self {
-            node_timing: HashMap::new(),
+            node_timing: RwLock::new(HashMap::new()),
             overruns: AtomicU64::new(0),
             critical_overruns: AtomicU64::new(0),
         }
@@ -675,81 +764,81 @@ impl BudgetEnforcer {
         Self::default()
     }
 
-    /// Set tick budget for a node.
-    pub(crate) fn set_budget(&mut self, node: String, budget: Duration) {
-        self.node_timing
-            .entry(node)
-            .or_insert_with(|| NodeTimingState::new(Some(budget)))
-            .budget = Some(budget);
+    /// Resolve (creating if absent) one node's timing state, so a caller can
+    /// hold it and never look it up again.
+    ///
+    /// This is what takes the tick path off the lock. Registration happens once
+    /// per node, before its executor starts ticking.
+    pub(crate) fn handle(&self, node: &str) -> Arc<NodeTimingState> {
+        if let Some(state) = self.node_timing.read().get(node) {
+            return Arc::clone(state);
+        }
+        let mut map = self.node_timing.write();
+        Arc::clone(
+            map.entry(node.to_string())
+                .or_insert_with(|| Arc::new(NodeTimingState::new(None))),
+        )
     }
 
-    /// Record a tick duration and check against budget.
+    /// Set tick budget for a node.
+    pub(crate) fn set_budget(&self, node: String, budget: Duration) {
+        self.node_timing
+            .write()
+            .entry(node)
+            .or_insert_with(|| Arc::new(NodeTimingState::new(Some(budget))))
+            .set_budget(budget);
+    }
+
+    /// Record a tick duration and check against budget, for a caller that has
+    /// already resolved the node's state.
     ///
-    /// This is the real enforcement: tracks per-node timing history,
-    /// computes overrun severity, and updates the ring buffer.
-    pub(crate) fn check_budget(
-        &mut self,
+    /// The RT tick loop uses this one. It touches no lock and no hash: the only
+    /// shared writes are the node's own atomics and the global overrun counter.
+    pub(crate) fn check_budget_of(
+        &self,
         node: &str,
+        state: &NodeTimingState,
         actual: Duration,
     ) -> Result<(), BudgetViolation> {
-        // `entry(node.to_string())` allocated a String on EVERY call, including
-        // the hit — and this one runs per tick for every RT node with a budget.
-        // It is the same defect the profiler carried, and the note there says
-        // why it matters: malloc has no WCET bound (arena contention -> brk/mmap
-        // -> page fault), so the check that polices timing had unbounded cost of
-        // its own, on the RT thread.
-        //
-        // `contains_key` + `get_mut` borrows the key instead of owning it: two
-        // hash lookups and no allocation in the steady state, against one lookup
-        // and a malloc/free pair before. Only a node's FIRST tick allocates.
-        if !self.node_timing.contains_key(node) {
-            self.node_timing
-                .insert(node.to_string(), NodeTimingState::new(None));
-        }
-        let state = self
-            .node_timing
-            .get_mut(node)
-            .expect("inserted immediately above");
-
-        if let Some(mut violation) = state.record_tick(actual) {
+        if let Some(violation) = state.record_tick(actual) {
             self.overruns.fetch_add(1, Ordering::SeqCst);
-            violation =
-                BudgetViolation::new(node.to_string(), violation.budget(), violation.actual());
-            return Err(violation);
+            return Err(BudgetViolation::new(
+                node.to_string(),
+                violation.budget(),
+                violation.actual(),
+            ));
         }
         Ok(())
     }
 
-    /// Record a deadline miss with severity for a node.
-    pub(crate) fn record_deadline_miss(&mut self, node: &str, severity_us: u64) {
-        // As `check_budget`: no allocation on the hit path. This runs on the RT
-        // thread every time a deadline is missed, and the report of a timing
-        // failure must not cost more than the failure did.
-        if let Some(state) = self.node_timing.get_mut(node) {
-            state.record_miss(severity_us);
-            return;
-        }
-        let mut state = NodeTimingState::new(None);
-        state.record_miss(severity_us);
-        self.node_timing.insert(node.to_string(), state);
+    /// `check_budget_of` for a caller that has not resolved the state.
+    ///
+    /// Test-only: the production paths all hold a resolved handle now — the RT
+    /// loop resolves at thread start, and `SafetyMonitor::check_tick_budget`
+    /// resolves per call for the non-RT callers.
+    #[cfg(test)]
+    pub(crate) fn check_budget(&self, node: &str, actual: Duration) -> Result<(), BudgetViolation> {
+        let state = self.handle(node);
+        self.check_budget_of(node, &state, actual)
     }
 
     /// Get timing stats for a specific node.
     #[cfg(test)]
     pub(crate) fn node_stats(&self, node: &str) -> Option<TimingStats> {
-        self.node_timing.get(node).map(|s| s.ring.stats())
+        self.node_timing.read().get(node).map(|s| s.ring.stats())
     }
 
     /// Get all node timing states (for timing report).
     pub(crate) fn all_node_stats(&self) -> Vec<NodeTimingReport> {
         self.node_timing
+            .read()
             .iter()
             .map(|(name, state)| NodeTimingReport {
                 name: name.clone(),
                 stats: state.ring.stats(),
-                budget: state.budget,
-                overruns: state.overrun_count,
-                deadline_misses: state.total_deadline_misses,
+                budget: state.budget(),
+                overruns: state.overrun_count(),
+                deadline_misses: state.total_deadline_misses(),
             })
             .collect()
     }
@@ -778,7 +867,7 @@ pub(crate) struct SafetyMonitor {
     /// `add_critical_node()` needs a write lock (infrequent setup-time call).
     watchdogs: Arc<RwLock<HashMap<String, Watchdog>>>,
     /// budget enforcer
-    budget_enforcer: Arc<Mutex<BudgetEnforcer>>,
+    budget_enforcer: Arc<BudgetEnforcer>,
     /// Critical nodes that must never fail — protected by RwLock for interior mutability.
     /// add_critical_node() acquires a write lock; all readers acquire a read lock.
     critical_nodes: Arc<RwLock<Vec<String>>>,
@@ -864,7 +953,7 @@ impl SafetyMonitor {
             state: Arc::new(Mutex::new(SafetyState::Normal)),
             emergency_stop: Arc::new(AtomicBool::new(false)),
             watchdogs: Arc::new(RwLock::new(HashMap::new())),
-            budget_enforcer: Arc::new(Mutex::new(BudgetEnforcer::new())),
+            budget_enforcer: Arc::new(BudgetEnforcer::new()),
             critical_nodes: Arc::new(RwLock::new(Vec::new())),
             deadline_misses: AtomicU64::new(0),
             max_deadline_misses,
@@ -914,7 +1003,7 @@ impl SafetyMonitor {
 
     /// Set tick budget for a node.
     pub(crate) fn set_tick_budget(&self, node_name: String, budget: Duration) {
-        self.budget_enforcer.lock().set_budget(node_name, budget);
+        self.budget_enforcer.set_budget(node_name, budget);
     }
 
     /// Feed watchdog for a node.
@@ -1108,14 +1197,45 @@ impl SafetyMonitor {
         node_name: &str,
         execution_time: Duration,
     ) -> Result<(), BudgetViolation> {
+        let state = self.budget_enforcer.handle(node_name);
+        self.check_tick_budget_of(node_name, &state, execution_time)
+    }
+
+    /// Resolve one node's timing state, so a tick loop can hold it and stop
+    /// paying for the lookup.
+    pub(crate) fn tick_budget_handle(&self, node_name: &str) -> Arc<NodeTimingState> {
+        self.budget_enforcer.handle(node_name)
+    }
+
+    /// `check_tick_budget` for a caller that resolved the state up front.
+    ///
+    /// This runs once per node per tick for every node with a `.tick_budget()`,
+    /// which is what an RT node configures — so it was the last blocking lock
+    /// on the RT tick path. Every RT chain is its own thread and all of them
+    /// took the SAME `Mutex<BudgetEnforcer>`, which made per-call cost grow
+    /// with chain count: measured 87.6 ns with one chain and 2886 ns with
+    /// eight, i.e. timing degraded as the robot used more cores. See
+    /// `budget_check_cost`.
+    ///
+    /// It could not be fixed the way the profiler and blackbox calls beside it
+    /// were, by dropping the sample under contention with `try_lock`: this call
+    /// is what RESETS `consecutive_misses` on a clean tick, and that counter
+    /// drives `trigger_emergency_stop`. A skipped reset leaves it stale-high
+    /// and can fire a spurious stop, so the sample has to be taken — the lock
+    /// had to go rather than be bypassed.
+    pub(crate) fn check_tick_budget_of(
+        &self,
+        node_name: &str,
+        state: &NodeTimingState,
+        execution_time: Duration,
+    ) -> Result<(), BudgetViolation> {
         let result = self
             .budget_enforcer
-            .lock()
-            .check_budget(node_name, execution_time);
+            .check_budget_of(node_name, state, execution_time);
 
         // Still counted for reporting — only the escalation is gone.
-        if result.is_err() && self.critical_nodes.read().contains(&node_name.to_string()) {
-            self.budget_enforcer.lock().mark_critical_overrun();
+        if result.is_err() && self.critical_nodes.read().iter().any(|n| n == node_name) {
+            self.budget_enforcer.mark_critical_overrun();
         }
 
         result
@@ -1151,8 +1271,6 @@ impl SafetyMonitor {
         // a full emergency stop. Nothing reset it, so a long enough run halted
         // regardless of health, and one badly tuned node spent the whole
         // robot's budget.
-        self.deadline_misses.fetch_add(1, Ordering::SeqCst);
-
         // The ceiling is now per node and CONSECUTIVE, which is the thing an
         // operator setting a "maximum deadline misses" actually means: this node
         // is not keeping up right now. A run of misses is a node in trouble; a
@@ -1161,14 +1279,24 @@ impl SafetyMonitor {
         // by `check_budget` on any tick that did not violate, so recovery
         // genuinely clears the count.
         let consecutive = {
-            let mut enforcer = self.budget_enforcer.lock();
-            enforcer.record_deadline_miss(node_name, severity_us);
-            enforcer
-                .node_timing
-                .get(node_name)
-                .map(|s| s.consecutive_misses)
-                .unwrap_or(0)
+            let state = self.budget_enforcer.handle(node_name);
+            state.record_miss(severity_us);
+            state.consecutive_misses()
         };
+        self.note_deadline_miss_recorded(node_name, consecutive);
+    }
+
+    /// The monitor-level half of recording a deadline miss, for a caller that
+    /// already recorded the per-node half through a resolved
+    /// [`NodeTimingState`] handle.
+    ///
+    /// Split out so the RT tick loop can update the node's own atomics without
+    /// a map lookup and still get the process-wide accounting and, critically,
+    /// the `max_deadline_misses` emergency stop. Skipping this would turn a
+    /// performance change into a silent safety regression: the node's counter
+    /// would climb and nothing would ever act on it.
+    pub(crate) fn note_deadline_miss_recorded(&self, node_name: &str, consecutive: u64) {
+        self.deadline_misses.fetch_add(1, Ordering::SeqCst);
 
         if consecutive >= self.max_deadline_misses {
             self.trigger_emergency_stop(format!(
@@ -1180,16 +1308,16 @@ impl SafetyMonitor {
 
     /// Get per-node timing stats (for timing report).
     pub(crate) fn all_node_timing(&self) -> Vec<NodeTimingReport> {
-        self.budget_enforcer.lock().all_node_stats()
+        self.budget_enforcer.all_node_stats()
     }
 
     /// Get consecutive miss count for a node.
     pub(crate) fn consecutive_misses(&self, node_name: &str) -> u64 {
         self.budget_enforcer
-            .lock()
             .node_timing
+            .read()
             .get(node_name)
-            .map(|s| s.consecutive_misses)
+            .map(|s| s.consecutive_misses())
             .unwrap_or(0)
     }
 
@@ -1434,7 +1562,7 @@ impl SafetyMonitor {
     pub(crate) fn get_stats(&self) -> SafetyStats {
         SafetyStats {
             state: self.get_state(),
-            budget_overruns: self.budget_enforcer.lock().get_overrun_count(),
+            budget_overruns: self.budget_enforcer.get_overrun_count(),
             deadline_misses: self.deadline_misses.load(Ordering::SeqCst),
             watchdog_expirations: self
                 .watchdogs
@@ -2039,7 +2167,7 @@ mod tests {
     /// TickTimingRing wraps correctly after capacity.
     #[test]
     fn test_timing_ring_wraps() {
-        let mut ring = TickTimingRing::new();
+        let ring = TickTimingRing::new();
         // Fill beyond capacity
         for i in 0..(TIMING_RING_CAPACITY + 100) {
             ring.record(i as u64);
@@ -2052,7 +2180,7 @@ mod tests {
     /// TimingStats p99 is correct for uniform data.
     #[test]
     fn test_timing_stats_p99() {
-        let mut ring = TickTimingRing::new();
+        let ring = TickTimingRing::new();
         // Record 100 samples: 1..=100
         for i in 1..=100u64 {
             ring.record(i);
@@ -2070,44 +2198,44 @@ mod tests {
     /// NodeTimingState tracks overruns correctly.
     #[test]
     fn test_node_timing_state_overruns() {
-        let mut state = NodeTimingState::new(Some(100_u64.us()));
+        let state = NodeTimingState::new(Some(100_u64.us()));
 
         // Normal tick — no violation
         assert!(state.record_tick(50_u64.us()).is_none());
-        assert_eq!(state.overrun_count, 0);
+        assert_eq!(state.overrun_count(), 0);
 
         // Overrun tick
         let violation = state.record_tick(150_u64.us());
         assert!(violation.is_some());
-        assert_eq!(state.overrun_count, 1);
-        assert_eq!(state.worst_overrun_us, 50); // 150 - 100
+        assert_eq!(state.overrun_count(), 1);
+        assert_eq!(state.worst_overrun_us(), 50); // 150 - 100
     }
 
     /// NodeTimingState tracks consecutive deadline misses.
     #[test]
     fn test_node_timing_consecutive_misses() {
-        let mut state = NodeTimingState::new(None);
+        let state = NodeTimingState::new(None);
 
         state.record_miss(100);
-        assert_eq!(state.consecutive_misses, 1);
+        assert_eq!(state.consecutive_misses(), 1);
         state.record_miss(200);
-        assert_eq!(state.consecutive_misses, 2);
+        assert_eq!(state.consecutive_misses(), 2);
         state.record_miss(50);
-        assert_eq!(state.consecutive_misses, 3);
+        assert_eq!(state.consecutive_misses(), 3);
         assert!(state.is_chronic());
 
         // Successful tick resets consecutive counter
         state.record_tick(10_u64.us());
-        assert_eq!(state.consecutive_misses, 0);
+        assert_eq!(state.consecutive_misses(), 0);
         assert!(!state.is_chronic());
         // But total misses persist
-        assert_eq!(state.total_deadline_misses, 3);
+        assert_eq!(state.total_deadline_misses(), 3);
     }
 
     /// BudgetEnforcer records per-node timing correctly.
     #[test]
     fn test_budget_enforcer_per_node() {
-        let mut enforcer = BudgetEnforcer::new();
+        let enforcer = BudgetEnforcer::new();
         enforcer.set_budget("motor".to_string(), 100_u64.us());
 
         // Under budget
@@ -2320,7 +2448,7 @@ mod tests {
 
     #[test]
     fn test_timing_ring_total_count() {
-        let mut ring = TickTimingRing::new();
+        let ring = TickTimingRing::new();
         assert_eq!(ring.total_count(), 0);
         ring.record(100);
         ring.record(200);
@@ -2330,7 +2458,7 @@ mod tests {
 
     #[test]
     fn test_timing_stats_fields() {
-        let mut ring = TickTimingRing::new();
+        let ring = TickTimingRing::new();
         ring.record(10);
         ring.record(20);
         ring.record(30);
@@ -2345,7 +2473,7 @@ mod tests {
 
     #[test]
     fn test_node_timing_is_chronic() {
-        let mut state = NodeTimingState::new(Some(1_u64.ms()));
+        let state = NodeTimingState::new(Some(1_u64.ms()));
         assert!(!state.is_chronic());
         state.record_miss(100);
         state.record_miss(200);
@@ -2356,7 +2484,7 @@ mod tests {
 
     #[test]
     fn test_budget_enforcer_node_stats() {
-        let mut enforcer = BudgetEnforcer::new();
+        let enforcer = BudgetEnforcer::new();
         // No data yet
         assert!(enforcer.node_stats("unknown").is_none());
 
@@ -2779,7 +2907,7 @@ mod tests {
     /// Verifies HashMap scaling and per-node isolation.
     #[test]
     fn test_budget_enforcer_20_nodes() {
-        let mut enforcer = BudgetEnforcer::new();
+        let enforcer = BudgetEnforcer::new();
 
         for i in 0..20 {
             enforcer.set_budget(
@@ -3066,7 +3194,7 @@ mod tests {
     /// BudgetEnforcer with zero budget: any non-zero tick triggers a violation.
     #[test]
     fn test_budget_enforcer_zero_budget() {
-        let mut enforcer = BudgetEnforcer::new();
+        let enforcer = BudgetEnforcer::new();
         enforcer.set_budget("zero_node".to_string(), Duration::ZERO);
 
         // A zero-duration tick should not trigger (0 is not > 0)
@@ -3177,7 +3305,7 @@ mod tests {
     /// Verifies ring buffer wrapping (capacity=1024) and correct stats after wrap.
     #[test]
     fn test_budget_enforcer_ring_buffer_stress() {
-        let mut enforcer = BudgetEnforcer::new();
+        let enforcer = BudgetEnforcer::new();
         enforcer.set_budget("stress_node".to_string(), 1_u64.ms());
 
         // Record 2000 ticks (wraps ring buffer which has capacity 1024)
@@ -3412,7 +3540,7 @@ mod tests {
     /// Timing ring stats with a single sample.
     #[test]
     fn test_timing_ring_single_sample() {
-        let mut ring = TickTimingRing::new();
+        let ring = TickTimingRing::new();
         ring.record(42);
         let stats = ring.stats();
         assert_eq!(stats.min_us, 42);
@@ -3437,42 +3565,42 @@ mod tests {
     /// NodeTimingState tracks worst_miss_us correctly across multiple misses.
     #[test]
     fn test_node_timing_worst_miss_tracking() {
-        let mut state = NodeTimingState::new(None);
+        let state = NodeTimingState::new(None);
 
         state.record_miss(100);
-        assert_eq!(state.worst_miss_us, 100);
+        assert_eq!(state.worst_miss_us(), 100);
 
         state.record_miss(500);
-        assert_eq!(state.worst_miss_us, 500);
+        assert_eq!(state.worst_miss_us(), 500);
 
         // A smaller miss does not overwrite the worst
         state.record_miss(200);
-        assert_eq!(state.worst_miss_us, 500);
+        assert_eq!(state.worst_miss_us(), 500);
 
-        assert_eq!(state.total_deadline_misses, 3);
+        assert_eq!(state.total_deadline_misses(), 3);
     }
 
     /// NodeTimingState with zero-duration budget: record_tick returns violation
     /// for any non-zero actual, tracks worst overrun correctly.
     #[test]
     fn test_node_timing_zero_budget_overrun_tracking() {
-        let mut state = NodeTimingState::new(Some(Duration::ZERO));
+        let state = NodeTimingState::new(Some(Duration::ZERO));
 
         // Zero tick vs zero budget: not a violation (0 is not > 0)
         assert!(state.record_tick(Duration::ZERO).is_none());
-        assert_eq!(state.overrun_count, 0);
+        assert_eq!(state.overrun_count(), 0);
 
         // 1us vs zero budget: violation
         let v = state.record_tick(1_u64.us());
         assert!(v.is_some());
-        assert_eq!(state.overrun_count, 1);
-        assert_eq!(state.worst_overrun_us, 1);
+        assert_eq!(state.overrun_count(), 1);
+        assert_eq!(state.worst_overrun_us(), 1);
 
         // 10us vs zero budget: bigger violation
         let v = state.record_tick(10_u64.us());
         assert!(v.is_some());
-        assert_eq!(state.overrun_count, 2);
-        assert_eq!(state.worst_overrun_us, 10);
+        assert_eq!(state.overrun_count(), 2);
+        assert_eq!(state.worst_overrun_us(), 10);
     }
 
     /// Watchdog graduated check on a freshly-constructed (never fed) watchdog:
@@ -3782,5 +3910,279 @@ mod estop_trigger_tests {
             "already latched — not a rising edge, so no second broadcast"
         );
         assert!(monitor.is_emergency_stop(), "the latch still holds");
+    }
+}
+
+/// What `check_tick_budget` costs the RT tick loop.
+///
+/// It runs once per node per tick for every node with a `.tick_budget()`, which
+/// is what an RT node configures, and it takes a BLOCKING
+/// `budget_enforcer.lock()`. The profiler and blackbox calls beside it in
+/// `tick_node` use `try_lock` precisely to avoid that, but this one cannot:
+/// `check_budget` is what RESETS `consecutive_misses` on a clean tick, and that
+/// counter drives `trigger_emergency_stop`. Skipping a sample would leave it
+/// stale-high and could fire a spurious e-stop, so the sample must not be
+/// dropped — meaning the lock has to go, not be bypassed.
+///
+/// `#[ignore]`d: a stopwatch, not an assertion.
+///
+/// ```text
+/// cargo test -p horus_core --release budget_check_cost -- --ignored --nocapture
+/// ```
+/// Correctness guards for taking the budget check off its mutex.
+///
+/// The speedup is the easy half. These are the half that matters: the counters
+/// this moved into atomics are the ones `trigger_emergency_stop` and the
+/// degradation ladder read, so a lost or mis-ordered update here is a robot
+/// that either stops for no reason or fails to stop when it should.
+#[cfg(test)]
+mod budget_atomics_correctness {
+    use super::*;
+
+    /// The `max_deadline_misses` ceiling must still fire when the miss is
+    /// recorded the way the RT loop records it.
+    ///
+    /// The RT executor no longer calls `record_deadline_miss`; it updates the
+    /// node's own atomics through a handle it resolved at thread start, then
+    /// calls `note_deadline_miss_recorded` for the process-wide half. If that
+    /// second call is ever dropped, the per-node counter still climbs and looks
+    /// perfectly healthy in every report — and the robot simply never stops.
+    /// Nothing else would notice.
+    #[test]
+    fn the_deadline_ceiling_still_fires_through_a_resolved_handle() {
+        let m = SafetyMonitor::new(3);
+        m.set_tick_budget("servo".to_string(), Duration::from_micros(800));
+        let state = m.tick_budget_handle("servo");
+
+        for i in 1..=2 {
+            state.record_miss(0);
+            m.note_deadline_miss_recorded("servo", state.consecutive_misses());
+            assert!(
+                !m.is_emergency_stop(),
+                "stopped after {i} consecutive misses, limit is 3"
+            );
+        }
+
+        state.record_miss(0);
+        m.note_deadline_miss_recorded("servo", state.consecutive_misses());
+        assert!(
+            m.is_emergency_stop(),
+            "3 consecutive misses reached the limit of 3 and did not stop"
+        );
+    }
+
+    /// A clean tick must clear the consecutive-miss run through the handle path.
+    ///
+    /// This is why the budget check could not simply be `try_lock`-and-skip
+    /// like the profiler call beside it: `record_tick` is what resets the
+    /// counter, so a dropped sample leaves it stale-high and the NEXT miss can
+    /// cross a ceiling it had no business crossing.
+    #[test]
+    fn a_clean_tick_clears_the_miss_run_and_prevents_a_spurious_stop() {
+        let m = SafetyMonitor::new(3);
+        m.set_tick_budget("servo".to_string(), Duration::from_micros(800));
+        let state = m.tick_budget_handle("servo");
+
+        for _ in 0..2 {
+            state.record_miss(0);
+            m.note_deadline_miss_recorded("servo", state.consecutive_misses());
+        }
+        assert_eq!(state.consecutive_misses(), 2);
+
+        // A tick well inside budget, taken the way the RT loop takes it.
+        m.check_tick_budget_of("servo", &state, Duration::from_micros(10))
+            .expect("10us is inside an 800us budget");
+        assert_eq!(
+            state.consecutive_misses(),
+            0,
+            "a clean tick must clear the run"
+        );
+
+        // So the next two misses must NOT reach the ceiling.
+        for _ in 0..2 {
+            state.record_miss(0);
+            m.note_deadline_miss_recorded("servo", state.consecutive_misses());
+        }
+        assert!(
+            !m.is_emergency_stop(),
+            "stopped on a 2-miss run after a clean tick had reset the counter"
+        );
+    }
+
+    /// Concurrent chains must not lose each other's updates.
+    ///
+    /// The mutex this replaced made that trivially true. The atomics have to
+    /// earn it: every chain shares one `BudgetEnforcer` and the global overrun
+    /// counter, even though each node's state is written by one thread only.
+    #[test]
+    fn concurrent_chains_lose_no_updates() {
+        const CHAINS: usize = 8;
+        const TICKS: u64 = 5_000;
+
+        let m = Arc::new(SafetyMonitor::new(u64::MAX));
+        let names: Vec<String> = (0..CHAINS).map(|c| format!("chain_{c}")).collect();
+        for n in &names {
+            // 1us budget, and every tick below is 10us, so EVERY tick overruns.
+            m.set_tick_budget(n.clone(), Duration::from_micros(1));
+        }
+
+        let threads: Vec<_> = names
+            .iter()
+            .cloned()
+            .map(|n| {
+                let m = Arc::clone(&m);
+                std::thread::spawn(move || {
+                    let state = m.tick_budget_handle(&n);
+                    for _ in 0..TICKS {
+                        let _ = m.check_tick_budget_of(&n, &state, Duration::from_micros(10));
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        // Per-node counts are exact.
+        for n in &names {
+            let state = m.tick_budget_handle(n);
+            assert_eq!(
+                state.overrun_count(),
+                TICKS,
+                "{n} lost overrun updates: {} of {TICKS}",
+                state.overrun_count()
+            );
+            assert_eq!(
+                state.ring.total_count(),
+                TICKS,
+                "{n} lost ring samples: {} of {TICKS}",
+                state.ring.total_count()
+            );
+        }
+
+        // And so is the shared total, which every chain increments.
+        assert_eq!(
+            m.budget_enforcer.get_overrun_count(),
+            TICKS * CHAINS as u64,
+            "the shared overrun counter lost updates across {CHAINS} chains"
+        );
+    }
+
+    /// A zero budget stays distinguishable from no budget.
+    ///
+    /// `budget_ns` flattens `Option<Duration>` into one atomic, and the first
+    /// version of that used `0` as the "absent" sentinel — which silently turned
+    /// a configured zero budget (every tick violates, and it is a tested
+    /// configuration) into no budget at all. The sentinel is `u64::MAX`.
+    #[test]
+    fn a_zero_budget_is_not_the_same_as_no_budget() {
+        let with_zero = NodeTimingState::new(Some(Duration::ZERO));
+        assert_eq!(with_zero.budget(), Some(Duration::ZERO));
+        assert!(
+            with_zero.record_tick(Duration::from_nanos(1)).is_some(),
+            "a 1ns tick must violate a zero budget"
+        );
+
+        let with_none = NodeTimingState::new(None);
+        assert_eq!(with_none.budget(), None);
+        assert!(
+            with_none.record_tick(Duration::from_secs(1)).is_none(),
+            "no budget means nothing can violate it"
+        );
+    }
+}
+
+#[cfg(test)]
+mod budget_hot_path_perf {
+    use super::*;
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    const NODES: usize = 8;
+    const TICKS: usize = 100_000;
+
+    fn monitor_with(names: &[String]) -> Arc<SafetyMonitor> {
+        let m = Arc::new(SafetyMonitor::new(100));
+        for n in names {
+            m.set_tick_budget(n.clone(), Duration::from_micros(800));
+        }
+        m
+    }
+
+    /// The old shape: resolve the node by name inside the call.
+    fn sweep_by_name(m: &SafetyMonitor, names: &[String]) -> f64 {
+        let start = Instant::now();
+        for _ in 0..TICKS {
+            for n in names {
+                // Well inside budget: the steady-state, non-violating path.
+                let _ = m.check_tick_budget(black_box(n), Duration::from_micros(10));
+            }
+        }
+        start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+    }
+
+    /// What the RT loop does now: resolve once, then update atomics.
+    fn sweep_by_handle(m: &SafetyMonitor, names: &[String]) -> f64 {
+        let states: Vec<_> = names.iter().map(|n| m.tick_budget_handle(n)).collect();
+        let start = Instant::now();
+        for _ in 0..TICKS {
+            for (n, st) in names.iter().zip(&states) {
+                let _ =
+                    m.check_tick_budget_of(black_box(n), black_box(st), Duration::from_micros(10));
+            }
+        }
+        start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+    }
+
+    /// Run both arms with `chains - 1` other threads doing the same work, which
+    /// is what a multi-chain robot actually does: `start_pool` gives each chain
+    /// its own thread and every one of them checks every budgeted node's budget
+    /// every tick.
+    fn under_chains(m: &Arc<SafetyMonitor>, names: &[String], chains: usize) -> (f64, f64) {
+        let stop = Arc::new(AtomicBool::new(false));
+        let others: Vec<_> = (1..chains)
+            .map(|c| {
+                let m = Arc::clone(m);
+                let stop = Arc::clone(&stop);
+                let mine: Vec<String> = (0..NODES).map(|i| format!("chain{c}_stage_{i}")).collect();
+                for n in &mine {
+                    m.set_tick_budget(n.clone(), Duration::from_micros(800));
+                }
+                std::thread::spawn(move || {
+                    while !stop.load(Ordering::Relaxed) {
+                        for n in &mine {
+                            let _ = m.check_tick_budget(n, Duration::from_micros(10));
+                        }
+                    }
+                })
+            })
+            .collect();
+        let by_name = sweep_by_name(m, names);
+        let by_handle = sweep_by_handle(m, names);
+        stop.store(true, Ordering::Relaxed);
+        for h in others {
+            h.join().unwrap();
+        }
+        (by_name, by_handle)
+    }
+
+    #[test]
+    #[ignore = "stopwatch, not an assertion — run manually with --ignored"]
+    fn budget_check_cost() {
+        let names: Vec<String> = (0..NODES)
+            .map(|i| format!("perception_stage_{i}"))
+            .collect();
+        let m = monitor_with(&names);
+
+        println!("\n  SafetyMonitor budget check, per node per tick:");
+        println!("    chains |    by name |  by handle |  speedup");
+        for chains in [1usize, 2, 4, 8] {
+            let (by_name, by_handle) = under_chains(&m, &names, chains);
+            println!(
+                "    {chains:6} | {by_name:8.1} ns | {by_handle:8.1} ns | {:6.1}x",
+                by_name / by_handle
+            );
+        }
+        println!();
     }
 }

--- a/horus_core/src/scheduling/types.rs
+++ b/horus_core/src/scheduling/types.rs
@@ -815,7 +815,7 @@ pub(crate) struct SharedMonitors {
 /// Executor threads check flags on every tick.
 #[derive(Default)]
 pub struct NodeControlMap {
-    inner: std::sync::RwLock<std::collections::HashMap<String, NodeControl>>,
+    inner: std::sync::RwLock<std::collections::HashMap<String, Arc<NodeControl>>>,
 }
 
 /// Per-node control flags.
@@ -845,12 +845,43 @@ pub struct NodeControl {
 impl NodeControlMap {
     pub fn register(&self, name: &str) {
         let mut map = self.inner.write().unwrap_or_else(|e| e.into_inner());
-        map.entry(name.to_string()).or_insert_with(|| NodeControl {
-            paused: std::sync::atomic::AtomicBool::new(false),
-            stopped: std::sync::atomic::AtomicBool::new(false),
-            health: AtomicHealthState::default(),
-            safe_state_requested: std::sync::atomic::AtomicBool::new(false),
+        map.entry(name.to_string()).or_insert_with(|| {
+            Arc::new(NodeControl {
+                paused: std::sync::atomic::AtomicBool::new(false),
+                stopped: std::sync::atomic::AtomicBool::new(false),
+                health: AtomicHealthState::default(),
+                safe_state_requested: std::sync::atomic::AtomicBool::new(false),
+            })
         });
+    }
+
+    /// Resolve a node's control block ONCE, so the tick loop never has to look
+    /// it up again.
+    ///
+    /// Every other accessor here takes `self.inner.read()` and hashes `name`.
+    /// That is fine for the main thread, which calls them when an operator
+    /// types `horus node pause`. It is not fine for an RT executor, which ran
+    /// three of them — `take_safe_state_request`, `is_stopped`, `is_paused` —
+    /// per node per tick. At 1 kHz with 8 nodes that is 24 lock acquisitions
+    /// and 24 SipHashes every millisecond, none of which can change more than
+    /// once in a blue moon.
+    ///
+    /// The lock is the sharper half of the cost. `std::sync::RwLock` has no
+    /// priority inheritance, so an RT thread that lands on a writer — a
+    /// concurrent `register()` from late node addition — blocks with no bound
+    /// derived from its own priority. That is a textbook priority inversion
+    /// sitting directly in the tick path.
+    ///
+    /// Holding the `Arc` removes both: the flags are then three relaxed atomic
+    /// loads on a cacheline this thread already owns. Registration is
+    /// idempotent (`or_insert_with`), so a handle resolved once stays the same
+    /// object for the process's life and cannot go stale.
+    pub fn handle(&self, name: &str) -> Option<Arc<NodeControl>> {
+        self.inner
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(name)
+            .cloned()
     }
 
     /// Record a node's graduated-watchdog health. Unknown names are ignored.
@@ -936,6 +967,12 @@ impl NodeControlMap {
             .unwrap_or(false)
     }
 
+    /// Unused since the RT tick loop began reading `stopped` through a handle
+    /// resolved by [`NodeControlMap::handle`] — it was this method's only
+    /// caller. Kept, with the same `allow` its `set_stopped` counterpart
+    /// already carries, so the by-name control pair stays symmetric for the CLI
+    /// paths that reach `NodeControlMap` generically.
+    #[allow(dead_code)]
     pub fn is_stopped(&self, name: &str) -> bool {
         self.inner
             .read()
@@ -974,8 +1011,25 @@ impl SharedMonitors {
     /// No-op if registry is not configured (~0ns).
     #[inline]
     pub fn update_registry(&self, node: &RegisteredNode, tick_ns: u64) {
+        let slot = self.registry_slots.get(node.name.as_ref()).copied();
+        self.update_registry_slot_of(node, slot, tick_ns);
+    }
+
+    /// `update_registry` for a caller that resolved the slot once up front.
+    ///
+    /// The by-name form hashes `node.name` on every tick to recover a `usize`
+    /// that is fixed at registration. That is the last per-tick hash of the node
+    /// name left in the RT loop, so the loop resolves these alongside its
+    /// control handles and passes the answer in.
+    #[inline]
+    pub fn update_registry_slot_of(
+        &self,
+        node: &RegisteredNode,
+        slot: Option<usize>,
+        tick_ns: u64,
+    ) {
         if let Some(ref registry) = self.registry {
-            if let Some(&slot) = self.registry_slots.get(node.name.as_ref()) {
+            if let Some(slot) = slot {
                 let (tick_count, error_count) = if let Some(ref ctx) = node.context {
                     let m = ctx.metrics();
                     (m.total_ticks(), m.errors_count() as u32)
@@ -1127,5 +1181,136 @@ mod subscription_freshness_tests {
             t.saturating_sub(last(&sf)) > Duration::from_millis(20).as_nanos() as u64,
             "an absent topic must not be reported fresh"
         );
+    }
+}
+
+/// Measurement harness for the RT tick loop's per-node control checks.
+///
+/// `#[ignore]`d: it is a stopwatch, not an assertion. Wall-clock numbers on a
+/// shared CI runner would make it a flaky gate, and the thing it measures is
+/// already guaranteed structurally — the fast path holds an `Arc` and touches
+/// no lock. Run it by hand with:
+///
+/// ```text
+/// cargo test -p horus_core --release control_lookup_cost -- --ignored --nocapture
+/// ```
+#[cfg(test)]
+mod hot_path_perf {
+    use super::*;
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    const NODES: usize = 8;
+    const TICKS: usize = 200_000;
+
+    fn names() -> Vec<String> {
+        // Representative of real node names, which is what gets hashed.
+        (0..NODES)
+            .map(|i| format!("perception_stage_{i}"))
+            .collect()
+    }
+
+    fn map_with(names: &[String]) -> NodeControlMap {
+        let map = NodeControlMap::default();
+        for n in names {
+            map.register(n);
+        }
+        map
+    }
+
+    /// Arm A: what the tick loop did — three by-name accessors per node.
+    fn by_name_ns(map: &NodeControlMap, names: &[String]) -> f64 {
+        let start = Instant::now();
+        let mut acc = 0u64;
+        for _ in 0..TICKS {
+            for n in names {
+                acc += map.take_safe_state_request(black_box(n)) as u64;
+                acc += map.is_stopped(black_box(n)) as u64;
+                acc += map.is_paused(black_box(n)) as u64;
+            }
+        }
+        black_box(acc);
+        start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+    }
+
+    /// Arm B: what it does now — resolve once, then three atomics.
+    fn by_handle_ns(map: &NodeControlMap, names: &[String]) -> f64 {
+        let handles: Vec<Arc<NodeControl>> = names.iter().map(|n| map.handle(n).unwrap()).collect();
+        let start = Instant::now();
+        let mut acc = 0u64;
+        for _ in 0..TICKS {
+            for h in &handles {
+                let c = black_box(h);
+                acc += c
+                    .safe_state_requested
+                    .swap(false, std::sync::atomic::Ordering::AcqRel) as u64;
+                acc += c.stopped.load(std::sync::atomic::Ordering::Relaxed) as u64;
+                acc += c.paused.load(std::sync::atomic::Ordering::Relaxed) as u64;
+            }
+        }
+        black_box(acc);
+        start.elapsed().as_nanos() as f64 / (TICKS * NODES) as f64
+    }
+
+    #[test]
+    #[ignore = "stopwatch, not an assertion — run manually with --ignored"]
+    fn control_lookup_cost() {
+        let names = names();
+        let map = map_with(&names);
+
+        // Alternate the arms and take the best of each, so a scheduler hiccup
+        // lands on whichever arm it lands on rather than on the first one run.
+        let mut a = f64::MAX;
+        let mut b = f64::MAX;
+        for _ in 0..5 {
+            a = a.min(by_name_ns(&map, &names));
+            b = b.min(by_handle_ns(&map, &names));
+        }
+
+        println!("\n  per node per tick, {NODES} nodes x {TICKS} ticks:");
+        println!("    by name   (RwLock + SipHash x3): {a:8.1} ns");
+        println!("    by handle (3 atomics)          : {b:8.1} ns");
+        println!(
+            "    saved                          : {:8.1} ns  ({:.1}x)",
+            a - b,
+            a / b
+        );
+        println!(
+            "    per tick for {NODES} nodes         : {:8.1} ns saved\n",
+            (a - b) * NODES as f64
+        );
+    }
+
+    /// The same question for a lock that is actually contended, which is the
+    /// case the RT thread cannot bound: `register()` takes the write guard.
+    #[test]
+    #[ignore = "stopwatch, not an assertion — run manually with --ignored"]
+    fn control_lookup_cost_under_writer() {
+        let names = names();
+        let map = Arc::new(map_with(&names));
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // A writer doing what late node registration does.
+        let writer = {
+            let map = Arc::clone(&map);
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                let mut i = 0u64;
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    map.register(&format!("late_{i}"));
+                    i += 1;
+                }
+            })
+        };
+
+        let a = by_name_ns(&map, &names);
+        let b = by_handle_ns(&map, &names);
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        writer.join().unwrap();
+
+        println!("\n  with a concurrent registrar holding the write lock:");
+        println!("    by name  : {a:8.1} ns/node/tick");
+        println!("    by handle: {b:8.1} ns/node/tick  ({:.1}x)\n", a / b);
     }
 }


### PR DESCRIPTION
The RT executor's steady-state tick took a lock and hashed the node's name
several times per node per tick, to read state that is fixed before the
executor thread even spawns. Two commits, same theme: everything the tick loop
needs is resolved once at thread start, so the steady-state tick takes **no
lock and hashes no name**.

`std::sync::RwLock` and `parking_lot::Mutex` both have no priority
inheritance, so an RT thread that lands on a holder blocks for a time bounded
by that holder's progress, not by its own priority. That is the defect — the
nanoseconds are secondary.

---

## 1. Control flags, registry slot, RNG seed

Three `RwLock<HashMap<String, _>>` lookups per node per tick
(`take_safe_state_request`, `is_stopped`, `is_paused`), each a read guard plus
a SipHash plus a probe, to read two `AtomicBool`s that change at most once in
the life of a fault. Plus the same name hashed again for the registry slot, and
again to reseed `horus::rng()`.

| control flags | by name | by handle | |
|---|---|---|---|
| uncontended | 149.0 ns | 8.4 ns | 17.7x |
| concurrent registrar holding the write lock | 1211.9 ns | 14.2 ns | **85.2x** |

| node-name hash | |
|---|---|
| recompute every tick | 24.8 ns |
| resolved once at thread start | 0 ns |

### Why the hash is a parameter and not a memo

Memoizing it on the tick context is the obvious cheaper-looking fix and it is
worse. It only HITS when the same node is entered twice in a row, which on a
multi-node chain never happens — the executor walks A, B, C, A, B, C and the
name differs on every call. On a miss it pays the comparison *and* the hash:
measured, **it loses 6.7 ns/tick** on any chain longer than one node.
`name_hash_cost` keeps those figures on record.

## 2. The budget check, which was the bigger one

`SafetyMonitor::check_tick_budget` runs once per node per tick for every node
with a `.tick_budget()` — what an RT node configures — and took a blocking
`Mutex<BudgetEnforcer>`. Every RT chain is its own thread and **all of them
took the same mutex**:

| chains | by name | by handle | speedup |
|---|---|---|---|
| 1 | 68.0 ns | 9.8 ns | 6.9x |
| 2 | 185.8 ns | 10.0 ns | 18.6x |
| 4 | 356.3 ns | 10.4 ns | 34.2x |
| 8 | 1032.3 ns | 12.4 ns | **83.1x** |

The speedup is not the point; the shape is. The old path got **15x worse from
1 to 8 chains** — RT timing degraded as the robot used more cores, exactly
backwards. The new one is flat (9.8 -> 12.4 ns).

It could not be fixed the way the profiler and blackbox calls beside it in
`tick_node` were, by dropping the sample under contention with `try_lock`.
This call is what RESETS `consecutive_misses` on a clean tick, and that counter
drives `trigger_emergency_stop`. A skipped reset leaves it stale-high and can
fire a **spurious emergency stop**. The sample has to be taken, so the lock had
to go rather than be bypassed.

So `NodeTimingState` is all atomics with `&self` methods, held by `Arc`.
`BudgetEnforcer`'s map is touched only to register a node or walk every node
for a report, never on the tick path.

Reproduce any of it:

```
cargo test -p horus_core --release control_lookup_cost -- --ignored --nocapture
cargo test -p horus_core --release name_hash_cost      -- --ignored --nocapture
cargo test -p horus_core --release budget_check_cost   -- --ignored --nocapture
```

The harnesses are `#[ignore]`d — they are stopwatches, not assertions, and
wall-clock numbers would make a flaky required gate.

---

## The invariant this rests on

A node is owned by exactly one executor, so exactly one thread WRITES its
state. That is what makes `record_tick`'s reset of `consecutive_misses` safe
against `record_miss`'s increment. The counters use `fetch_add`/`fetch_max`
regardless, so a second writer would not lose a count — it would clobber the
reset, which is the dangerous half. Now written down on the type.

The ring buffer is deliberately allowed to tear for readers: it feeds
min/avg/p99 of a 1024-sample window in a shutdown report, and nothing acts on
one stale sample. That is stated where it could otherwise look like an
oversight.

## Guards

Seven tests, **each confirmed to fail when the behaviour it describes is
deliberately broken**:

- `the_deadline_ceiling_still_fires_through_a_resolved_handle` — the RT loop no
  longer calls `record_deadline_miss`; it updates the node's atomics and then
  calls `note_deadline_miss_recorded` for the process-wide half. Drop that
  second call and the per-node counter still climbs, still looks healthy in
  every report, and the robot simply never stops.
- `a_clean_tick_clears_the_miss_run_and_prevents_a_spurious_stop` — the reason
  `try_lock` was not an option, asserted directly.
- `concurrent_chains_lose_no_updates` — 8 threads, exact per-node and shared
  counts.
- `a_zero_budget_is_not_the_same_as_no_budget` — see below.
- `the_precomputed_hash_path_seeds_identically_to_the_by_name_path` and
  `an_rt_node_draws_the_documented_rng_stream_for_its_name_and_tick` — pin the
  RNG stream. A wrong hash would not fail loudly; it would quietly make an RT
  node draw a different stream than the same node draws on the main loop. The
  existing executor context test checks `dt` and `budget`, never the seed.
- `cli_pause_reaches_a_running_rt_node_through_its_cached_handle` — resolving
  handles once is only correct because `Scheduler::run` registers every node
  before calling `start_pool`, an ordering neither site stated. If that ever
  reverses, every handle resolves to `None`, pause and kill go nowhere, and
  nothing panics: the control map stays perfectly correct, just unobserved.

### Three things only the ablations found

1. `budget_ns` flattens `Option<Duration>` into one atomic, and my first
   version used `0` as the "absent" sentinel — silently turning a configured
   **zero budget** (a real, tested configuration meaning "every tick violates")
   into no budget at all. Two existing tests caught it. The sentinel is
   `u64::MAX`.
2. An earlier version of the seed test passed against a genuinely broken memo.
   A plain A,B,A,B alternation never actually hits a memo, so a stale
   write-back stays invisible; catching it needs X,Y,Y — a node ticking twice
   in a row after a different node ran. Any mixed-rate chain produces that
   constantly (1 kHz beside 10 Hz gives A,A,...,A,B,A,A,...).
3. The pause test originally **hung** instead of failing. `RtExecutor::drop`
   joins its threads, and those threads only leave the tick loop when `running`
   goes false, so an assertion firing first unwinds into a `join` that never
   returns. It now stops the pool before asserting and fails in 0.36s.

## Verification

`cargo fmt --all --check`, `cargo clippy -p horus_core --all-targets -D
warnings`, `cargo test -p horus_core --doc`, `cargo build --workspace
--release` all clean. `cargo test -p horus_core --release --lib`: **2554
passed, 0 failed**.

Integration: the failures that appear are load-sensitive and rotate between
runs — each passes in isolation on a quiet machine, and this box was at load
7-25 with a sibling build running and `/dev/shm` at 8.6G. Named for honesty:
`a_node_that_only_panics_does_not_keep_its_watchdog_fed` (already on the
`coverage.yml` skip list), `test_max_deadline_misses_stops_scheduler` (asserts
wall-clock `elapsed < 3s` for something that takes 0.04s alone, 5/5),
`a_scheduler_watchdog_does_not_cover_best_effort_nodes` (3/3 alone),
`bus_driven_thread_can_request_rt_and_learn_what_it_got` (reproduces on
unmodified `main` at db7728a4), plus two `cross_language_ipc` tests that
`import horus` with no Python extension built in this worktree.
