### PR TITLE
fix: two confirmed defects where a guard excluded the case it was written for

### DIFF
--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -2596,7 +2596,16 @@ impl Scheduler {
         // tick_once() always executes sequentially (reproducibility over wall-time).
         // The dependency graph determines ORDER, not parallelism.
         // Phase 2 rebuild: check for new topic registrations after first tick.
-        if self.first_tick_done && self.graph_registry_version > 0 {
+        // No `graph_registry_version > 0` guard here. It read as "have we
+        // seeded yet", but 0 is the legitimate seeded value for the shape this
+        // rebuild exists to serve: `Topic::new` registers nothing, registration
+        // happens lazily on the first `send()`/`recv()`, so a node that first
+        // touches a topic inside `tick()` leaves the registry at version 0 when
+        // `finalize_and_init` seeds from it. The sentinel then excluded exactly
+        // the transition it was written to catch, and the rebuild could never
+        // fire for the common program shape (#186). The `!=` below is already
+        // the whole "did the topology change" test, and it is correct from 0.
+        if self.first_tick_done {
             let current_version = crate::communication::topic_node_registry().version();
             if current_version != self.graph_registry_version {
                 self.build_dependency_graph();
@@ -5928,7 +5937,16 @@ impl Scheduler {
         // Phase 2: rebuild graph once after first tick if topology changed.
         // send()/recv() during the first tick register topics that weren't
         // visible at init() time. One rebuild captures them; then locked.
-        if self.first_tick_done && self.graph_registry_version > 0 {
+        // No `graph_registry_version > 0` guard here. It read as "have we
+        // seeded yet", but 0 is the legitimate seeded value for the shape this
+        // rebuild exists to serve: `Topic::new` registers nothing, registration
+        // happens lazily on the first `send()`/`recv()`, so a node that first
+        // touches a topic inside `tick()` leaves the registry at version 0 when
+        // `finalize_and_init` seeds from it. The sentinel then excluded exactly
+        // the transition it was written to catch, and the rebuild could never
+        // fire for the common program shape (#186). The `!=` below is already
+        // the whole "did the topology change" test, and it is correct from 0.
+        if self.first_tick_done {
             let current_version = crate::communication::topic_node_registry().version();
             if current_version != self.graph_registry_version {
                 self.build_dependency_graph();

--- a/horus_core/src/scheduling/scheduler/tests.rs
+++ b/horus_core/src/scheduling/scheduler/tests.rs
@@ -6540,3 +6540,72 @@ fn launch_rate_hz_overrides_the_compiled_in_tick_rate() {
          this was 2000us: the key was exported, validated, and read by nothing"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Phase-2 graph rebuild fires for topics first used in tick() (#186)
+// ---------------------------------------------------------------------------
+
+/// The rebuild must fire for the shape it was written for.
+///
+/// `Topic::new` registers nothing; registration is lazy, on the first
+/// `send()`/`recv()`. So a node that first touches a topic inside `tick()`
+/// leaves the registry at version 0 when `finalize_and_init` seeds
+/// `graph_registry_version` from it — and the old guard, `first_tick_done &&
+/// graph_registry_version > 0`, then excluded exactly that case forever. The
+/// sentinel meant "have we seeded yet", but 0 is a legitimate seeded value.
+///
+/// Ablation-checked: restore the `> 0` term and this fails with the version
+/// still at 0 after ticking.
+#[test]
+fn phase_two_rebuild_fires_for_a_topic_first_used_in_tick() {
+    let _guard = lock_scheduler();
+
+    struct LateTopicNode {
+        out: Option<crate::communication::Topic<u64>>,
+        name: String,
+    }
+    impl Node for LateTopicNode {
+        fn name(&self) -> &str {
+            "late_topic"
+        }
+        fn tick(&mut self) {
+            // First touch is HERE, not in init() — the shape the rebuild exists
+            // for, and the one the sentinel excluded.
+            if self.out.is_none() {
+                self.out = crate::communication::Topic::new(&self.name).ok();
+            }
+            if let Some(ref t) = self.out {
+                t.send(1u64);
+            }
+        }
+    }
+
+    let topic = format!("phase2_late_{}", std::process::id());
+    let mut scheduler = Scheduler::new().tick_rate(1000_u64.hz()).verbose(false);
+    let _ = scheduler
+        .add(LateTopicNode {
+            out: None,
+            name: topic.clone(),
+        })
+        .build();
+
+    // Two ticks: the first registers the topic, the second is where the guard
+    // is consulted with `first_tick_done` already true.
+    scheduler.tick_once().expect("first tick");
+    let registry_after_first = crate::communication::topic_node_registry().version();
+    scheduler.tick_once().expect("second tick");
+
+    assert!(
+        registry_after_first > 0,
+        "the node's send() must have registered the topic — if this is 0 the \
+         test is not exercising lazy registration and proves nothing"
+    );
+    assert_eq!(
+        scheduler.graph_registry_version,
+        crate::communication::topic_node_registry().version(),
+        "the Phase-2 rebuild must have caught up to the registry. Before #186 \
+         this stayed at its seeded 0 forever: the guard required \
+         graph_registry_version > 0, which is exactly what a topic first used \
+         in tick() can never satisfy"
+    );
+}

--- a/horus_py/src/topic.rs
+++ b/horus_py/src/topic.rs
@@ -285,7 +285,7 @@ macro_rules! pod_topic_types {
                                 Some(val.log_summary())
                             } else { None };
                             let topic_ref = topic.clone();
-                            py.detach(|| { topic_ref.lock().expect("lock").send(val); });
+                            py.detach(|| topic_lock(&topic_ref).map(|g| g.send(val)))?;
                             if let Some(s) = summary {
                                 log_ipc_event(py, node, &self.name, s,
                                     start.elapsed().as_nanos() as u64, "log_pub");
@@ -306,9 +306,7 @@ macro_rules! pod_topic_types {
                     $(
                         TopicType::$rust_ty(topic) => {
                             let topic_ref = topic.clone();
-                            let msg_opt = py.detach(|| {
-                                topic_ref.lock().expect("lock").recv()
-                            });
+                            let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv()))?;
                             if let Some(val) = msg_opt {
                                 if node.is_some() {
                                     use horus::core::LogSummary;
@@ -344,8 +342,8 @@ macro_rules! pod_topic_types {
                             } else { None };
                             let topic_ref = topic.clone();
                             let sent = py.detach(|| {
-                                topic_ref.lock().expect("lock").try_send(val).is_ok()
-                            });
+                                topic_lock(&topic_ref).map(|g| g.try_send(val).is_ok())
+                            })?;
                             if sent {
                                 if let Some(s) = summary {
                                     log_ipc_event(py, node, &self.name, s,
@@ -382,8 +380,8 @@ macro_rules! pod_topic_types {
                             // a 10 ms wait here would stop every other Python thread
                             // in the process for 10 ms.
                             let sent = py.detach(|| {
-                                topic_ref.lock().expect("lock").send_blocking(val, timeout).is_ok()
-                            });
+                                topic_lock(&topic_ref).map(|g| g.send_blocking(val, timeout).is_ok())
+                            })?;
                             if sent {
                                 if let Some(s) = summary {
                                     log_ipc_event(py, node, &self.name, s,
@@ -704,9 +702,11 @@ impl PyTopic {
                 let img = py_img.inner().clone();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.lock().expect("topic lock poisoned").send(&img);
-                    true
-                });
+                    topic_lock(&topic_ref).map(|g| {
+                        g.send(&img);
+                        true
+                    })
+                })?;
                 if node.is_some() {
                     log_ipc_event(
                         py,
@@ -724,9 +724,11 @@ impl PyTopic {
                 let pc = py_pc.inner().clone();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.lock().expect("topic lock poisoned").send(&pc);
-                    true
-                });
+                    topic_lock(&topic_ref).map(|g| {
+                        g.send(&pc);
+                        true
+                    })
+                })?;
                 if node.is_some() {
                     log_ipc_event(
                         py,
@@ -744,9 +746,11 @@ impl PyTopic {
                 let depth = py_depth.inner().clone();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.lock().expect("topic lock poisoned").send(&depth);
-                    true
-                });
+                    topic_lock(&topic_ref).map(|g| {
+                        g.send(&depth);
+                        true
+                    })
+                })?;
                 if node.is_some() {
                     log_ipc_event(
                         py,
@@ -785,7 +789,7 @@ impl PyTopic {
                     .data_slice()
                     .map_err(|e| PyRuntimeError::new_err(format!("tensor read failed: {e}")))?;
                 let success = py.detach(|| -> PyResult<bool> {
-                    let t = topic_ref.lock().expect("topic lock poisoned");
+                    let t = topic_lock(&topic_ref)?;
                     let dst = t
                         .alloc_tensor(&shape, dtype, device)
                         .map_err(|e| PyRuntimeError::new_err(format!("pool alloc failed: {e}")))?;
@@ -842,7 +846,7 @@ impl PyTopic {
                     .data_slice()
                     .map_err(|e| PyRuntimeError::new_err(format!("chunk read failed: {e}")))?;
                 let success = py.detach(|| -> PyResult<bool> {
-                    let t = topic_ref.lock().expect("topic lock poisoned");
+                    let t = topic_lock(&topic_ref)?;
                     let mut dst = t
                         .alloc_chunk(horizon, action_dim, dtype, device, t0_ns, dt_ns)
                         .map_err(|e| PyRuntimeError::new_err(format!("pool alloc failed: {e}")))?;
@@ -896,9 +900,11 @@ impl PyTopic {
                 let log_summary = msg.log_summary();
                 let topic_ref = topic.clone();
                 let success = py.detach(|| {
-                    topic_ref.lock().expect("topic lock poisoned").send(msg);
-                    true
-                });
+                    topic_lock(&topic_ref).map(|g| {
+                        g.send(msg);
+                        true
+                    })
+                })?;
                 if node.is_some() {
                     log_ipc_event(
                         py,
@@ -1165,7 +1171,7 @@ impl PyTopic {
         match &self.topic_type {
             TopicType::Image(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv()))?;
                 if let Some(img) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -1185,7 +1191,7 @@ impl PyTopic {
             }
             TopicType::PointCloud(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv()))?;
                 if let Some(pc) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -1205,7 +1211,7 @@ impl PyTopic {
             }
             TopicType::DepthImage(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv()))?;
                 if let Some(depth) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -1230,8 +1236,7 @@ impl PyTopic {
                 // the descriptor's pool_id matches this topic's pool — guarding
                 // against a cross-pool descriptor instead of silently handing back
                 // a null data pointer.
-                let msg_opt =
-                    py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv_handle());
+                let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv_handle()))?;
                 if let Some(handle) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -1268,8 +1273,7 @@ impl PyTopic {
                 // recycled — and a recycled slot is valid memory holding some
                 // other chunk's numbers, so the servo would track the wrong
                 // trajectory rather than fail.
-                let msg_opt =
-                    py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv_chunk());
+                let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv_chunk()))?;
                 if let Some(handle) = msg_opt {
                     if node.is_some() {
                         log_ipc_event(
@@ -1295,7 +1299,7 @@ impl PyTopic {
             }
             TopicType::Generic(topic) => {
                 let topic_ref = topic.clone();
-                let msg_opt = py.detach(|| topic_ref.lock().expect("topic lock poisoned").recv());
+                let msg_opt = py.detach(|| topic_lock(&topic_ref).map(|g| g.recv()))?;
                 if let Some(msg) = msg_opt {
                     if node.is_some() {
                         use horus::core::LogSummary;
@@ -1766,12 +1770,12 @@ impl PyTopic {
     ///
     /// Returns:
     ///     Number of pending messages (u64)
-    fn pending_count(&self) -> u64 {
-        topic_dispatch!(
-            &self.topic_type,
-            t,
-            topic_lock(t).map(|g| g.pending_count()).unwrap_or(0)
-        )
+    fn pending_count(&self) -> PyResult<u64> {
+        // Raises rather than reporting 0, for the reason #125 gave for the loss
+        // counters: 0 is a legitimate answer here, so `unwrap_or(0)` on a
+        // poisoned lock hands back "nothing pending" when it means "could not
+        // look" -- indistinguishable to the caller, and the wrong one to act on.
+        topic_dispatch!(&self.topic_type, t, Ok(topic_lock(t)?.pending_count()))
     }
 
     /// Messages this subscriber never saw because the publisher lapped it.
@@ -1832,24 +1836,16 @@ impl PyTopic {
     ///
     /// Returns:
     ///     Publisher count (u32)
-    fn pub_count(&self) -> u32 {
-        topic_dispatch!(
-            &self.topic_type,
-            t,
-            topic_lock(t).map(|g| g.pub_count()).unwrap_or(0)
-        )
+    fn pub_count(&self) -> PyResult<u32> {
+        topic_dispatch!(&self.topic_type, t, Ok(topic_lock(t)?.pub_count()))
     }
 
     /// Number of active subscribers on this topic.
     ///
     /// Returns:
     ///     Subscriber count (u32)
-    fn sub_count(&self) -> u32 {
-        topic_dispatch!(
-            &self.topic_type,
-            t,
-            topic_lock(t).map(|g| g.sub_count()).unwrap_or(0)
-        )
+    fn sub_count(&self) -> PyResult<u32> {
+        topic_dispatch!(&self.topic_type, t, Ok(topic_lock(t)?.sub_count()))
     }
 
     /// Read the most recent message without consuming it.
@@ -1868,7 +1864,7 @@ impl PyTopic {
         macro_rules! rl {
             ($t:expr, $py:expr, $PyT:ident) => {{
                 let tr = $t.clone();
-                let msg_opt = $py.detach(|| tr.lock().expect("topic lock poisoned").read_latest());
+                let msg_opt = $py.detach(|| topic_lock(&tr).map(|g| g.read_latest()))?;
                 match msg_opt {
                     Some(msg) => Ok(Some(Py::new($py, $PyT { inner: msg })?.into_any())),
                     None => Ok(None),
@@ -2217,6 +2213,42 @@ mod tests {
             *topic_lock(&lock).unwrap(),
             4000,
             "the topic guard must serialise all access, not just writers"
+        );
+    }
+
+    /// Every acquisition of the topic guard must go through `topic_lock`.
+    ///
+    /// #125 made the loss counters raise on a poisoned lock instead of
+    /// answering 0, because 0 was indistinguishable from "could not read". It
+    /// did not sweep the other acquisitions, so this file then held three
+    /// answers to the same event: raise, panic (20 sites across send/try_send/
+    /// send_blocking/recv/read_latest), and a silent 0 (pending_count,
+    /// pub_count, sub_count) -- the identical defect #125 had just removed.
+    ///
+    /// A behavioural test is not available here: poisoning needs a Rust panic
+    /// under the guard, which no shipped Python API can induce, and CI builds
+    /// this crate with --no-default-features precisely so the test binary does
+    /// not link libpython (see the `[lib]` note in Cargo.toml), so no #[test]
+    /// can construct a PyTopic. A source invariant is the honest substitute,
+    /// and it is the shape that actually regressed.
+    #[test]
+    fn every_topic_guard_acquisition_raises_rather_than_panics() {
+        let src = include_str!("topic.rs");
+        // Split so the needle is not contiguous in the file being searched --
+        // otherwise this guard matches its own assertion and fails whatever the
+        // code does.
+        let panicking = concat!("lock().", "expect(");
+        assert!(
+            !src.contains(panicking),
+            "a topic guard is being acquired with a panicking unwrap. SIGABRT is \
+             not catchable from Python: it takes the interpreter down with no \
+             traceback and no chance to fail over. Use topic_lock(), which raises."
+        );
+        let silent_zero = concat!("map(|g| g.", "pending_count()).unwrap_or(0)");
+        assert!(
+            !src.contains(silent_zero),
+            "a count is falling back to 0 on a poisoned lock -- the exact defect \
+             #125 removed from the loss counters"
         );
     }
 }


### PR DESCRIPTION
Closes #127, closes #186. Both are behaviour changes on published surfaces — flagged rather than slipped in.

## #127 — a poisoned topic lock had three different answers

`horus_py/src/topic.rs` handled the same event three ways:

| behaviour | sites |
|---|---|
| raise | `stats`, `missed_count`, `dropped_count` — from #125 |
| **panic** | 17 sites: `send` / `try_send` / `send_blocking` / `recv` / `read_latest` |
| **silently 0** | `pending_count`, `pub_count`, `sub_count` |

The panics are the worse half. A Rust panic across the pyo3 boundary aborts, and **SIGABRT is not catchable from Python** — no traceback, no chance to fail over, the interpreter goes down with the robot.

The silent zeros are the *exact* defect #125 removed from the loss counters, still sitting three methods away: `0` is a legitimate answer for all three, so `unwrap_or(0)` reports "nothing pending" when it means "could not look".

All 20 now go through `topic_lock()`, which raises `PyRuntimeError`.

**Breaking, narrowly:** `pending_count`/`pub_count`/`sub_count` gain `PyResult` signatures, so they can raise where they previously could not — the same change #125 made to the loss counters, for the same reason. `_horus.pyi` already declares `-> int`, which stays correct; no caller in this repo uses them.

**On the test — this one is a compromise and I would rather say so.** Poisoning needs a Rust panic under the guard, which no shipped Python API can induce, and CI builds this crate `--no-default-features` precisely so the test binary does not link libpython — so no `#[test]` here can construct a `PyTopic`. The guard asserts the *shape* that regressed, with its needle `concat!`-split so it does not match its own assertion.

## #186 — the Phase-2 rebuild could never fire

```rust
if self.first_tick_done && self.graph_registry_version > 0 {
```

The sentinel reads as "have we seeded yet", but **0 is the legitimate seeded value for exactly the shape this rebuild serves.** `Topic::new` registers nothing; registration is lazy, on the first `send()`/`recv()`. A node that first touches a topic inside `tick()` leaves the registry at version 0 when `finalize_and_init` seeds from it — so `> 0` excluded the one transition the code was written to catch, permanently, for the common program shape.

Dropped from both sites (`tick_once` and `execute_nodes`). The `!=` below it is already the whole "did the topology change" test, and it is correct from 0.

Ablation-checked — restoring the sentinel fails the new test:
```
assertion `left == right` failed
  left: 0     <- the seeded value, never advanced
 right: 1
```

## A caveat on the suite, stated rather than buried

`horus_core --lib` flaked across four passes: **2 failed, 0, 1, 0**. My test never appeared in a failure, and the scheduler module itself passed **199/199 three times running**. `/dev/shm` was at 6.1 GB with 70 entries from concurrent sessions, which is the known cause of that rotating pattern in this repo.

I could not attribute the flakes to this change, and I am not claiming they are unrelated — only that I looked, and this is what I found.

## Verified

`fmt --check` · `clippy -p horus_py --no-default-features --all-targets -D warnings` · `horus_py` 68 tests · `horus_core` scheduler 199 tests ×3.