### PR TITLE
docs/ci: make the codebase readable and its documentation checkable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,25 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      # Doctests. `--lib` above does NOT run them, and no other job did either:
+      # before this step, `grep -rn -- '--doc' .github/workflows/` returned
+      # nothing, so every `///` example in the workspace was unverified. The
+      # `Documentation` job runs `cargo doc`, which builds the pages and does
+      # not compile the examples in them.
+      #
+      # This matters because the examples are the first code a new contributor
+      # copies. Measured on the tree that added this step: 21 passed, 0 failed.
+      #
+      # It is a thin gate today and the number says why: 193 of the workspace's
+      # examples are fenced ```rust,ignore``` and are skipped, so this compiles
+      # 21 of 214. Converting the ignores that only need to type-check to
+      # ```no_run``` is the follow-up that gives this step its teeth; the step
+      # has to exist first or there is nothing to convert them into.
+      - name: Doctests
+        run: cargo test --workspace --exclude horus_py --doc
+        env:
+          RUST_BACKTRACE: 1
+
       # The resolver's crates.io/PyPI tests carry #[ignore] so a contributor
       # without network access gets a green suite and a failure means the
       # resolver is wrong rather than the network. CI does have access, so it
@@ -360,6 +379,19 @@ jobs:
           # also the right call — docs should describe the crate as it ships,
           # i.e. with its default features on.
           cargo doc --workspace --no-deps --exclude horus_manager
+          # Again with horus_core's internals visible.
+          #
+          # Ten of its eleven modules are `#[doc(hidden)]` by default, and
+          # rustdoc does not resolve links inside a hidden module — so the run
+          # above holds `-D warnings` over roughly a quarter of the crate and
+          # silently skips the rest. Four broken links had accumulated behind
+          # that gap, including a `[`HorusError::OutOfRange`]` naming a variant
+          # the error refactor deleted, and two pointing at private items.
+          #
+          # `internal-docs` is docs-only: it gates nothing but the
+          # `#[doc(hidden)]` attributes, so this compiles no extra code. The
+          # published documentation is still what the first command renders.
+          cargo doc -p horus_core --no-deps --features internal-docs
         env:
           RUSTDOCFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -757,13 +757,16 @@ repository; `:850` notes that neither substitutes for the other.
    and line 794 sits inside the `cli-integration` job (`:309`) which is in the
    aggregator's needs list (`:1374`).
 
