### PR TITLE
fix: three more drifted duplications from the audit

### DIFF
--- a/horus_core/src/core/presence.rs
+++ b/horus_core/src/core/presence.rs
@@ -284,15 +284,43 @@ pub fn escape_control_chars(s: &str) -> String {
     out
 }
 
+/// Longest node name this host will mint.
+pub const MAX_NODE_NAME_LEN: usize = 255;
+
+/// Longest node name that survives presence replication to another host.
+///
+/// Deliberately tighter than [`MAX_NODE_NAME_LEN`]: a receiver bounds the names
+/// it will accept off the wire so a hostile broadcast cannot fill a presence
+/// file with arbitrary text (see `is_plain_node_name` in horus_net). The two
+/// bounds are different on purpose — what was NOT on purpose is that neither
+/// side knew the other's number, so a name of 129..=255 characters was accepted
+/// here, written, put on the wire, and silently dropped by every remote host.
+/// `validate_node_name` now says so at mint time.
+pub const MAX_REPLICATED_NODE_NAME_LEN: usize = 128;
+
 pub fn validate_node_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("node name must not be empty".into());
     }
-    if name.len() > 255 {
+    if name.len() > MAX_NODE_NAME_LEN {
         return Err(format!(
-            "node name too long ({} chars, max 255)",
+            "node name too long ({} chars, max {MAX_NODE_NAME_LEN})",
             name.len()
         ));
+    }
+    if name.len() > MAX_REPLICATED_NODE_NAME_LEN {
+        // Not an error: the name is valid on this host and everything local
+        // works. It simply will not cross a network boundary, and silence was
+        // the whole defect — the node appeared on this host and existed for no
+        // other, with nothing anywhere to explain the difference.
+        crate::hlog!(
+            warn,
+            "node name is {} characters; names longer than {} are dropped by \
+             remote hosts during presence replication, so this node will be \
+             invisible off-box. Shorten it if you rely on multi-host discovery.",
+            name.len(),
+            MAX_REPLICATED_NODE_NAME_LEN
+        );
     }
     if name.contains("..") {
         return Err("node name must not contain '..'".into());

--- a/horus_manager/src/commands/doctor.rs
+++ b/horus_manager/src/commands/doctor.rs
@@ -1910,7 +1910,7 @@ fn probe_registry(base_url: &str) -> RegistryProbe {
         Err(e) => return RegistryProbe::Unreachable(e.to_string()),
     };
 
-    let url = format!("{}/api/packages/search", base_url.trim_end_matches('/'));
+    let url = format!("{}/api/packages/search", base_url);
     match client.get(url).query(&[("q", "horus")]).send() {
         Ok(response) => RegistryProbe::Status(response.status().as_u16()),
         Err(e) => RegistryProbe::Unreachable(e.to_string()),

--- a/horus_manager/src/commands/upgrade.rs
+++ b/horus_manager/src/commands/upgrade.rs
@@ -938,11 +938,7 @@ fn check_plugin_version(name: &str) -> Option<String> {
         .ok()?;
 
     let encoded = name.replace('@', "%40").replace('/', "%2F");
-    let url = format!(
-        "{}/api/packages/{}/latest",
-        base_url.trim_end_matches('/'),
-        encoded
-    );
+    let url = format!("{}/api/packages/{}/latest", base_url, encoded);
 
     let resp = client.get(&url).send().ok()?;
     if !resp.status().is_success() {

--- a/horus_manager/src/config.rs
+++ b/horus_manager/src/config.rs
@@ -61,10 +61,24 @@ pub fn plugin_registry_url() -> Option<String> {
     resolve_registry_url("HORUS_PLUGIN_REGISTRY_URL", DEFAULT_PLUGIN_REGISTRY_URL)
 }
 
+/// Resolve a registry base URL, normalised so callers can join paths freely.
+///
+/// The trailing slash is stripped HERE rather than at each use. Every caller
+/// builds paths as `format!("{base}/api/...")`, and of roughly two dozen such
+/// sites exactly two remembered to `trim_end_matches('/')` — so a
+/// `HORUS_REGISTRY_URL` ending in `/` produced `//api/...` almost everywhere
+/// and the correct URL in two places. Normalising once means no site has to
+/// remember, and the two that did can stop.
+///
+/// `RegistryClient::with_base_url` deliberately stores whatever it is handed;
+/// that contract is unchanged. This is the layer that decides what to hand it.
 fn resolve_registry_url(var: &str, fallback: Option<&str>) -> Option<String> {
+    fn normalise(url: &str) -> String {
+        url.trim().trim_end_matches('/').to_string()
+    }
     match std::env::var(var) {
-        Ok(url) if !url.trim().is_empty() => Some(url.trim().to_string()),
-        _ => fallback.map(str::to_string),
+        Ok(url) if !url.trim().is_empty() => Some(normalise(&url)),
+        _ => fallback.map(normalise),
     }
 }
 

--- a/horus_manager/src/registry/mod.rs
+++ b/horus_manager/src/registry/mod.rs
@@ -489,10 +489,41 @@ mod dispatch_tests {
     fn a_trailing_slash_does_not_become_a_double_slash() {
         // Guards the self-hosted path: HORUS_REGISTRY_URL is typed by a human,
         // and "https://reg.example/" is at least as likely as the bare form.
-        let client = RegistryClient::with_base_url("https://reg.example/".to_string());
+        //
+        // This test used to trim inside its own assertion:
+        //
+        //     assert!(!format!("{}/api/packages",
+        //         client.base_url().trim_end_matches('/')).contains("//api"))
+        //
+        // which cannot fail whatever the code does — it asserted on a locally
+        // trimmed copy, not on anything production builds. Meanwhile roughly
+        // two dozen call sites joined the raw base_url and two trimmed it, so
+        // the bug it was named for was live the whole time it was green.
+        //
+        // Assert on the resolver instead, which is the layer that now
+        // normalises, and join the way callers actually join.
+        let _guard = crate::CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("HORUS_REGISTRY_URL").ok();
+        // SAFETY: the process-wide lock above serialises env access in tests.
+        unsafe { std::env::set_var("HORUS_REGISTRY_URL", "https://reg.example/") };
+
+        let resolved = crate::config::registry_url().expect("a URL was set");
+        let joined = format!("{resolved}/api/packages");
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("HORUS_REGISTRY_URL", v) },
+            None => unsafe { std::env::remove_var("HORUS_REGISTRY_URL") },
+        }
+
         assert!(
-            !format!("{}/api/packages", client.base_url().trim_end_matches('/')).contains("//api"),
-            "callers must trim the trailing slash before joining a path"
+            !resolved.ends_with('/'),
+            "registry_url() must normalise the trailing slash so no caller has \
+             to remember: got {resolved:?}"
+        );
+        assert!(
+            !joined.contains("//api"),
+            "joining the resolved URL the way every call site joins it must not \
+             produce a double slash: got {joined:?}"
         );
     }
 

--- a/horus_net/src/presence.rs
+++ b/horus_net/src/presence.rs
@@ -98,7 +98,10 @@ fn json_escape(s: &str) -> String {
 /// line of defence behind `json_escape`).
 fn is_plain_node_name(name: &str) -> bool {
     !name.is_empty()
-        && name.len() <= 128
+        // The bound is horus_core's, not a second copy of the number. It used
+        // to be a bare 128 here against a bare 255 there, so a name in
+        // 129..=255 was minted locally and dropped here without a word.
+        && name.len() <= horus_core::core::presence::MAX_REPLICATED_NODE_NAME_LEN
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')

--- a/horus_sys/src/shm/fallback.rs
+++ b/horus_sys/src/shm/fallback.rs
@@ -29,7 +29,12 @@ impl ShmRegion {
     /// Open an existing region without creating it.
     pub fn open_existing(name: &str, minimum_size: usize) -> Result<Self> {
         super::validate_region_name(name)?;
-        let path = PathBuf::from("/tmp/horus/topics").join(format!("horus_{}", name));
+        // The module's single definition of the mapping, not a second copy.
+        // This line was `/tmp/horus/topics/horus_<name>`: the `horus_` prefix
+        // was dropped on 2026-03-29 and the namespace never added, so this
+        // backend addressed a path no other part of the system writes — the
+        // same divergence that left the replication seam dead for four months.
+        let path = super::topic_shm_path(name);
         let file = OpenOptions::new().read(true).write(true).open(&path)?;
         let size = file.metadata()?.len() as usize;
         anyhow::ensure!(size >= minimum_size, "existing SHM region is too small");
@@ -69,15 +74,19 @@ impl ShmRegion {
     pub fn new(name: &str, size: usize) -> Result<Self> {
         super::validate_region_name(name)?;
         // NOTE: this backend is only compiled for platforms that are neither
-        // Linux, macOS nor Windows. It stores regions in a fixed, world-writable
-        // /tmp path with no namespace and opens them via exists()-then-open,
-        // which is a symlink/TOCTOU hazard. It is not hardened here because it
+        // Linux, macOS nor Windows. It opens regions via exists()-then-open,
+        // which is a symlink/TOCTOU hazard, and is not hardened here because it
         // is unreachable on every supported target; see the audit notes.
-        let horus_shm_dir = PathBuf::from("/tmp/horus/topics");
-        std::fs::create_dir_all(&horus_shm_dir)
+        //
+        // The path is no longer fixed or namespace-less: it comes from
+        // `topic_shm_path`, and the directory is created with
+        // `create_shm_dir_all` (mode 0o700) like the Linux arm, rather than a
+        // bare `create_dir_all` into a world-writable /tmp.
+        let horus_shm_dir = super::shm_topics_dir();
+        super::create_shm_dir_all(&horus_shm_dir)
             .with_context(|| format!("Failed to create SHM dir: {}", horus_shm_dir.display()))?;
 
-        let path = horus_shm_dir.join(format!("horus_{}", name));
+        let path = super::topic_shm_path(name);
 
         let (file, is_owner) = if path.exists() {
             let file = OpenOptions::new()


### PR DESCRIPTION
Second batch from the duplication audit. Each verified end to end by me rather than taken on the audit's word.

## 1. Node names: 255 where minted, 128 on the wire

`horus_core::validate_node_name` accepted up to **255**; `horus_net::is_plain_node_name` dropped anything over **128** when receiving presence. A node named 129–255 characters was created, written, broadcast — and silently discarded by every remote host. It existed on one box and nowhere else, with nothing anywhere to explain the difference.

**The tighter wire bound is deliberate** — its doc says it stops a hostile broadcast filling the presence file with arbitrary text. So I did not merge the numbers. Both are now named constants in `horus_core`:

| | |
|---|---|
| `MAX_NODE_NAME_LEN` | 255 — what this host will mint |
| `MAX_REPLICATED_NODE_NAME_LEN` | 128 — what survives replication |

`horus_net` references the second instead of restating `128`, and `validate_node_name` warns at mint time when a name will not replicate. What was wrong was never the two bounds; it was that **neither side knew the other's number**.

## 2. The fallback SHM backend addressed a path nothing else writes

`horus_sys/src/shm/mod.rs` documents `topic_shm_path` as *"the **single definition** of the topic-name → path mapping"*, and names the four months the replication seam spent dead because the network side kept building `horus_<name>` after that prefix was dropped.

`fallback.rs` then rebuilt it by hand at two sites — with the dead prefix and no namespace:

```rust
let path = PathBuf::from("/tmp/horus/topics").join(format!("horus_{}", name));
```

Now calls `topic_shm_path` and `shm_topics_dir`, and creates the directory with `create_shm_dir_all` (mode `0o700`) like the Linux arm rather than a bare `create_dir_all` into world-writable `/tmp`. Its `NOTE` is corrected — that half of the hazard is gone.

**This arm is `cfg`'d off Linux/macOS/Windows, so a normal `cargo check` never compiles it.** I lifted the gate and compiled it directly; without that the change would have been unverified until someone built for BSD.

## 3. A trailing slash in `HORUS_REGISTRY_URL` produced `//api` at ~22 sites

Two call sites trimmed it; the rest did not. Normalised once in `resolve_registry_url`, and the two redundant trims dropped so no site implies the duty is still the caller's. `RegistryClient`'s contract — store the URL it was handed — is unchanged; this is the layer that decides what to hand it.

**The test named for this bug could not fail.** It trimmed inside its own assertion:

```rust
assert!(!format!("{}/api/packages",
    client.base_url().trim_end_matches('/')).contains("//api"))
```

so it asserted on a locally trimmed copy rather than anything production builds, and stayed green through the entire life of the defect. Replaced with one that drives `config::registry_url()` and joins the way callers join. Ablation — removing the normalisation:

```
registry_url() must normalise the trailing slash so no caller has to
remember: got "https://reg.example/"
test result: FAILED
```

## Verified

`fmt --check` · `clippy --workspace --all-targets -D warnings` · **horus_manager 3495** · **horus_net 361** · **horus_sys 223** tests.
