### PR TITLE
fix: fold duplication batches 5-7 (#200, #201, #202) into one CI cycle

### DIFF
--- a/horus_core/src/communication/topic/header.rs
+++ b/horus_core/src/communication/topic/header.rs
@@ -1627,28 +1627,37 @@ fn read_slot_inner(
             mmap.get(slot_start..end)?.to_vec()
         } else {
             // Split layout: [HEADER (640)] [SEQ_ARRAY (cap * 8)] [DATA (cap * type_size)]
-            let seq_array_size = capacity * std::mem::size_of::<u64>();
-            let data_region_start = TOPIC_HEADER_SIZE + seq_array_size;
-            let required = data_region_start + capacity * type_size;
+            //
+            // Through `shm_layout`, like the colo arm three lines above. This
+            // used to restate the arithmetic — `TOPIC_HEADER_SIZE + capacity * 8
+            // + capacity * type_size` — with `*` rather than the checked helper,
+            // on two u32s read straight out of a header another process wrote.
+            // A release profile has no overflow-checks, so on a 32-bit target
+            // the product wraps and a truncated file satisfies a check for a
+            // ring that does not fit. The slot was then taken with `mmap[a..b]`,
+            // which panics, where the colo arm uses `.get(..)?`.
+            let required = super::shm_layout::required_region_len_checked(capacity, type_size)?;
             if mmap.len() < required {
                 return None;
             }
-            let slot_start = data_region_start + last_written * type_size;
-            mmap[slot_start..slot_start + type_size].to_vec()
+            let slot_start = super::shm_layout::data_slot_offset(capacity, last_written, type_size);
+            let end = slot_start.checked_add(type_size)?;
+            mmap.get(slot_start..end)?.to_vec()
         }
     } else {
         if slot_size < 16 || capacity == 0 {
             return None;
         }
         // Serde layout: [header (640B)] [seq_array (cap * 8B)] [data slots (cap * slot_size)]
-        let seq_array_size = capacity * std::mem::size_of::<u64>();
-        let data_region_start = TOPIC_HEADER_SIZE + seq_array_size;
-        let required = data_region_start + capacity * slot_size;
+        //
+        // Same helpers as the POD arms, for the same reason: the multiplication
+        // is over header-supplied values and must not wrap silently.
+        let required = super::shm_layout::required_region_len_checked(capacity, slot_size)?;
         if mmap.len() < required {
             return None;
         }
         // Slot layout: [8 bytes padding][8 bytes data-len (u64 LE)][data…]
-        let slot_start = data_region_start + last_written * slot_size;
+        let slot_start = super::shm_layout::data_slot_offset(capacity, last_written, slot_size);
         let len_offset = slot_start + 8;
         let data_offset = slot_start + 16;
         // SAFETY: len_offset is within mmap bounds (validated by required size check above);

--- a/horus_manager/src/cargo_gen.rs
+++ b/horus_manager/src/cargo_gen.rs
@@ -1813,19 +1813,18 @@ pub fn generate_workspace(
         // Auto-inject horus core path deps. Required — see the note on the
         // single-package path above; an empty section yields unresolvable
         // imports in every workspace member.
+        //
+        // `write_horus_path_deps`, not a second copy of its loop. The copy that
+        // used to be here emitted `name = { path = "…" }` and dropped the
+        // `features = [...]` clause, so `horus_dep_features` — which turns
+        // `enable = ["net"]` in horus.toml, and `HORUS_ENABLE` from
+        // `horus run --net`, into the `net` cargo feature — reached
+        // single-package projects and no workspace project at all. A user
+        // asking for LAN replication in a workspace got a build without it and
+        // no error: the feature was parsed, resolved, and dropped on the floor
+        // one generator over. Members inherit through `horus.workspace = true`.
         {
-            for dep_name in &["horus", "horus_core", "horus_library", "horus_macros"] {
-                let dep_path = horus_source.join(dep_name);
-                if dep_path.exists() && dep_path.join("Cargo.toml").exists() {
-                    writeln!(
-                        root_cargo,
-                        "{} = {{ path = \"{}\" }}",
-                        dep_name,
-                        toml_path(dep_path.display())
-                    )
-                    .unwrap();
-                }
-            }
+            write_horus_path_deps(&mut root_cargo, &horus_source, root_manifest);
             // serde is implicit — see write_implicit_deps. Members opt in via
             // `serde = { workspace = true }` (added in generate_member_cargo).
             //
@@ -5144,5 +5143,51 @@ mod tests {
 
         assert!(!dir.path().join(".cargo").exists());
         assert!(!horus_dir.join(".cargo/config.toml").exists());
+    }
+
+    /// A workspace project must get the same cargo features a single-package
+    /// project gets.
+    ///
+    /// `horus_dep_features` turns `enable = ["net"]` in horus.toml — and
+    /// `HORUS_ENABLE`, which `horus run --net` sets — into the `net` feature on
+    /// the `horus` dependency. It had exactly one caller,
+    /// `write_horus_path_deps`, which had exactly one caller: the
+    /// single-package generator. The workspace generator carried its own copy
+    /// of that loop with the `features = [...]` clause missing, so asking for
+    /// LAN replication in a workspace produced a build without it and no error.
+    ///
+    /// This asserts on the emitted TOML, which is the artifact that decides
+    /// what cargo compiles.
+    #[test]
+    fn the_workspace_generator_emits_the_features_the_manifest_asks_for() {
+        let mut manifest = HorusManifest::default();
+        manifest.enable = vec!["net".to_string()];
+        let features = horus_dep_features(&manifest);
+        assert!(
+            features.iter().any(|f| f == "net"),
+            "enable = [\"net\"] must resolve to the `net` cargo feature; got {features:?}"
+        );
+
+        // The shared writer must put them in the TOML for any caller.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = tmp.path();
+        for c in ["horus", "horus_core", "horus_macros"] {
+            std::fs::create_dir_all(src.join(c)).unwrap();
+            std::fs::write(src.join(c).join("Cargo.toml"), "[package]\n").unwrap();
+        }
+        let mut out = String::new();
+        write_horus_path_deps(&mut out, src, &manifest);
+
+        let horus_line = out
+            .lines()
+            .find(|l| l.starts_with("horus = "))
+            .expect("the horus dependency must be written");
+        assert!(
+            horus_line.contains("features = [\"net\"]"),
+            "the `horus` dep must carry the requested features. The workspace \
+             generator used to emit this line without them, which is how \
+             `horus run --net` silently produced a build with no replication. \
+             Got: {horus_line}"
+        );
     }
 }

--- a/horus_manager/src/discovery/topics.rs
+++ b/horus_manager/src/discovery/topics.rs
@@ -15,7 +15,13 @@ pub(super) fn discover_shared_memory_uncached() -> HorusResult<Vec<SharedMemoryI
     for t in &sys_topics {
         if !t.is_alive && t.creator_pid > 0 {
             let topic_path = topics_dir.join(&t.name);
-            let meta_path = topics_dir.join(format!("{}.meta", t.name.replace('.', "_")));
+            // horus_sys owns this mapping. This line used to be
+            // `t.name.replace('.', "_")`, which agrees with
+            // `sanitize_namespace` only for names whose sole special character
+            // is a dot — a topic like `robot-arm/imu` produced
+            // `robot-arm/imu.meta`, a path that cannot exist, so its sidecar
+            // was never reaped and accumulated for the life of the machine.
+            let meta_path = horus_sys::shm::topic_meta_path(&t.name);
             let _ = std::fs::remove_file(&topic_path);
             let _ = std::fs::remove_file(&meta_path);
         }

--- a/horus_manager/src/registry/helpers.rs
+++ b/horus_manager/src/registry/helpers.rs
@@ -1052,7 +1052,11 @@ pub(crate) fn extract_package_dependencies(dir: &Path) -> Result<Vec<DependencyS
     Ok(dependencies)
 }
 
-/// Check if a Cargo.toml has dependencies on horus crates (horus_core, horus_library, horus_macros)
+/// Whether a Cargo.toml depends on any crate HORUS ships.
+///
+/// The set is `error_wrapper::FIRST_PARTY_CRATES`. The doc here used to name
+/// three of them — and so did the code — which left out the one a real package
+/// is most likely to use.
 fn cargo_toml_has_horus_deps(package_dir: &Path) -> bool {
     let cargo_toml_path = package_dir.join(CARGO_TOML);
     let content = match fs::read_to_string(&cargo_toml_path) {
@@ -1067,9 +1071,15 @@ fn cargo_toml_has_horus_deps(package_dir: &Path) -> bool {
         Some(d) => d,
         None => return false,
     };
-    deps.contains_key("horus_core")
-        || deps.contains_key("horus_library")
-        || deps.contains_key("horus_macros")
+    // The shared list, not a third copy of it. This used to name exactly
+    // horus_core, horus_library and horus_macros - omitting `horus`, the
+    // facade crate every `horus new` scaffold writes and every documented
+    // example imports (`use horus::prelude::*`). So a published package
+    // depending on `horus` was not recognised as depending on HORUS at all,
+    // and the path overrides that point cargo at the local source tree were
+    // never injected for it.
+    deps.keys()
+        .any(|k| crate::error_wrapper::is_first_party_crate(k))
 }
 
 /// The command HORUS prints when it cannot find its own source tree — the "I
@@ -2156,7 +2166,7 @@ pub fn generate_signing_keypair() -> Result<()> {
 
 #[cfg(test)]
 mod system_package_name_tests {
-    use super::is_safe_system_package_name;
+    use super::{cargo_toml_has_horus_deps, is_safe_system_package_name};
 
     #[test]
     fn accepts_real_package_names() {
@@ -2223,5 +2233,50 @@ mod system_package_name_tests {
         assert!(!is_safe_system_package_name(".hidden"));
         assert!(!is_safe_system_package_name(&"a".repeat(129)));
         assert!(is_safe_system_package_name(&"a".repeat(128)));
+    }
+
+    /// A package depending on the `horus` facade must be recognised.
+    ///
+    /// `cargo_toml_has_horus_deps` gates whether `horus install` injects the
+    /// path overrides that point cargo at the local HORUS source tree. It used
+    /// to name horus_core, horus_library and horus_macros explicitly — leaving
+    /// out `horus`, which is what `horus new` writes and what every documented
+    /// example imports. So the most ordinary package shape there is went
+    /// unrecognised, and the check that was supposed to catch HORUS packages
+    /// caught only the ones nobody writes by hand.
+    #[test]
+    fn a_package_depending_on_the_facade_is_recognised() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        for (name, dep) in [
+            ("facade", "horus = \"0.4.1\""),
+            ("core", "horus_core = \"0.4.1\""),
+            ("macros", "horus_macros = \"0.4.1\""),
+        ] {
+            let dir = tmp.path().join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("Cargo.toml"),
+                format!("[package]\nname = \"p\"\n\n[dependencies]\n{dep}\n"),
+            )
+            .unwrap();
+            assert!(
+                cargo_toml_has_horus_deps(&dir),
+                "a package depending on `{dep}` must be recognised as a HORUS package"
+            );
+        }
+
+        // And a package that depends on none of ours still is not one.
+        let other = tmp.path().join("unrelated");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(
+            other.join("Cargo.toml"),
+            "[package]\nname = \"p\"\n\n[dependencies]\nserde = \"1\"\n",
+        )
+        .unwrap();
+        assert!(
+            !cargo_toml_has_horus_deps(&other),
+            "the check must still discriminate, or it is not a check"
+        );
     }
 }

--- a/horus_sys/src/shm/mod.rs
+++ b/horus_sys/src/shm/mod.rs
@@ -3307,15 +3307,36 @@ mod meta_path_tests {
                  a stem carrying `/` names a directory that does not exist, which is how \
                  these files stopped being reaped"
             );
+            // `file_name()` alone cannot see the bug this test exists for.
+            // A mapping that let `/` through would produce
+            // `<topics>/robot-arm/imu.meta`, whose file_name is `imu.meta` and
+            // whose stem is `imu` - both assertions above pass. What actually
+            // breaks the reaper is the sidecar not being a direct child of the
+            // topics directory, so assert that.
+            assert_eq!(
+                p.parent(),
+                Some(shm_topics_dir().as_path()),
+                "{name}: the sidecar must sit directly in {}, not in a subdirectory of it; \
+                 got {}",
+                shm_topics_dir().display(),
+                p.display()
+            );
         }
 
         // The specific disagreement: dot-only replacement is not enough.
-        let naive = "robot-arm/imu".replace('.', "_");
+        //
+        // Compare whole paths. Comparing `file_name()` against `"robot-arm/imu.meta"`
+        // - which is what this used to do - can never fail: a file name cannot
+        // contain a path separator, so the assertion held no matter what
+        // `topic_meta_path` returned.
+        let naive = shm_topics_dir().join(format!("{}.meta", "robot-arm/imu".replace('.', "_")));
         let real = topic_meta_path("robot-arm/imu");
         assert_ne!(
-            real.file_name().unwrap().to_str().unwrap(),
-            format!("{naive}.meta"),
-            "if these ever agree the test has stopped discriminating"
+            real,
+            naive,
+            "topic_meta_path must not be the naive dot-only replacement; that mapping \
+             yields {} , a path under a directory that is never created",
+            naive.display()
         );
     }
 }

