### PR TITLE
fix(shm): two more hand-restated copies of geometry the layout module owns

### DIFF
--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -1627,28 +1627,37 @@ fn read_slot_inner(
             mmap.get(slot_start..end)?.to_vec()
         } else {
             // Split layout: [HEADER (640)] [SEQ_ARRAY (cap * 8)] [DATA (cap * type_size)]
-            let seq_array_size = capacity * std::mem::size_of::<u64>();
-            let data_region_start = TOPIC_HEADER_SIZE + seq_array_size;
-            let required = data_region_start + capacity * type_size;
+            //
+            // Through `shm_layout`, like the colo arm three lines above. This
+            // used to restate the arithmetic — `TOPIC_HEADER_SIZE + capacity * 8
+            // + capacity * type_size` — with `*` rather than the checked helper,
+            // on two u32s read straight out of a header another process wrote.
+            // A release profile has no overflow-checks, so on a 32-bit target
+            // the product wraps and a truncated file satisfies a check for a
+            // ring that does not fit. The slot was then taken with `mmap[a..b]`,
+            // which panics, where the colo arm uses `.get(..)?`.
+            let required = super::shm_layout::required_region_len_checked(capacity, type_size)?;
             if mmap.len() < required {
                 return None;
             }
-            let slot_start = data_region_start + last_written * type_size;
-            mmap[slot_start..slot_start + type_size].to_vec()
+            let slot_start = super::shm_layout::data_slot_offset(capacity, last_written, type_size);
+            let end = slot_start.checked_add(type_size)?;
+            mmap.get(slot_start..end)?.to_vec()
         }
     } else {
         if slot_size < 16 || capacity == 0 {
             return None;
         }
         // Serde layout: [header (640B)] [seq_array (cap * 8B)] [data slots (cap * slot_size)]
-        let seq_array_size = capacity * std::mem::size_of::<u64>();
-        let data_region_start = TOPIC_HEADER_SIZE + seq_array_size;
-        let required = data_region_start + capacity * slot_size;
+        //
+        // Same helpers as the POD arms, for the same reason: the multiplication
+        // is over header-supplied values and must not wrap silently.
+        let required = super::shm_layout::required_region_len_checked(capacity, slot_size)?;
         if mmap.len() < required {
             return None;
         }
         // Slot layout: [8 bytes padding][8 bytes data-len (u64 LE)][data…]
-        let slot_start = data_region_start + last_written * slot_size;
+        let slot_start = super::shm_layout::data_slot_offset(capacity, last_written, slot_size);
         let len_offset = slot_start + 8;
         let data_offset = slot_start + 16;
         // SAFETY: len_offset is within mmap bounds (validated by required size check above);

--- a/horus_manager/src/discovery/topics.rs
+++ b/horus_manager/src/discovery/topics.rs
@@ -15,7 +15,13 @@ pub(super) fn discover_shared_memory_uncached() -> HorusResult<Vec<SharedMemoryI
     for t in &sys_topics {
         if !t.is_alive && t.creator_pid > 0 {
             let topic_path = topics_dir.join(&t.name);
-            let meta_path = topics_dir.join(format!("{}.meta", t.name.replace('.', "_")));
+            // horus_sys owns this mapping. This line used to be
+            // `t.name.replace('.', "_")`, which agrees with
+            // `sanitize_namespace` only for names whose sole special character
+            // is a dot — a topic like `robot-arm/imu` produced
+            // `robot-arm/imu.meta`, a path that cannot exist, so its sidecar
+            // was never reaped and accumulated for the life of the machine.
+            let meta_path = horus_sys::shm::topic_meta_path(&t.name);
             let _ = std::fs::remove_file(&topic_path);
             let _ = std::fs::remove_file(&meta_path);
         }

--- a/horus_sys/src/shm/mod.rs
+++ b/horus_sys/src/shm/mod.rs
@@ -3307,15 +3307,36 @@ mod meta_path_tests {
                  a stem carrying `/` names a directory that does not exist, which is how \
                  these files stopped being reaped"
             );
+            // `file_name()` alone cannot see the bug this test exists for.
+            // A mapping that let `/` through would produce
+            // `<topics>/robot-arm/imu.meta`, whose file_name is `imu.meta` and
+            // whose stem is `imu` - both assertions above pass. What actually
+            // breaks the reaper is the sidecar not being a direct child of the
+            // topics directory, so assert that.
+            assert_eq!(
+                p.parent(),
+                Some(shm_topics_dir().as_path()),
+                "{name}: the sidecar must sit directly in {}, not in a subdirectory of it; \
+                 got {}",
+                shm_topics_dir().display(),
+                p.display()
+            );
         }
 
         // The specific disagreement: dot-only replacement is not enough.
-        let naive = "robot-arm/imu".replace('.', "_");
+        //
+        // Compare whole paths. Comparing `file_name()` against `"robot-arm/imu.meta"`
+        // - which is what this used to do - can never fail: a file name cannot
+        // contain a path separator, so the assertion held no matter what
+        // `topic_meta_path` returned.
+        let naive = shm_topics_dir().join(format!("{}.meta", "robot-arm/imu".replace('.', "_")));
         let real = topic_meta_path("robot-arm/imu");
         assert_ne!(
-            real.file_name().unwrap().to_str().unwrap(),
-            format!("{naive}.meta"),
-            "if these ever agree the test has stopped discriminating"
+            real,
+            naive,
+            "topic_meta_path must not be the naive dot-only replacement; that mapping \
+             yields {} , a path under a directory that is never created",
+            naive.display()
         );
     }
 }

