### PR TITLE
docs(examples): sim3d is private, so say so where users hit it

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -91,7 +91,17 @@ CMake finds the library in `target/` automatically from a checkout; pass
 ## Prerequisites
 
 - [Horus](https://github.com/softmata/horus) installed (`horus` CLI available)
-- [sim3d](https://github.com/softmata/horus-sim3d) installed (for physics simulation)
+- **sim3d is not publicly available yet.** The simulator is a private
+  repository, so `https://github.com/softmata/horus-sim3d` returns 404 and
+  `horus install horus-sim3d` cannot find it (#49).
+
+  Every example still builds and runs without it — skip the `sim3d ...` line.
+  What you lose depends on the example: the control examples
+  (`differential_drive`, `differential_drive_cpp`, `quadruped`, `robot_arm`,
+  `multi_robot`) publish commands and are fully exercised on their own, while
+  `sensor_navigation` and `sensor_navigation_py` **subscribe to `lidar.scan`
+  and `imu.data`, which the simulator is what publishes** — they will start,
+  tick, and receive nothing.
 - Python 3.9+ (for `python_robot` and `sensor_navigation_py`)
 - A C++17 compiler, cmake 3.20+, and make or ninja (for `differential_drive_cpp`
   and the `horus_cpp/examples/` programs) — `horus doctor` checks all three
@@ -101,7 +111,9 @@ CMake finds the library in `target/` automatically from a checkout; pass
 Every Rust example follows the same workflow:
 
 ```bash
-# Terminal 1: start the simulator (optional — examples work without sim)
+# Terminal 1: start the simulator.
+# SKIP THIS - sim3d is not public yet (see Prerequisites). The controller
+# below runs on its own; it just has no simulated world to talk to.
 sim3d --mode visual --robot robots/<robot>.urdf --world worlds/<world>.yaml
 
 # Terminal 2: run the controller

--- a/examples/differential_drive/README.md
+++ b/examples/differential_drive/README.md
@@ -18,6 +18,11 @@ A mobile robot that drives in a square pattern. The simplest possible Horus appl
 
 **Terminal 1 — start the simulator:**
 
+> **sim3d is not public yet.** The simulator lives in a private repository,
+> so this command will not work for you — see [../README.md](../README.md#prerequisites).
+> The example below runs without it; the simulator only adds visualisation
+> and simulated sensor input.
+
 ```bash
 sim3d --mode visual --robot robots/diffbot.urdf --world worlds/flat_ground.yaml --robot-name diffbot
 ```

--- a/examples/differential_drive_cpp/README.md
+++ b/examples/differential_drive_cpp/README.md
@@ -58,6 +58,11 @@ source at the project root is detected as the main file and then never compiled.
 
 **Terminal 1 — start the simulator (optional; the controller runs without it):**
 
+> **sim3d is not public yet.** The simulator lives in a private repository,
+> so this command will not work for you — see [../README.md](../README.md#prerequisites).
+> The example below runs without it; the simulator only adds visualisation
+> and simulated sensor input.
+
 ```bash
 sim3d --mode visual --robot robots/diffbot.urdf --world worlds/flat_ground.yaml --robot-name diffbot
 ```

--- a/examples/multi_robot/README.md
+++ b/examples/multi_robot/README.md
@@ -33,6 +33,11 @@ Each scout runs proportional control toward its formation offset from the coordi
 
 **Terminal 1 — start the simulator:**
 
+> **sim3d is not public yet.** The simulator lives in a private repository,
+> so this command will not work for you — see [../README.md](../README.md#prerequisites).
+> The example below runs without it; the simulator only adds visualisation
+> and simulated sensor input.
+
 ```bash
 sim3d --mode visual --world worlds/arena.yaml
 ```

--- a/examples/quadruped/README.md
+++ b/examples/quadruped/README.md
@@ -31,6 +31,11 @@ GaitGenerator (200Hz)  -->  JointController (200Hz, RT)  -->  joint_commands
 
 **Terminal 1 — start the simulator:**
 
+> **sim3d is not public yet.** The simulator lives in a private repository,
+> so this command will not work for you — see [../README.md](../README.md#prerequisites).
+> The example below runs without it; the simulator only adds visualisation
+> and simulated sensor input.
+
 ```bash
 sim3d --mode visual --robot robots/quadruped.urdf --world worlds/terrain.yaml --robot-name quadruped
 ```

--- a/examples/robot_arm/README.md
+++ b/examples/robot_arm/README.md
@@ -18,6 +18,11 @@ A 6-DOF manipulator that sweeps through predefined waypoints. Demonstrates joint
 
 **Terminal 1 — start the simulator:**
 
+> **sim3d is not public yet.** The simulator lives in a private repository,
+> so this command will not work for you — see [../README.md](../README.md#prerequisites).
+> The example below runs without it; the simulator only adds visualisation
+> and simulated sensor input.
+
 ```bash
 sim3d --mode visual --robot robots/arm6dof.urdf --world worlds/tabletop.yaml --robot-name arm6dof
 ```

--- a/examples/sensor_navigation/README.md
+++ b/examples/sensor_navigation/README.md
@@ -30,6 +30,12 @@ SensorFrames (1Hz)     TelemetryLogger (2Hz)
 
 **Terminal 1 — start the simulator:**
 
+> **sim3d is not public yet** — it lives in a private repository, so this
+> command will not work for you (#49). This example subscribes to
+> `lidar.scan` and `imu.data`, and the simulator is what publishes them:
+> without it the node starts and ticks but receives no data. See
+> [../README.md](../README.md#prerequisites).
+
 ```bash
 sim3d --mode visual \
   --robot robots/sensor_bot.urdf \

--- a/examples/sensor_navigation_py/README.md
+++ b/examples/sensor_navigation_py/README.md
@@ -50,6 +50,12 @@ offsets in `build_frames()` are read from it.
 
 **Terminal 1 — start the simulator (it is what publishes `lidar.scan` and `imu.data`):**
 
+> **sim3d is not public yet** — it lives in a private repository, so this
+> command will not work for you (#49). This example subscribes to
+> `lidar.scan` and `imu.data`, and the simulator is what publishes them:
+> without it the node starts and ticks but receives no data. See
+> [../README.md](../README.md#prerequisites).
+
 ```bash
 sim3d --mode visual --robot robots/sensor_bot.urdf --world worlds/obstacle_course.yaml --robot-name sensor_bot
 ```


### PR DESCRIPTION
Closes #49.

The reporter ran `horus install horus-sim3d`, got *"not found in registry"*, followed the documentation link, and got a 404. Both reports are accurate, and they are the same fact:

```
$ gh repo view softmata/horus-sim3d --json visibility
{"visibility":"PRIVATE"}
$ curl -o /dev/null -w '%{http_code}' https://github.com/softmata/horus-sim3d
404
```

**`softmata/horus-sim3d` exists but is private**, so the URL 404s for everyone outside the org and the package is not installable. The registry being down (#173) is a second, independent reason the install fails — fixing one would not fix this.

## What was wrong in this repo

**Seven** example READMEs list sim3d as a prerequisite and put a `sim3d ...` command in the first terminal of their quick start, with nothing to indicate it is unobtainable. Every external user who follows them lands exactly where #49 landed.

Each now says so at the point of use, and the top-level Prerequisites entry says what you actually lose.

## The part I got wrong first

My first pass added one generic note to all seven: *"the example below runs without it; the simulator only adds visualisation and simulated sensor input."*

That is false for two of them. `sensor_navigation` subscribes to `lidar.scan` and `imu.data` (`sensor_navigation/main.rs:40,92`) and **the simulator is what publishes them** — it starts, ticks, and receives nothing. The regex that inserted the note happened to skip `sensor_navigation_py`, whose README says outright that the simulator "is what publishes" those topics, which is what caught it.

So the note is now split:

| examples | without sim3d |
|---|---|
| `differential_drive`, `differential_drive_cpp`, `quadruped`, `robot_arm`, `multi_robot` | publish commands; fully exercised standalone |
| `sensor_navigation`, `sensor_navigation_py` | start and tick, but **receive no data** |

## Scope

No code change — this is a documentation defect. What actually resolves the install is the simulator becoming public, or the registry coming back. This stops users burning an afternoon finding that out themselves.

`cargo test -p horus_manager --test docs_scaffold` — 12 passed.