### PR TITLE
fix: three drifted duplications, and a guard for the family they belong to

### DIFF
--- a/horus_core/src/scheduling/registry.rs
+++ b/horus_core/src/scheduling/registry.rs
@@ -81,8 +81,14 @@ pub struct NodeSlot {
     pub deadline_misses: AtomicU32,
     /// Watchdog severity: 0=Ok, 1=Warning, 2=Expired, 3=Critical.
     pub watchdog_severity: AtomicU8,
-    /// Padding.
-    pub _pad1: [u8; 35],
+    /// Padding to the end of cache line 2.
+    ///
+    /// 43, not 35. The counters above occupy 8+4+4+4+1 = 21 bytes from offset
+    /// 64, so reaching 128 takes 43. With 35 this struct placed
+    /// `last_tick_ns` at 120 — inside cache line 2, sharing a line with the
+    /// counters the comments above deliberately separate it from, and 8 bytes
+    /// below where every accessor in this file actually reads and writes it.
+    pub _pad1: [u8; 43],
 
     // === Cache line 3: Timing (64 bytes) ===
     /// Duration of most recent tick (nanoseconds).
@@ -98,6 +104,31 @@ pub struct NodeSlot {
 }
 
 const _: () = assert!(std::mem::size_of::<NodeSlot>() == 192);
+
+// The size assert above passed for the whole time this struct disagreed with
+// the bytes on disk: `align(64)` absorbed the 8 missing bytes of `_pad1` into
+// tail padding, so 192 held either way while every timing field sat one slot
+// low. `register_node`, `update_node` and `read_all_slots_from_path` address
+// these four by literal offset, and those literals are the on-disk truth —
+// they are what every HORUS process has ever written. Bind the two together so
+// a future reorder is a build failure rather than a silent shift.
+//
+// This is the guard `shm_layout.rs` already applies to `TopicHeader`; this
+// region simply never got one.
+const _: () = {
+    assert!(std::mem::offset_of!(NodeSlot, tick_count) == 64);
+    assert!(std::mem::offset_of!(NodeSlot, last_tick_ns) == 128);
+    assert!(std::mem::offset_of!(NodeSlot, avg_tick_ns) == 136);
+    assert!(std::mem::offset_of!(NodeSlot, max_tick_ns) == 144);
+    assert!(std::mem::offset_of!(NodeSlot, p99_tick_ns) == 152);
+    // The counters and the timing block must not share a cache line — the
+    // separation those `=== Cache line N ===` comments describe is the whole
+    // reason for the padding, and it is what `_pad1: [u8; 35]` defeated.
+    assert!(
+        std::mem::offset_of!(NodeSlot, tick_count) / 64
+            != std::mem::offset_of!(NodeSlot, last_tick_ns) / 64
+    );
+};
 
 /// Non-atomic snapshot of a `NodeSlot` for external consumers.
 #[derive(Debug, Clone)]

--- a/horus_manager/src/commands/clean.rs
+++ b/horus_manager/src/commands/clean.rs
@@ -63,7 +63,14 @@ pub fn run_clean(
                 if cache_dir.exists() {
                     items.push(serde_json::json!({
                         "type": "horus_cache",
-                        "path": "~/.horus/cache/",
+                        // The real directory, not a literal. `cache_dir()` is
+                        // the platform cache (XDG `~/.cache/horus/` on Linux),
+                        // while this string said `~/.horus/cache/` - the
+                        // installer's state root, a different place entirely.
+                        // The size and file count beside it were always
+                        // measured from the real one, so the JSON showed
+                        // correct numbers against a path they did not describe.
+                        "path": cache_dir.display().to_string(),
                         "size": get_dir_size(&cache_dir),
                         "files": count_files(&cache_dir),
                         "exists": true,

--- a/horus_manager/src/commands/launch.rs
+++ b/horus_manager/src/commands/launch.rs
@@ -1155,16 +1155,42 @@ fn launch_node(
         // NOTE: nothing in the workspace reads HORUS_NODE_PRIORITY, so this is
         // currently a no-op — kept because removing it would silently drop the
         // only trace of a user's configured value. See the `priority` field doc.
+        //
+        // The note above told maintainers; it never told the operator. Someone
+        // writing `priority: 80` in a launch file had no way to learn it was
+        // not applied, which is the same failure `rate_hz` had (#185) —
+        // parsed, validated, exported, discarded. Say it out loud until a
+        // reader exists; RT priority reaches nodes through RtConfig::priority
+        // and wiring an environment override into that is a scheduling change,
+        // not a launcher one.
+        eprintln!(
+            "  warning: node '{}' sets priority: {} — HORUS does not apply it yet. \
+             The node will run at the priority its own RtConfig requests. \
+             Set it with .priority() in the node, or an execution class.",
+            node.name, priority
+        );
         cmd.env("HORUS_NODE_PRIORITY", priority.to_string());
     }
     if let Some(rate) = node.rate_hz {
         cmd.env("HORUS_NODE_RATE_HZ", rate.to_string());
     }
+    // Namespace: the launch file's, then the node's own overriding it.
+    //
+    // Both write HORUS_NAMESPACE, which is the key the runtime actually reads
+    // (horus_sys/src/discover/mod.rs:527). The per-node value used to be
+    // exported as HORUS_NODE_NAMESPACE, a spelling that appears nowhere else in
+    // the tree - so a node-level `namespace:` was parsed, exported and ignored,
+    // and the node silently stayed in the file-level namespace. Same defect as
+    // the `rate_hz` key in #185: written on one side, read by nobody on the
+    // other, with no error to notice.
+    //
+    // Node-level last so it wins: a setting on the node is more specific than
+    // the file's default, which is the only reason to write one.
     if let Some(ref ns) = namespace {
         cmd.env("HORUS_NAMESPACE", ns);
     }
     if let Some(ref ns) = node.namespace {
-        cmd.env("HORUS_NODE_NAMESPACE", ns);
+        cmd.env("HORUS_NAMESPACE", ns);
     }
 
     // Set parameters as environment.
@@ -2386,5 +2412,91 @@ nodes:
         // Should succeed with no active sessions (not panic)
         let result = show_launch_status();
         result.unwrap();
+    }
+
+    /// Every environment key this launcher exports must have a reader.
+    ///
+    /// Two keys were exported and read by nobody: `HORUS_NODE_RATE_HZ` (#185,
+    /// now honoured in `Scheduler::finalize_config`) and
+    /// `HORUS_NODE_NAMESPACE`, whose per-node `namespace:` was parsed,
+    /// validated, exported and silently discarded because the runtime reads
+    /// `HORUS_NAMESPACE`. Both were internally consistent on the writing side,
+    /// which is why nothing caught them.
+    ///
+    /// This walks the keys this file exports and fails on any that appear
+    /// nowhere else in the workspace.
+    #[test]
+    fn every_exported_env_key_has_a_reader_somewhere() {
+        let src = include_str!("launch.rs");
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root");
+
+        // Keys this launcher hands to a child process.
+        let mut exported: Vec<String> = Vec::new();
+        for line in src.lines() {
+            let Some(rest) = line.split_once("cmd.env(\"") else {
+                continue;
+            };
+            let Some((key, _)) = rest.1.split_once('"') else {
+                continue;
+            };
+            // HORUS_PARAM_* is a prefix built at runtime, not a literal key.
+            //
+            // HORUS_NODE_PRIORITY is a KNOWN, documented no-op: the note at its
+            // export site says so, and the launcher now warns the operator at
+            // launch time. It is exempt so this guard keeps failing on NEW dead
+            // keys instead of being deleted for one it already accounts for.
+            // Delete this arm when a reader lands.
+            if key.starts_with("HORUS_") && !key.ends_with('_') && key != "HORUS_NODE_PRIORITY" {
+                exported.push(key.to_string());
+            }
+        }
+        assert!(
+            exported.len() >= 3,
+            "found {} exported keys - the scan stopped matching and proves nothing",
+            exported.len()
+        );
+
+        for key in &exported {
+            let mut readers = 0usize;
+            for dir in [
+                "horus_core/src",
+                "horus_sys/src",
+                "horus_py/src",
+                "horus/src",
+            ] {
+                let d = root.join(dir);
+                if !d.exists() {
+                    continue;
+                }
+                readers += count_key_in_tree(&d, key);
+            }
+            assert!(
+                readers > 0,
+                "`{key}` is exported to every launched node and read by nothing. \
+                 Either wire a reader or stop exporting it - a key that is \
+                 parsed, validated and discarded looks like a working feature \
+                 to whoever writes it in a launch file."
+            );
+        }
+    }
+
+    fn count_key_in_tree(dir: &std::path::Path, key: &str) -> usize {
+        let mut n = 0;
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                n += count_key_in_tree(&p, key);
+            } else if p.extension().is_some_and(|x| x == "rs")
+                && std::fs::read_to_string(&p).is_ok_and(|s| s.contains(key))
+            {
+                n += 1;
+            }
+        }
+        n
     }
 }


### PR DESCRIPTION
From a workspace-wide duplication audit (~450k LOC, six dimensions). These are the ones **I verified myself end to end** — the audit's other findings are not in this PR.

The audit targeted duplication that has *drifted*, not duplication that looks untidy. Two copies that still agree are a maintenance cost; two that have diverged are a live bug, and the code cannot tell you which is which.

## 1. `NodeSlot`'s declared layout disagreed with every accessor by 8 bytes

`registry.rs` describes the on-disk slot **twice** — once as a `#[repr(C, align(64))]` struct, once as literal offsets in `register_node`, `update_node` and `read_all_slots_from_path`. They disagreed:

```
last_tick_ns    = 120   <- accessors use 128
avg_tick_ns     = 128   <- accessors use 136
max_tick_ns     = 136   <- accessors use 144
p99_tick_ns     = 144   <- accessors use 152
```

Every timing field was one slot off, and the real p99 landed in `_pad2` where nothing could reach it. **`NodeSlot` is public** (`scheduling::registry`) and the module doc explicitly invites external tools to mmap the file and read it — so anyone using the documented type gets `last_tick_ns = 0` and everything after it shifted.

**The literals are canonical**, on two grounds: they are what every HORUS process has ever written, and they are the copy that honours the struct's own `=== Cache line 3 ===` comments. At 120, timing sits back inside the counters' cache line — the false sharing the padding exists to prevent. So `_pad1` becomes 43 and the struct moves to meet the bytes.

**The existing assert never had a chance.** `size_of::<NodeSlot>() == 192` passed the entire time, because `align(64)` absorbed the missing 8 bytes into tail padding. Added the `offset_of!` guards that `shm_layout.rs` already applies to `TopicHeader`, plus one asserting the counters and timing occupy different cache lines. Ablation — restoring `[u8; 35]`:

```
error[E0080]: evaluation panicked: assertion failed:
  std::mem::offset_of!(NodeSlot, last_tick_ns) == 128
```

## 2. A per-node `namespace:` in a launch file was silently ignored

`HORUS_NODE_NAMESPACE` was exported and read by nothing; the runtime reads `HORUS_NAMESPACE` (`horus_sys/src/discover/mod.rs:527`). Exactly the `rate_hz` defect from #185 — parsed, validated, exported, discarded. Node-level now writes `HORUS_NAMESPACE` **after** the file-level value, so the more specific setting wins.

## 3. `horus clean --json` named a directory it does not touch

`"path": "~/.horus/cache/"` printed beside a size and file count measured from `cache_dir()` — the XDG cache. Right numbers, wrong path; `~/.horus` is the installer's *state* root.

## The guard, and what it caught immediately

Every `HORUS_*` key the launcher exports must have a reader somewhere in the workspace. It failed on first run with a **third** instance: `HORUS_NODE_PRIORITY`.

That one is a *known* no-op with a note at its export site — but the note told maintainers and never told the operator. Someone writing `priority: 80` had no way to learn it was not applied. The launcher now warns at launch time. The key is exempt in the guard, with the exemption documented and scoped to delete when a reader lands, so the guard keeps failing on **new** dead keys rather than being deleted for one already accounted for.

I did not wire RT priority itself: it reaches nodes through `RtConfig::priority`, and an environment override into that is a scheduling change with SCHED_FIFO implications, not a launcher one.

## One finding I did not act on

The audit also reported that discovery hard-codes UDP port 9100. **Every `9100` in `discovery.rs` is test code** and the encoder takes the port as a parameter, so I could not confirm it and changed nothing there.

## Verified

`fmt --check` · `clippy --workspace --all-targets -D warnings` · `horus_core` registry 16 tests · `horus_manager` launch 64 tests.