--- a/horus_sys/src/shm/mod.rs
+++ b/horus_sys/src/shm/mod.rs
@@ -1081,11 +1081,25 @@ pub fn write_topic_meta(name: &str, size: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The `.meta` sidecar path for a topic.
+///
+/// The single definition of this mapping, for the same reason `topic_shm_path`
+/// is the single definition of the region mapping. `sanitize_namespace` maps
+/// every byte outside `[A-Za-z0-9_]` to `_`, and topic names legally contain
+/// `-`, `/` and `.` — so a name like `robot-arm/imu` lands at
+/// `robot_arm_imu.meta`. horus_manager's stale-topic reaper used to compute
+/// this itself as `name.replace('.', "_")`, which agrees only for names whose
+/// sole special character is a dot: for anything with a `-` or `/` it produced
+/// a path that cannot exist, and those sidecars were never reaped.
+pub fn topic_meta_path(name: &str) -> PathBuf {
+    shm_topics_dir().join(format!("{}.meta", sanitize_namespace(name)))
+}
+
 /// Remove a topic metadata file. Best-effort — errors are silently ignored.
 ///
 /// Called by ShmRegion::drop when the owner releases the region.
 pub fn remove_topic_meta(name: &str) {
-    let path = shm_topics_dir().join(format!("{}.meta", sanitize_namespace(name)));
+    let path = topic_meta_path(name);
     if let Err(e) = std::fs::remove_file(&path) {
         if e.kind() != std::io::ErrorKind::NotFound {
             log::debug!("Failed to remove topic meta {}: {}", path.display(), e);
@@ -3261,5 +3275,47 @@ mod untrusted_meta_tests {
 
         let _ = std::fs::remove_file(&hostile);
         let _ = std::fs::remove_file(&good);
+    }
+}
+
+#[cfg(test)]
+mod meta_path_tests {
+    use super::*;
+
+    /// The sidecar mapping must handle every character a topic name may carry.
+    ///
+    /// horus_manager's reaper computed this as `name.replace('.', "_")`, which
+    /// agrees with `sanitize_namespace` only when the name's sole special
+    /// character is a dot. Topic names legally contain `-`, `/` and `.`
+    /// (horus_core topic name validation), and `horus_sys/tests/parity_shm.rs`
+    /// exercises `sensor.imu/v1`. For anything with a `-` or `/` the two
+    /// disagreed, the reaper looked for a path that cannot exist, and the
+    /// sidecar was never removed.
+    #[test]
+    fn the_sidecar_mapping_covers_every_legal_topic_character() {
+        for name in ["cmd_vel", "sensor.imu", "sensor.imu/v1", "robot-arm/imu"] {
+            let p = topic_meta_path(name);
+            let file = p.file_name().unwrap().to_str().unwrap();
+            assert!(
+                file.ends_with(".meta"),
+                "{name}: expected a .meta sidecar, got {file}"
+            );
+            let stem = file.strip_suffix(".meta").unwrap();
+            assert!(
+                stem.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+                "{name}: the sidecar stem must be sanitised to [A-Za-z0-9_], got {stem:?} - \
+                 a stem carrying `/` names a directory that does not exist, which is how \
+                 these files stopped being reaped"
+            );
+        }
+
+        // The specific disagreement: dot-only replacement is not enough.
+        let naive = "robot-arm/imu".replace('.', "_");
+        let real = topic_meta_path("robot-arm/imu");
+        assert_ne!(
+            real.file_name().unwrap().to_str().unwrap(),
+            format!("{naive}.meta"),
+            "if these ever agree the test has stopped discriminating"
+        );
     }
 }


### PR DESCRIPTION
Fifth batch from the duplication audit.

## 1. `read_slot_inner` restated the layout arithmetic in two of its three arms

The **colo** arm calls `colo_required_region_len` and `colo_payload_offset`. Three lines below it, the **split** arm wrote the same thing out by hand:

```rust
let seq_array_size = capacity * std::mem::size_of::<u64>();
let data_region_start = TOPIC_HEADER_SIZE + seq_array_size;
let required = data_region_start + capacity * type_size;
...
mmap[slot_start..slot_start + type_size].to_vec()
```

and the **serde** arm did the same with `slot_size`. Two problems, both of which the helpers exist to prevent:

- bare `*` on two `u32`s read out of a header another process wrote. A robot's release profile has **no `overflow-checks`**, so on a 32-bit controller the product wraps and a truncated file satisfies a check for a ring that does not fit.
- `mmap[a..b]` **panics**, where the colo arm three lines up uses `.get(..)?`.

Both now use `required_region_len_checked` and `data_slot_offset`. The helpers compute identical values for every shape I checked:

| capacity | type_size | hand-written | helper |
|---:|---:|---:|---:|
| 8 | 4 | 736 | 736 |
| 1024 | 16 | 25216 | 25216 |
| 64 | 304 | 20608 | 20608 |

So this is a substitution, not a behaviour change. What changes is that overflow and out-of-bounds now return `None` instead of wrapping or panicking.

## 2. The `.meta` sidecar mapping was reimplemented in `horus_manager`

`horus_sys` builds it with `sanitize_namespace`, which maps every byte outside `[A-Za-z0-9_]` to `_`. The manager's stale-topic reaper built it as `name.replace('.', "_")` — which agrees **only** when the name's sole special character is a dot.

Topic names legally carry `-`, `/` and `.`, and `horus_sys/tests/parity_shm.rs` already exercises `sensor.imu/v1`. So for `robot-arm/imu`:

| | |
|---|---|
| `horus_sys` writes | `robot_arm_imu.meta` |
| the reaper looked for | `robot-arm/imu.meta` |

That second path **cannot exist** — the `/` names a directory. Those sidecars were never reaped, and accumulated for the life of the machine.

Added `horus_sys::shm::topic_meta_path` as the single definition, alongside `topic_shm_path` (whose doc already records the four months the replication seam spent broken for exactly this reason). Both `horus_sys` sites and the manager use it. Purely additive to the public surface.

The test asserts the sanitised stem for every legal character class, and asserts the naive dot-only form **disagrees** — so it fails if it ever stops discriminating.

## Verified

`fmt --check` · `clippy --workspace --all-targets -D warnings` · **horus_sys 224** · **horus_manager 3497** · **horus_core communication 664** tests.