-   The exception is `readme_contract.rs`'s `the_readme_quick_start_compiles`,
-   which is `#[ignore]`d with the reason "run in the docs-contract job"
-   (`readme_contract.rs:146`). Nothing runs it: no workflow mentions
-   `readme_contract`, `docs-contract.yml`'s cargo invocations name only the
-   `docs_*` targets, and `integration-tests.yml:794` passes no
-   `--include-ignored`. If you change the README's Quick Start, compile it
-   yourself:
+   `readme_contract.rs`'s `the_readme_quick_start_compiles` is `#[ignore]`d
+   with the reason "run in the docs-contract job" (`readme_contract.rs:146`),
+   and that job does now run it — `docs-contract.yml` invokes
+   `cargo test -p horus_manager --test readme_contract -- --include-ignored`.
+
+   This paragraph previously said the opposite ("Nothing runs it: no workflow
+   mentions `readme_contract`") and told you to compile the Quick Start by hand.
+   That was true when it was written and stopped being true when the invocation
+   was added; the prose was not updated with it. You can still run it locally,
+   but CI will catch a broken Quick Start without you:
 
    ```bash
    cargo test -p horus_manager --test readme_contract -- --include-ignored

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -544,8 +544,8 @@ coverage, and gates nothing.
 | `cli_runtime_integration` (18 ignored), `launch_and_workflow` (5), `real_project_ipc` (3) | `horus_core/tests/` | need a debug build of `-p horus --examples` plus `horus_manager` that no job produces (`integration-tests.yml:160-166`) |
 | `transient_subscribers_permanently_flip_a_topic_to_a_lossy_backend` | `participant_count_leak.rs:62` | `#[ignore]`d with the reason "documents an open defect" |
 | `naive_protocol_tears_proving_the_model_can_detect_it` | `loom_pod_broadcast.rs:225` | deliberately excluded (`integration-tests.yml:186`); it is supposed to fail, so running it in CI would be wrong — but nothing checks that it *still* fails |
-| `docs_parity` | `horus_manager/tests/docs_parity.rs` | all three of its tests are `#[ignore]`d with the reason "needs a horus-docs checkout; wired into the docs-contract workflow" (`:193,:259,:336`). `grep -rn docs_parity .github/` returns nothing. The suite that exists to catch *undocumented* new surface never runs |
-| `readme_contract`'s `#[ignore]`d test | `readme_contract.rs:146` | reason: "slow: builds a scratch crate; run in the docs-contract job". That job does not name the target. The other 10 tests in the file do run, via `integration-tests.yml:794` |
+| `docs_parity` | `horus_manager/tests/docs_parity.rs` | all three tests are `#[ignore]`d with the reason "needs a horus-docs checkout; wired into the docs-contract workflow" (`:193,:259,:336`) — and it **is** wired: `docs-contract.yml` runs `cargo test -p horus_manager --test docs_parity -- --ignored --nocapture`. This row previously read "`grep -rn docs_parity .github/` returns nothing … never runs", which was true when written and was falsified by the commit that added the invocation |
+| `readme_contract`'s `#[ignore]`d test | `readme_contract.rs:146` | reason: "slow: builds a scratch crate; run in the docs-contract job". That job **does** name the target now (`docs-contract.yml`, `--include-ignored`); this row previously said it did not. The other 10 tests in the file also run, via `integration-tests.yml:794` |
 | `cpp_toolchain_contract`'s `#[ignore]`d test | `cpp_toolchain_contract.rs:464` | reason: "slow: cross-compiles horus_cpp; run with `--ignored`". Nothing does. The other 19 run |
 | `.config/nextest.toml` | repo root config | a fully worked per-test timeout guard (60 s × 3 hard kill at `:50`, `test-threads = 1` at `:66`, `retries = 0` at `:70`, `leak-timeout = "500ms"` at `:77`, a `ci` profile with JUnit output at `:83-101` and a `soak` profile at `:103-110`) that no workflow uses — `grep -rn nextest .github/` returns nothing, and no markdown mentions it |
 | `horus_manager/tests/web_e2e/` | Puppeteer suite, `package.json:5-7` | referenced only by `.github/dependabot.yml:105`, whose own comment records that no CI workflow runs the suite and that puppeteer is `hasInstallScript: true`, so the dependency graph is exercised exclusively on workstations |
@@ -554,12 +554,18 @@ coverage, and gates nothing.
 | `tests/docker/run_all.sh` | repo `tests/docker/` | `docker-distro-tests.yml:43-61` builds the five Dockerfiles and runs the image `CMD` and `test_user_workflow.sh` directly; `run_all.sh` is unreferenced. `acceptance_linux_macos.sh` and `acceptance_windows.ps1` beside it *are* used, by `cross-platform-parity.yml` and `distribution.yml` |
 | `horus_core`'s doctests | 13 blocks tagged ```` ```rust ```` and one ```` ```no_run ```` in `horus_core/src` | see below |
 
-Three of these are worse than merely unrun, and the distinction matters when you
-are deciding what to fix first: `docs_parity`, `readme_contract` and
-`cpp_toolchain_contract` carry `#[ignore]` *reason strings asserting they are
-wired*. A reader of the source has no way to discover otherwise short of
-grepping the workflows. If you add an `#[ignore]` with a reason naming a
-workflow, add the invocation in the same commit.
+`cpp_toolchain_contract` carries an `#[ignore]` *reason string asserting it is
+wired* while nothing runs it, and a reader of the source has no way to discover
+that short of grepping the workflows. If you add an `#[ignore]` whose reason
+names a workflow, add the invocation in the same commit.
+
+`docs_parity` and `readme_contract` used to be listed here for the same fault
+and have since been wired up — which exposed the mirror-image hazard this table
+now demonstrates twice over. **A table asserting that something is unrun is
+itself untested prose, and it rots in the direction that wastes a newcomer's
+time**: it sends them to hand-run a suite CI already covers, and it teaches them
+to distrust the workflows. Re-derive the rows against
+`grep -rn '<target>' .github/` before relying on any of them.
 
 **On `nextest.toml`.** Its stated premise has partly expired: it says at `:8`
 that "None of the jobs in `.github/workflows/ci.yml` set `timeout-minutes`", and

--- a/horus_core/Cargo.toml
+++ b/horus_core/Cargo.toml
@@ -75,6 +75,9 @@ horus-tf = { git = "https://github.com/softmata/horus-tf.git", rev = "d525dfcf58
 workspace = true
 
 [features]
+# Render the crate-internal modules in rustdoc. Docs-only: it gates nothing
+# but `#[doc(hidden)]`, so it changes no code and no dependency.
+internal-docs = []
 default = ["macros", "telemetry", "blackbox"]
 macros = ["horus_macros"]
 

--- a/horus_core/README.md
+++ b/horus_core/README.md
@@ -111,9 +111,17 @@ caught it (`rt_allocator.rs:21-26`, `rt_alloc_guard_installed.rs:35-38`).
 ## How to read the internals
 
 `--document-private-items` is **not** enough on its own. It disables rustdoc's
-private-stripping pass, not its hidden-stripping pass, so the eleven hidden
-modules stay stripped. You need nightly and `--document-hidden-items`, which is
-unstable and refuses to run without `-Z unstable-options`:
+private-stripping pass, not its hidden-stripping pass, so the hidden modules
+stay stripped. Use the `internal-docs` feature, which lifts the
+`#[doc(hidden)]` attributes and works on stable:
+
+```sh
+cargo doc -p horus_core --no-deps --document-private-items \
+  --features internal-docs --open
+```
+
+The nightly form below still works and needs no feature, but it requires a
+nightly toolchain and an unstable flag, which is why the feature exists:
 
 ```sh
 RUSTDOCFLAGS="-Z unstable-options --document-hidden-items" \

--- a/horus_core/src/core/log_buffer.rs
+++ b/horus_core/src/core/log_buffer.rs
@@ -614,9 +614,11 @@ pub fn publish_log(entry: LogEntry) {
 ///
 /// Returns a join handle. Drop or join to stop the drain thread.
 pub fn start_log_file_drain() -> Option<std::thread::JoinHandle<()>> {
-    let enabled = std::env::var("HORUS_LOG_FILE")
-        .map(|v| v == "true" || v == "1")
-        .unwrap_or(false);
+    // `env_flag`, not a local truth table. This site accepted only "true" and
+    // "1", so `HORUS_LOG_FILE=yes` turned logging off while `HORUS_SIM_MODE=yes`
+    // turned simulation on — the same framework disagreeing with itself about
+    // one word. See `horus_sys::env` for the vocabulary.
+    let enabled = horus_sys::env::env_flag("HORUS_LOG_FILE").unwrap_or(false);
     if !enabled {
         return None;
     }

--- a/horus_core/src/drivers/mod.rs
+++ b/horus_core/src/drivers/mod.rs
@@ -96,9 +96,13 @@ pub fn load_from<P: AsRef<Path>>(path: P) -> HorusResult<Vec<(String, Box<dyn No
     // to force real hardware got inert `SimStubNode`s instead — actuators never
     // commanded, sensors never read, and nothing said so. Parse the value, the
     // way HORUS_NET_ENABLED already does.
-    let sim_mode = std::env::var("HORUS_SIM_MODE")
-        .map(|v| !(v.is_empty() || v == "0" || v.eq_ignore_ascii_case("false")))
-        .unwrap_or(false);
+    // Through `env_flag` now. The shape below was already the fix for
+    // `=false` turning simulation ON, but it still treated every value it did
+    // not recognise as an opt-in — so `HORUS_SIM_MODE=no` swapped every driver
+    // for an inert `SimStubNode`, and `=maybe` would have too. An unrecognised
+    // value now leaves the default (off) in force, which is the safe direction
+    // for a flag that disconnects the robot from its hardware.
+    let sim_mode = horus_sys::env::env_flag("HORUS_SIM_MODE").unwrap_or(false);
 
     let selective_targets: Option<Vec<String>> = if sim_mode {
         std::env::var("HORUS_SIM_TARGETS")

--- a/horus_core/src/error.rs
+++ b/horus_core/src/error.rs
@@ -850,7 +850,7 @@ macro_rules! horus_internal {
 
 /// Convenience type alias for Results using HorusError.
 ///
-/// **Prefer the short aliases [`Result`] and [`Error`](tyalias@Error) in all new code.**
+/// **Prefer the short aliases [`Result`] and [`Error`](type@Error) in all new code.**
 /// `HorusResult` and `HorusError` are the canonical names but verbose —
 /// the aliases exist specifically so you can write `Result<()>` and `Error`
 /// without the `Horus` prefix everywhere.

--- a/horus_core/src/error.rs
+++ b/horus_core/src/error.rs
@@ -850,7 +850,7 @@ macro_rules! horus_internal {
 
 /// Convenience type alias for Results using HorusError.
 ///
-/// **Prefer the short aliases [`Result`] and [`Error`] in all new code.**
+/// **Prefer the short aliases [`Result`] and [`Error`](tyalias@Error) in all new code.**
 /// `HorusResult` and `HorusError` are the canonical names but verbose —
 /// the aliases exist specifically so you can write `Result<()>` and `Error`
 /// without the `Horus` prefix everywhere.

--- a/horus_core/src/lib.rs
+++ b/horus_core/src/lib.rs
@@ -15,25 +15,45 @@
 //! **Note:** This is an internal crate. Users should depend on `horus` and
 //! import from `horus::prelude::*`.
 
-// Public modules — accessible cross-crate but hidden from user docs.
-// Users should go through `horus::prelude`, not import from `horus_core` directly.
-#[doc(hidden)]
+// Public modules — accessible cross-crate, hidden from user docs by default.
+// Users should go through `horus::prelude`, not import from `horus_core`
+// directly, and the crate note above says so.
+//
+// The hiding is `cfg_attr`'d rather than unconditional so a MAINTAINER can lift
+// it on stable:
+//
+//     cargo doc -p horus_core --no-deps --document-private-items \
+//       --features internal-docs --open
+//
+// Before this was a feature, the only way to read the internals was the nightly
+// incantation in horus_core/README.md — `-Z unstable-options
+// --document-hidden-items` — because `--document-private-items` disables
+// rustdoc's private-stripping pass and not its hidden-stripping pass. That put
+// the API browser for a 112k-line crate behind an unstable flag, so on stable
+// `cargo doc --open` showed one module (`terminal`), zero structs and an empty
+// search index.
+//
+// CI documents WITH the feature (ci.yml, Documentation job) precisely so
+// `-D warnings` sees these modules: while they were unconditionally hidden,
+// rustdoc never resolved their links and four broken ones had accumulated,
+// including a `HorusError::OutOfRange` the error refactor had deleted.
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod actions;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod communication;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod core;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod drivers;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod error;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod memory;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod params;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod scheduling;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod services;
 /// Non-panicking console output.
 ///
@@ -42,7 +62,7 @@ pub mod services;
 /// operator pipes `horus run` into `head`. Anything printing from a node, a
 /// background thread, or a safety path should use these instead.
 pub mod terminal;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "internal-docs"), doc(hidden))]
 pub mod types;
 pub(crate) mod utils;
 