--- a/horus_sys/src/shm/mod.rs
+++ b/horus_sys/src/shm/mod.rs
@@ -1081,11 +1081,25 @@ pub fn write_topic_meta(name: &str, size: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The `.meta` sidecar path for a topic.
+///
+/// The single definition of this mapping, for the same reason `topic_shm_path`
+/// is the single definition of the region mapping. `sanitize_namespace` maps
+/// every byte outside `[A-Za-z0-9_]` to `_`, and topic names legally contain
+/// `-`, `/` and `.` — so a name like `robot-arm/imu` lands at
+/// `robot_arm_imu.meta`. horus_manager's stale-topic reaper used to compute
+/// this itself as `name.replace('.', "_")`, which agrees only for names whose
+/// sole special character is a dot: for anything with a `-` or `/` it produced
+/// a path that cannot exist, and those sidecars were never reaped.
+pub fn topic_meta_path(name: &str) -> PathBuf {
+    shm_topics_dir().join(format!("{}.meta", sanitize_namespace(name)))
+}
+
 /// Remove a topic metadata file. Best-effort — errors are silently ignored.
 ///
 /// Called by ShmRegion::drop when the owner releases the region.
 pub fn remove_topic_meta(name: &str) {
-    let path = shm_topics_dir().join(format!("{}.meta", sanitize_namespace(name)));
+    let path = topic_meta_path(name);
     if let Err(e) = std::fs::remove_file(&path) {
         if e.kind() != std::io::ErrorKind::NotFound {
             log::debug!("Failed to remove topic meta {}: {}", path.display(), e);
@@ -3261,5 +3275,47 @@ mod untrusted_meta_tests {
 
         let _ = std::fs::remove_file(&hostile);
         let _ = std::fs::remove_file(&good);
+    }
+}
+
+#[cfg(test)]
+mod meta_path_tests {
+    use super::*;
+
+    /// The sidecar mapping must handle every character a topic name may carry.
+    ///
+    /// horus_manager's reaper computed this as `name.replace('.', "_")`, which
+    /// agrees with `sanitize_namespace` only when the name's sole special
+    /// character is a dot. Topic names legally contain `-`, `/` and `.`
+    /// (horus_core topic name validation), and `horus_sys/tests/parity_shm.rs`
+    /// exercises `sensor.imu/v1`. For anything with a `-` or `/` the two
+    /// disagreed, the reaper looked for a path that cannot exist, and the
+    /// sidecar was never removed.
+    #[test]
+    fn the_sidecar_mapping_covers_every_legal_topic_character() {
+        for name in ["cmd_vel", "sensor.imu", "sensor.imu/v1", "robot-arm/imu"] {
+            let p = topic_meta_path(name);
+            let file = p.file_name().unwrap().to_str().unwrap();
+            assert!(
+                file.ends_with(".meta"),
+                "{name}: expected a .meta sidecar, got {file}"
+            );
+            let stem = file.strip_suffix(".meta").unwrap();
+            assert!(
+                stem.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+                "{name}: the sidecar stem must be sanitised to [A-Za-z0-9_], got {stem:?} - \
+                 a stem carrying `/` names a directory that does not exist, which is how \
+                 these files stopped being reaped"
+            );
+        }
+
+        // The specific disagreement: dot-only replacement is not enough.
+        let naive = "robot-arm/imu".replace('.', "_");
+        let real = topic_meta_path("robot-arm/imu");
+        assert_ne!(
+            real.file_name().unwrap().to_str().unwrap(),
+            format!("{naive}.meta"),
+            "if these ever agree the test has stopped discriminating"
+        );
     }
 }


### PR DESCRIPTION
Folds **#200**, **#201** and **#202** onto current `main`. No new work — the three branches merged with zero conflicts, and the net diff is exactly their union.

## Why fold rather than merge three times

`main` requires seven status contexts with `strict: true`, so each merge forces every remaining PR to update and re-run the full ~70-job matrix. Three PRs is three sequential cycles; this is one. The same approach was used for the earlier batches.

| PR | Change | Files |
|---|---|---|
| #200 | `fix(shm)`: two more hand-restated copies of geometry the layout module owns | 3 |
| #201 | `fix(cargo_gen)`: the workspace generator dropped the features it was asked for | 1 |
| #202 | `fix(registry)`: the installer's crate list omitted the one crate everyone uses | 1 |

Net: 5 files, +220/-28. The three touch disjoint files apart from `header.rs`, which only #200 changes.

## The one interaction worth checking

#200 was written before #203 landed, and #203 extracted `read_slot_from_region` out of `read_slot_inner`. Git placed #200's hunk inside the extracted function — which is the right outcome and slightly better than the original: the checked-arithmetic hardening now covers both the one-shot read *and* #203's cached `TopicReader`, which share that parser. Verified no hand-restated geometry survives in `header.rs` (only the comment describing what was removed), and #203's own `SHM_MAP_COUNT` placement is intact.

## Why #201 was red and needs no fix

#201 changes exactly one file, `horus_manager/src/cargo_gen.rs`, and was failing two jobs that cannot reach it:

* **Code Coverage** — `cross_process_sigkill_mid_write_recovery` in `horus_core --test log_system_tests`. A cross-process SIGKILL test, unrelated to the workspace generator.
* **Run Benchmarks** — topic IPC benchmarks, with the *whole* distribution shifted: median +69%, p95 +83%, `ns/msg` +57%. A uniform scale-up like that is a slower runner, not a regression; a real one does not move the median and the throughput figure together while the changed file is not linked into the benchmark at all.

## Verification on the folded tree

`horus_core --lib` 2588 passed, `horus_sys --lib` 248, `pod_ring_slot_geometry` 10, plus the RT guards from #203 (`rt_helper_thread_isolation`, `ready_dispatch_pool`). `cargo fmt --check` and `clippy --all-targets -D warnings` across `horus_sys`/`horus_core`/`horus_manager` are clean.

One `horus_core` scheduler test failed on the first run and passed 5/5 in isolation and on a clean re-run — the rotating parallel-test contention this workstation shows under load, not a defect in the fold.

Closes #200. Closes #201. Closes #202.