### PR TITLE
fix(registry): the installer's crate list omitted the one crate everyone uses

### DIFF
--- a/horus_manager/src/registry/helpers.rs
+++ b/horus_manager/src/registry/helpers.rs
@@ -1052,7 +1052,11 @@ pub(crate) fn extract_package_dependencies(dir: &Path) -> Result<Vec<DependencyS
     Ok(dependencies)
 }
 
-/// Check if a Cargo.toml has dependencies on horus crates (horus_core, horus_library, horus_macros)
+/// Whether a Cargo.toml depends on any crate HORUS ships.
+///
+/// The set is `error_wrapper::FIRST_PARTY_CRATES`. The doc here used to name
+/// three of them — and so did the code — which left out the one a real package
+/// is most likely to use.
 fn cargo_toml_has_horus_deps(package_dir: &Path) -> bool {
     let cargo_toml_path = package_dir.join(CARGO_TOML);
     let content = match fs::read_to_string(&cargo_toml_path) {
@@ -1067,9 +1071,15 @@ fn cargo_toml_has_horus_deps(package_dir: &Path) -> bool {
         Some(d) => d,
         None => return false,
     };
-    deps.contains_key("horus_core")
-        || deps.contains_key("horus_library")
-        || deps.contains_key("horus_macros")
+    // The shared list, not a third copy of it. This used to name exactly
+    // horus_core, horus_library and horus_macros - omitting `horus`, the
+    // facade crate every `horus new` scaffold writes and every documented
+    // example imports (`use horus::prelude::*`). So a published package
+    // depending on `horus` was not recognised as depending on HORUS at all,
+    // and the path overrides that point cargo at the local source tree were
+    // never injected for it.
+    deps.keys()
+        .any(|k| crate::error_wrapper::is_first_party_crate(k))
 }
 
 /// The command HORUS prints when it cannot find its own source tree — the "I
@@ -2156,7 +2166,7 @@ pub fn generate_signing_keypair() -> Result<()> {
 
 #[cfg(test)]
 mod system_package_name_tests {
-    use super::is_safe_system_package_name;
+    use super::{cargo_toml_has_horus_deps, is_safe_system_package_name};
 
     #[test]
     fn accepts_real_package_names() {
@@ -2223,5 +2233,50 @@ mod system_package_name_tests {
         assert!(!is_safe_system_package_name(".hidden"));
         assert!(!is_safe_system_package_name(&"a".repeat(129)));
         assert!(is_safe_system_package_name(&"a".repeat(128)));
+    }
+
+    /// A package depending on the `horus` facade must be recognised.
+    ///
+    /// `cargo_toml_has_horus_deps` gates whether `horus install` injects the
+    /// path overrides that point cargo at the local HORUS source tree. It used
+    /// to name horus_core, horus_library and horus_macros explicitly — leaving
+    /// out `horus`, which is what `horus new` writes and what every documented
+    /// example imports. So the most ordinary package shape there is went
+    /// unrecognised, and the check that was supposed to catch HORUS packages
+    /// caught only the ones nobody writes by hand.
+    #[test]
+    fn a_package_depending_on_the_facade_is_recognised() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        for (name, dep) in [
+            ("facade", "horus = \"0.4.1\""),
+            ("core", "horus_core = \"0.4.1\""),
+            ("macros", "horus_macros = \"0.4.1\""),
+        ] {
+            let dir = tmp.path().join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("Cargo.toml"),
+                format!("[package]\nname = \"p\"\n\n[dependencies]\n{dep}\n"),
+            )
+            .unwrap();
+            assert!(
+                cargo_toml_has_horus_deps(&dir),
+                "a package depending on `{dep}` must be recognised as a HORUS package"
+            );
+        }
+
+        // And a package that depends on none of ours still is not one.
+        let other = tmp.path().join("unrelated");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(
+            other.join("Cargo.toml"),
+            "[package]\nname = \"p\"\n\n[dependencies]\nserde = \"1\"\n",
+        )
+        .unwrap();
+        assert!(
+            !cargo_toml_has_horus_deps(&other),
+            "the check must still discriminate, or it is not a check"
+        );
     }
 }


### PR DESCRIPTION
Seventh batch from the duplication audit.

`cargo_toml_has_horus_deps` gates whether `horus install` injects the `[patch]` path overrides that point cargo at the local HORUS source tree. It named three crates:

```rust
deps.contains_key("horus_core")
    || deps.contains_key("horus_library")
    || deps.contains_key("horus_macros")
```

**`horus` is not among them** — the facade crate that `horus new` writes into every scaffold, and that every documented example imports as `use horus::prelude::*`.

So a published package whose `Cargo.toml` says `horus = "0.4.1"` was not recognised as depending on HORUS at all, and the overrides were never injected for it. The check meant to catch HORUS packages caught only the shapes nobody writes by hand.

## Why this was hard to see by reading

`error_wrapper::FIRST_PARTY_CRATES` is the canonical list — thirteen names, with a doc explaining exactly why they matter and what cargo prints when they cannot be resolved. The installer carried a three-name copy, **and its own doc comment restated the same three**:

```rust
/// Check if a Cargo.toml has dependencies on horus crates
/// (horus_core, horus_library, horus_macros)
```

The code and its documentation agreed with each other and disagreed with reality. Nothing in the file looks wrong until you compare it against a list two modules over.

Now calls `is_first_party_crate`; the doc names the set instead of enumerating a stale subset of it.

## Ablation

Restore the three-name list and the test fails:

```
a package depending on `horus = "0.4.1"` must be recognised as a HORUS package
test result: FAILED
```

It also asserts an unrelated package (`serde` only) is still **not** matched, so the check cannot pass by becoming indiscriminate.

## Verified

`fmt --check` · `clippy -p horus_manager --all-targets -D warnings` · `registry` 187 tests · `error_wrapper` 86 tests.