--- a/horus_core/src/memory/depth_image.rs
+++ b/horus_core/src/memory/depth_image.rs
@@ -134,10 +134,15 @@ impl DepthImage {
     ///
     /// # Errors
     ///
-    /// - [`HorusError::OutOfRange`] — for U16 images, if the converted
+    /// - [`HorusError::InvalidInput`] — for U16 images, if the converted
     ///   millimeter value does not fit in `u16` (e.g., value > 65.535m at
     ///   default scale 1.0). Callers must handle this instead of silently
     ///   storing the saturated `u16::MAX`.
+    ///
+    /// The link used to name `HorusError::OutOfRange`, which the error refactor
+    /// folded into `InvalidInput(ValidationError::…)` (see error.rs:399). The
+    /// broken link survived because this module was `#[doc(hidden)]`, so
+    /// rustdoc never resolved it.
     pub fn set_depth(&mut self, x: u32, y: u32, value: f32) -> HorusResult<&mut Self> {
         if x >= self.width() || y >= self.height() {
             return Ok(self);

--- a/horus_core/src/memory/tensor_handle.rs
+++ b/horus_core/src/memory/tensor_handle.rs
@@ -101,7 +101,7 @@ impl TensorHandle {
     /// and dtype.
     ///
     /// This is the ergonomic constructor for creating a tensor to fill in and
-    /// publish: the data lives in the [`global_pool`](crate::communication::topic::pool_registry::global_pool)
+    /// publish: the data lives in the process-wide tensor pool (`global_pool`)
     /// and the device is inferred from that pool's backend (CPU by default). For
     /// an explicit pool or device, use [`alloc`](Self::alloc).
     ///

--- a/horus_core/src/params.rs
+++ b/horus_core/src/params.rs
@@ -51,10 +51,20 @@ impl ParamMetadata {
     }
 }
 
+/// Callback type for parameter change notification.
+/// Called with (key, old_value, new_value). Return Err to reject the change.
+pub type ParamChangeCallback =
+    Arc<dyn Fn(&str, Option<&Value>, &Value) -> Result<(), String> + Send + Sync>;
+
 /// Runtime parameter store for dynamic configuration.
 ///
 /// Provides a typed key-value store with validation, persistence, and
 /// concurrent access support.
+///
+/// The whole of this block — description and doctest — used to sit on
+/// `ParamChangeCallback` below, a type alias, because a new item was inserted
+/// between the comment and the struct it belonged to. `RuntimeParams` itself
+/// rendered undocumented while a callback alias carried its example.
 ///
 /// # Example
 ///
@@ -69,11 +79,6 @@ impl ParamMetadata {
 /// let speed: f64 = params.get("max_speed").unwrap();
 /// assert_eq!(speed, 1.5);
 /// ```
-/// Callback type for parameter change notification.
-/// Called with (key, old_value, new_value). Return Err to reject the change.
-pub type ParamChangeCallback =
-    Arc<dyn Fn(&str, Option<&Value>, &Value) -> Result<(), String> + Send + Sync>;
-
 pub struct RuntimeParams {
     /// Parameter storage - BTreeMap maintains sorted order
     params: Arc<RwLock<BTreeMap<String, Value>>>,

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -323,7 +323,6 @@ pub(crate) struct RecordingState {
 /// lifetime and dropped during shutdown — use `Drop` to clean up resources.
 pub type LifecycleStartFn = Box<dyn FnOnce() -> Option<Box<dyn Any + Send>> + Send>;
 
-/// Central orchestrator: holds nodes, drives the tick loop.
 /// What the presence refresh needs about a node the main thread does not own.
 #[derive(Debug, Clone)]
 pub(super) struct PresenceEntry {
@@ -336,6 +335,17 @@ pub(super) struct PresenceEntry {
     pub main_thread: bool,
 }
 
+/// Central orchestrator: holds nodes, drives the tick loop.
+///
+/// This is the type a HORUS program is built around: nodes are registered on
+/// it, it partitions them by scheduling class across the RT, compute, event and
+/// async-I/O executors, and it owns the loop that ticks them and enforces their
+/// deadlines.
+///
+/// The doc line above used to sit one item higher, stranded on top of
+/// `PresenceEntry`'s own comment — so the framework's primary public type
+/// rendered with no description at all, and a private struct was documented as
+/// the orchestrator.
 pub struct Scheduler {
     pub(super) nodes: Vec<RegisteredNode>,
     pub(super) running: Arc<AtomicBool>,
@@ -1996,7 +2006,7 @@ impl Scheduler {
 
     /// Set OS-level scheduling priority using SCHED_FIFO (Linux RT-PREEMPT required).
     ///
-    /// Delegates to [`super::rt::set_realtime_priority`].
+    /// Delegates to `super::rt::set_realtime_priority` (crate-private).
     ///
     /// # Arguments
     /// * `priority` - Priority level (1-99, higher = more important)

--- a/horus_core/src/scheduling/scheduler/mod.rs
+++ b/horus_core/src/scheduling/scheduler/mod.rs
@@ -698,13 +698,14 @@ impl Scheduler {
         };
 
         // Network discovery is enabled by default (like ROS2).
-        // Opt out via HORUS_NET_ENABLED=false (or =0) env var, or `.network(false)`.
+        // Opt out via HORUS_NET_ENABLED=false (or 0/no/off), or `.network(false)`.
         // The actual horus_net startup is handled by a lifecycle hook registered
         // by the integration layer (e.g., the `horus` umbrella crate).
-        if std::env::var("HORUS_NET_ENABLED")
-            .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
-            .unwrap_or(false)
-        {
+        //
+        // An opt-out reads the same vocabulary as an opt-in: this site accepted
+        // `0` and `false` but not `no` or `off`, so two of the four words that
+        // mean "off" everywhere else in HORUS left networking running.
+        if horus_sys::env::env_flag("HORUS_NET_ENABLED") == Some(false) {
             s.network_enabled = false;
         }
 

--- a/horus_sys/src/env/mod.rs
+++ b/horus_sys/src/env/mod.rs
@@ -1,0 +1,128 @@
+//! One vocabulary for boolean environment variables.
+//!
+//! # Why this exists
+//!
+//! HORUS reads 60-odd `HORUS_*` variables, and before this module every site
+//! decided for itself what counted as "on". The forms in production were:
+//!
+//! ```text
+//! v == "true" || v == "1"                            HORUS_LOG_FILE
+//! !(v.is_empty() || v == "0" || eq_ic(v, "false"))   HORUS_SIM_MODE
+//! v == "0" || eq_ic(v, "false")                      HORUS_NET_ENABLED  (opt-out)
+//! env::var(..).is_ok()                               presence-only
+//! v == "1"                                           HORUS_WIN_REALTIME_CLASS
+//! ```
+//!
+//! The consequence was not academic. `HORUS_LOG_FILE=yes` was **false** while
+//! `HORUS_SIM_MODE=no` was **true** — the second one silently swapping every
+//! driver for an inert `SimStubNode`, actuators never commanded and sensors
+//! never read. Two variables in the same framework disagreed about the word
+//! "no", and nothing in the codebase said which was right.
+//!
+//! # The vocabulary
+//!
+//! `1`, `true`, `yes`, `on` are true. `0`, `false`, `no`, `off` and the empty
+//! string are false. Matching is ASCII case-insensitive, so `True` and `ON`
+//! work. Surrounding whitespace is trimmed, because a value that arrived from a
+//! YAML launch file or a shell here-doc often carries some.
+//!
+//! # Why an unrecognised value is `None`, not `false`
+//!
+//! `env_flag` returns `Option<bool>`: `None` means "unset or not a boolean I
+//! recognise", which leaves the caller's default in force. `HORUS_SIM_MODE=maybe`
+//! therefore keeps simulation off rather than turning it on — the old
+//! `!(v == "0")` shape treated every typo as an opt-in, which is the wrong
+//! direction for a flag that disconnects the robot from its hardware.
+//!
+//! It also matches what the reference page already promises for
+//! `HORUS_SHM_PREFAULT`: "an unrecognised value keeps the default rather than
+//! meaning off".
+
+/// Read a boolean environment variable using the project-wide vocabulary.
+///
+/// Returns `None` when the variable is unset, or set to something that is not
+/// a recognised truth value — in both cases the caller's default should stand.
+///
+/// ```
+/// # use horus_sys::env::env_flag;
+/// // Unset variables leave the caller's default in force.
+/// assert_eq!(env_flag("HORUS_A_VARIABLE_NOBODY_SETS"), None);
+/// ```
+pub fn env_flag(name: &str) -> Option<bool> {
+    parse_flag(std::env::var(name).ok()?.as_str())
+}
+
+/// The parsing half, separated from the environment so it can be tested
+/// without mutating process-global state — `set_var` is not safe against a
+/// concurrent `getenv` on another thread, and the test binaries here run
+/// in parallel.
+pub fn parse_flag(raw: &str) -> Option<bool> {
+    let v = raw.trim();
+    if v.is_empty() {
+        return Some(false);
+    }
+    if v.eq_ignore_ascii_case("1")
+        || v.eq_ignore_ascii_case("true")
+        || v.eq_ignore_ascii_case("yes")
+        || v.eq_ignore_ascii_case("on")
+    {
+        return Some(true);
+    }
+    if v.eq_ignore_ascii_case("0")
+        || v.eq_ignore_ascii_case("false")
+        || v.eq_ignore_ascii_case("no")
+        || v.eq_ignore_ascii_case("off")
+    {
+        return Some(false);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_whole_vocabulary_is_accepted_in_any_case() {
+        for t in ["1", "true", "TRUE", "True", "yes", "YES", "on", "On"] {
+            assert_eq!(parse_flag(t), Some(true), "{t:?} must be true");
+        }
+        for f in ["0", "false", "FALSE", "no", "NO", "off", "Off", ""] {
+            assert_eq!(parse_flag(f), Some(false), "{f:?} must be false");
+        }
+    }
+
+    /// The two divergences that motivated this module, pinned as tests.
+    #[test]
+    fn the_words_that_used_to_disagree_now_agree() {
+        // `HORUS_LOG_FILE=yes` was false because that site matched only
+        // "true"/"1".
+        assert_eq!(parse_flag("yes"), Some(true));
+        // `HORUS_SIM_MODE=no` was TRUE, because that site treated anything
+        // that was not "0"/"false"/empty as an opt-in — so a deploy script
+        // saying "no" got inert SimStubNodes and no diagnostic.
+        assert_eq!(parse_flag("no"), Some(false));
+    }
+
+    #[test]
+    fn an_unrecognised_value_leaves_the_default_in_force() {
+        for junk in ["maybe", "2", "yep", "sim", "-1"] {
+            assert_eq!(
+                parse_flag(junk),
+                None,
+                "{junk:?} must not be read as a truth value in either direction"
+            );
+        }
+    }
+
+    #[test]
+    fn whitespace_from_a_launch_file_or_here_doc_is_trimmed() {
+        assert_eq!(parse_flag(" true "), Some(true));
+        assert_eq!(parse_flag("\toff\n"), Some(false));
+    }
+
+    #[test]
+    fn env_flag_reports_none_for_an_unset_variable() {
+        assert_eq!(env_flag("HORUS_DEFINITELY_UNSET_XYZZY"), None);
+    }
+}

--- a/horus_sys/src/env/mod.rs
+++ b/horus_sys/src/env/mod.rs
@@ -44,10 +44,18 @@
 /// a recognised truth value — in both cases the caller's default should stand.
 ///
 /// ```
-/// # use horus_sys::env::env_flag;
-/// // Unset variables leave the caller's default in force.
-/// assert_eq!(env_flag("HORUS_A_VARIABLE_NOBODY_SETS"), None);
+/// # use horus_sys::env::parse_flag;
+/// assert_eq!(parse_flag("yes"),   Some(true));
+/// assert_eq!(parse_flag("off"),   Some(false));
+/// assert_eq!(parse_flag(""),      Some(false));
+/// // Not a truth value: the caller's default stands.
+/// assert_eq!(parse_flag("maybe"), None);
 /// ```
+///
+/// The example exercises [`parse_flag`] rather than `env_flag` on purpose: an
+/// assertion about a variable being *unset* is only true until someone's shell
+/// or CI image happens to set it, and a doctest that depends on the ambient
+/// environment is a flake waiting for a machine that disagrees.
 pub fn env_flag(name: &str) -> Option<bool> {
     parse_flag(std::env::var(name).ok()?.as_str())
 }
@@ -121,8 +129,25 @@ mod tests {
         assert_eq!(parse_flag("\toff\n"), Some(false));
     }
 
+    /// `env_flag` is the thin half — it reads the variable and hands the value
+    /// to `parse_flag`. Asserting it on a name this process itself controls
+    /// keeps the check honest without depending on what the ambient
+    /// environment happens to hold.
     #[test]
-    fn env_flag_reports_none_for_an_unset_variable() {
-        assert_eq!(env_flag("HORUS_DEFINITELY_UNSET_XYZZY"), None);
+    fn env_flag_delegates_to_parse_flag() {
+        // A name unique to this process, so a developer's shell or a CI image
+        // cannot decide the outcome.
+        let name = format!("HORUS_ENV_FLAG_SELFTEST_{}", std::process::id());
+        assert_eq!(env_flag(&name), None, "an unset variable must not decide");
+
+        // SAFETY: the name embeds this process's pid and is used by nothing
+        // else, so no other thread can be reading it concurrently.
+        unsafe { std::env::set_var(&name, "YES") };
+        assert_eq!(env_flag(&name), Some(true));
+        unsafe { std::env::set_var(&name, "off") };
+        assert_eq!(env_flag(&name), Some(false));
+        unsafe { std::env::set_var(&name, "banana") };
+        assert_eq!(env_flag(&name), None);
+        unsafe { std::env::remove_var(&name) };
     }
 }

--- a/horus_sys/src/lib.rs
+++ b/horus_sys/src/lib.rs
@@ -18,7 +18,7 @@
 //! | [`device`] | Serial port and video device enumeration |
 //! | [`platform`] | OS/distro detection, directories, shell, package manager |
 //! | [`sync`] | Environment synchronization (toolchains, system deps) |
-//! | [`env`] | One vocabulary for boolean `HORUS_*` environment variables |
+//! | [`mod@env`] | One vocabulary for boolean `HORUS_*` environment variables |
 //!
 //! ## Platform Support
 //!

--- a/horus_sys/src/lib.rs
+++ b/horus_sys/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod device;
 pub mod discover;
+pub mod env;
 pub mod fs;
 pub mod platform;
 pub mod process;

--- a/horus_sys/src/lib.rs
+++ b/horus_sys/src/lib.rs
@@ -18,6 +18,7 @@
 //! | [`device`] | Serial port and video device enumeration |
 //! | [`platform`] | OS/distro detection, directories, shell, package manager |
 //! | [`sync`] | Environment synchronization (toolchains, system deps) |
+//! | [`env`] | One vocabulary for boolean `HORUS_*` environment variables |
 //!
 //! ## Platform Support
 //!


### PR DESCRIPTION
Five fixes from a maintainability audit of the tree, framed by one question: **what does a human developer taking over from an AI actually pay?**

Every claim below was measured or reproduced, and several audit findings are *not* here because checking them refuted them (noted at the end).

## The headline: rustdoc rendered nothing

`cargo doc -p horus_core --open` produced a front page with **one module** (`terminal`), **zero structs**, and **zero entries in the search index** — for a 112k-line runtime crate. The standard first move for a Rust developer meeting a new crate returned nothing.

Ten of eleven modules carry `#[doc(hidden)]`, and that is deliberate — the crate note says "internal crate, use `horus::prelude`", and `horus_core/README.md` has a whole *How to read the internals* section. The problem is the escape hatch it documents needs **nightly and an unstable flag**:

```
RUSTDOCFLAGS="-Z unstable-options --document-hidden-items" cargo +nightly doc …
```

because `--document-private-items` disables rustdoc's *private*-stripping pass, not its *hidden*-stripping pass. Verified rather than assumed: with that flag the front page gained exactly one module — `utils`, the `pub(crate)` one — and none of the hidden ten.

So the attributes are now `cfg_attr`'d behind a docs-only `internal-docs` feature. **Default output is unchanged** (still one module — the user-facing boundary is intact); a maintainer on **stable** gets all eleven and a populated search index.

| | modules on the front page |
|---|---|
| default (docs.rs, users) | 1 — unchanged |
| `--features internal-docs` (maintainers, stable) | **11** |

## That change immediately found four broken links

rustdoc does not resolve links inside a hidden module, so `-D warnings` had been holding roughly a quarter of the crate and silently skipping the rest. CI now documents horus_core a second time with the feature on, which is the half of this PR worth keeping even if the rest is bikeshedded.

The sharpest one: `set_depth`'s `# Errors` section pointed at `HorusError::OutOfRange`, **a variant the error refactor deleted**. A maintainer was being told to match on something they cannot write, and nothing in the build disagreed.

## Two public types were documented as something else

`Scheduler` — the type a HORUS program is built around — had **no doc comment at all**. Its description sat one item higher, stranded on `PresenceEntry`, so a private struct rendered as the orchestrator. `RuntimeParams`'s whole block, *including a working doctest*, sat on the `ParamChangeCallback` type alias.

Same cause both times: an item inserted between a comment and its target, with nothing in the build able to notice.

## Doctests never ran

`grep -rn -- '--doc' .github/workflows/` returned nothing. `--lib` excludes them and `cargo doc` only renders them, so every `///` example was unverified. Added a step; 21 pass.

Its comment says plainly that it is a **thin** gate — 193 of 214 examples are `rust,ignore` — because a step protecting 21 examples should not be described as protecting the examples. Converting the type-check-only ignores to `no_run` is the follow-up, and needs this step to exist first.

## Two variables disagreed about the word "no"

`HORUS_LOG_FILE=yes` was **false**. `HORUS_SIM_MODE=no` was **true** — silently swapping every driver for an inert `SimStubNode`: actuators never commanded, sensors never read, nothing said so.

`horus_sys::env::env_flag` is now the one answer (`1/true/yes/on`, `0/false/no/off`, case-insensitive, trimmed). An unrecognised value returns `None` so the caller's default stands — `HORUS_SIM_MODE=maybe` keeps simulation *off*, the safe direction for a flag that disconnects hardware, and it matches what the reference page already promises for `HORUS_SHM_PREFAULT`.

**Deliberately not routed:** `HORUS_RT_ALLOW_CORE_SHARING` and `HORUS_WIN_REALTIME_CLASS`. Their vocabularies are *published* in horus-docs (the first is documented case-sensitive on purpose), so changing them needs a paired docs change, not a drive-by.

## Two onboarding docs were actively lying

CONTRIBUTING.md told contributors `readme_contract`'s Quick Start test is run by nothing and handed them a manual command. TESTING.md said `docs_parity` "never runs". Both false — `docs-contract.yml` runs both. Each was true when written and was falsified by the commit that added the invocation.

That direction of rot is the one that costs a newcomer: it sends them to hand-run suites CI already covers, and teaches them the workflows can't be trusted. TESTING.md's closing rule now says so and tells the reader to re-derive a row before relying on it. `cpp_toolchain_contract` and the `nextest` config really are unrun and keep their rows — re-checked, not carried over.

## Findings deliberately excluded

The audit's verification pass refuted 40 of 79 claims. Two I dropped after checking myself:

- **"Six competing output idioms; horus_manager uses `print_line` in zero files."** A file-level grep counting **test modules**. Production `println!` in horus_core/horus_sys/horus_net is effectively **zero** against 228 `print_line` calls — `src/` here holds more test code (154k lines) than production (130k), so naive greps over it report mostly tests. The codebase is disciplined here.
- **Function-length metrics.** Two independent attempts produced nonsense (`is_known_pypi` "564 lines" is a 3-line binary search followed by a data table). Not reportable.

## Verification

`fmt`, `clippy -D warnings`, `--no-default-features`, CI's four cross-compile commands, and **both** rustdoc modes with `-D warnings` are clean. `horus_core --lib` 2588, `horus_sys --lib` 253 (+5 new), doctests 21.

One `horus_core` scheduler test failed mid-run and passed 3/3 in isolation and on a clean re-run — the rotating parallel-test contention this workstation shows under load, in a file this branch does not touch.